### PR TITLE
Fix notes/folders persistence

### DIFF
--- a/src/hooks/useNotesStorage.js
+++ b/src/hooks/useNotesStorage.js
@@ -21,15 +21,11 @@ const useNotesStorage = () => {
   }, [sidebarCollapsed])
 
   useEffect(() => {
-    if (notes.length > 0) {
-      localStorage.setItem('notes', JSON.stringify(notes))
-    }
+    localStorage.setItem('notes', JSON.stringify(notes))
   }, [notes])
 
   useEffect(() => {
-    if (folders.length > 0) {
-      localStorage.setItem('folders', JSON.stringify(folders))
-    }
+    localStorage.setItem('folders', JSON.stringify(folders))
   }, [folders])
 
   return {


### PR DESCRIPTION
## Summary
- always persist notes and folders to localStorage

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fed19cf8c832c8c4ae9f6145034cf