### PR TITLE
Fix npm install command failure

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,13 +10,17 @@ import {
   TemplatesModal,
   ExportModal
 } from '@/components/modals'
-import { useKeyboardShortcuts } from '@/hooks'
+import { useKeyboardShortcuts, useHydration } from '@/hooks'
 import { useUIStore, useNoteStore, useFolderStore } from '@/stores'
 
 export default function Home() {
+  const hydrated = useHydration()
   const { sidebarCollapsed } = useUIStore()
   const { addNote } = useNoteStore()
   const { addFolder, activeFolderId } = useFolderStore()
+
+  // Use default value during SSR to avoid hydration mismatch
+  const isSidebarCollapsed = hydrated ? sidebarCollapsed : false
 
   // Set up keyboard shortcuts
   useKeyboardShortcuts({
@@ -34,7 +38,7 @@ export default function Home() {
       {/* Sidebar */}
       <div
         className={`flex-none transition-all duration-300 ${
-          sidebarCollapsed ? 'w-[50px]' : 'w-64'
+          isSidebarCollapsed ? 'w-[50px]' : 'w-64'
         }`}
       >
         <Sidebar />
@@ -44,7 +48,7 @@ export default function Home() {
       <div
         className="flex-1 h-full overflow-hidden"
         style={{
-          width: `calc(100vw - ${sidebarCollapsed ? '50px' : '16rem'})`
+          width: `calc(100vw - ${isSidebarCollapsed ? '50px' : '16rem'})`
         }}
       >
         <Editor />

--- a/src/components/sidebar/FolderTree.tsx
+++ b/src/components/sidebar/FolderTree.tsx
@@ -10,6 +10,7 @@ import {
 } from '@heroicons/react/24/outline'
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid'
 import { useNoteStore, useFolderStore, useUIStore, useTagStore } from '@/stores'
+import { useHydration } from '@/hooks'
 import { EditableText } from '../shared/EditableText'
 import { Badge } from '../ui'
 
@@ -18,6 +19,7 @@ interface FolderTreeProps {
 }
 
 export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
+  const hydrated = useHydration()
   const { currentView } = useUIStore()
   const {
     notes,
@@ -43,10 +45,11 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
   } = useFolderStore()
   const { tags, getTagById } = useTagStore()
 
-  const rootFolders = useMemo(() => getRootFolders(), [folders])
-  const activeNotes = useMemo(() => getActiveNotes(), [notes])
-  const deletedNotes = useMemo(() => getDeletedNotes(), [notes])
-  const recentNotes = useMemo(() => getRecentNotes(10), [notes])
+  // Use empty arrays during SSR to avoid hydration mismatch
+  const rootFolders = useMemo(() => hydrated ? getRootFolders() : [], [folders, hydrated])
+  const activeNotes = useMemo(() => hydrated ? getActiveNotes() : [], [notes, hydrated])
+  const deletedNotes = useMemo(() => hydrated ? getDeletedNotes() : [], [notes, hydrated])
+  const recentNotes = useMemo(() => hydrated ? getRecentNotes(10) : [], [notes, hydrated])
 
   // Render note item
   const NoteItem = ({ note, className = '' }: { note: typeof notes[0]; className?: string }) => {

--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -14,11 +14,13 @@ import {
   Cog6ToothIcon
 } from '@heroicons/react/24/outline'
 import { useUIStore, useNoteStore, useFolderStore } from '@/stores'
+import { useHydration } from '@/hooks'
 import { FolderTree } from './FolderTree'
 import { ContextMenu } from './ContextMenu'
 import type { ContextMenuState } from '@/types'
 
 export const Sidebar = () => {
+  const hydrated = useHydration()
   const {
     sidebarCollapsed,
     toggleSidebar,
@@ -33,9 +35,10 @@ export const Sidebar = () => {
 
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null)
 
-  const deletedNotes = getDeletedNotes()
-  const recentNotes = getRecentNotes(5)
-  const pinnedNotes = getPinnedNotes()
+  // Use default values during SSR/hydration to avoid mismatch
+  const deletedNotes = hydrated ? getDeletedNotes() : []
+  const recentNotes = hydrated ? getRecentNotes(5) : []
+  const pinnedNotes = hydrated ? getPinnedNotes() : []
 
   const handleAddNote = () => {
     addNote({ folderId: activeFolderId })

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,3 +2,4 @@
 export { useKeyboardShortcuts } from './useKeyboardShortcuts'
 export { useDebounce, useDebouncedCallback, useThrottledCallback } from './useDebounce'
 export { useCollaboration, useLocalCollaboration } from './useCollaboration'
+export { useHydration } from './useHydration'

--- a/src/hooks/useHydration.ts
+++ b/src/hooks/useHydration.ts
@@ -1,0 +1,19 @@
+import { useState, useEffect } from 'react'
+
+/**
+ * Hook to track client-side hydration.
+ * Returns false on the server and during initial hydration,
+ * returns true after the component has hydrated on the client.
+ *
+ * This is useful for components that use persisted state (like Zustand with persist)
+ * to avoid hydration mismatches between server and client.
+ */
+export function useHydration() {
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    setHydrated(true)
+  }, [])
+
+  return hydrated
+}


### PR DESCRIPTION
Remove the two-layer state management (isPreviewMode + showPreview) that required 800ms of inactivity before showing preview. Now when preview mode is toggled via Ctrl+E or button, it shows immediately. Clicking the preview returns to edit mode.