### PR TITLE
Fix hooks to persist empty lists

### DIFF
--- a/src/hooks/useNotesStorage.js
+++ b/src/hooks/useNotesStorage.js
@@ -21,15 +21,11 @@ const useNotesStorage = () => {
   }, [sidebarCollapsed])
 
   useEffect(() => {
-    if (notes.length > 0) {
-      localStorage.setItem('notes', JSON.stringify(notes))
-    }
+    localStorage.setItem('notes', JSON.stringify(notes))
   }, [notes])
 
   useEffect(() => {
-    if (folders.length > 0) {
-      localStorage.setItem('folders', JSON.stringify(folders))
-    }
+    localStorage.setItem('folders', JSON.stringify(folders))
   }, [folders])
 
   return {


### PR DESCRIPTION
## Summary
- save empty notes and folders arrays to localStorage by removing length guards

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683ff84e9db4832ca1037a5e853171bd