### PR TITLE
Update README and clean up Vercel files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,6 @@ yarn-error.log*
 # env files (can opt-in for committing if needed)
 .env*
 
-# vercel
-.vercel
 
 # typescript
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-## Getting Started
+# Noteser
 
-First, run the development server:
+Noteser is a simple note‑taking application built with Next.js and React. It lets you organise notes in folders and write using Markdown.
 
-```bash
-# Initial Setup
-npm install
-# Develop
-npm run dev
-```
+## Setup
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   Then open [http://localhost:3001](http://localhost:3001) in your browser.
 
-You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
+## Features
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- Create, rename and delete notes
+- Organise notes in folders
+- Markdown editing with live preview
+- Toggleable sidebar for navigation
+- Data is stored in local storage
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+Start editing the application by modifying `src/app/page.js` and related components.

--- a/public/vercel.svg
+++ b/public/vercel.svg
@@ -1,1 +1,0 @@
-<svg fill="none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1155 1000"><path d="m577.3 0 577.4 1000H0z" fill="#fff"/></svg>


### PR DESCRIPTION
## Summary
- document Noteser features in README
- use port 3001 in docs and fix file paths
- remove Vercel font paragraph and vercel.svg
- delete `.vercel` entry from `.gitignore`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684000728010832c88a19131fd7f66ee