### PR TITLE
Sync: typed GitHub API errors + 403 rate-limit retry + telemetry

### DIFF
--- a/src/__tests__/githubApiError.test.ts
+++ b/src/__tests__/githubApiError.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment node
+ *
+ * GitHubAPIError covers the typed error thrown by every Git Data API
+ * helper. It carries status, GitHub's `message` field, the rate-limit
+ * reset epoch, and a remaining quota — enough for the UI to render a
+ * precise message instead of "Failed (403)".
+ */
+
+import { GitHubAPIError, ensureOk } from '../utils/github'
+
+function makeRes(status: number, body: unknown = null, headers: Record<string, string> = {}): Response {
+  return new Response(body == null ? null : JSON.stringify(body), {
+    status,
+    headers: new Headers({ 'Content-Type': 'application/json', ...headers }),
+  })
+}
+
+describe('GitHubAPIError', () => {
+  test('captures status + operation + GitHub message', async () => {
+    const res = makeRes(422, { message: 'Update is not a fast forward' })
+    const err = await GitHubAPIError.fromResponse(res, 'Update branch ref')
+    expect(err).toBeInstanceOf(GitHubAPIError)
+    expect(err.status).toBe(422)
+    expect(err.operation).toBe('Update branch ref')
+    expect(err.githubMessage).toBe('Update is not a fast forward')
+    expect(err.message).toContain('Update branch ref')
+    expect(err.message).toContain('422')
+    expect(err.message).toContain('Update is not a fast forward')
+  })
+
+  test('handles non-JSON bodies gracefully', async () => {
+    const res = new Response('not json', {
+      status: 500,
+      headers: { 'Content-Type': 'text/html' },
+    })
+    const err = await GitHubAPIError.fromResponse(res, 'Create blob')
+    expect(err.status).toBe(500)
+    expect(err.githubMessage).toBeNull()
+  })
+
+  test('captures rate-limit headers', async () => {
+    const reset = Math.floor(Date.now() / 1000) + 600
+    const res = makeRes(403, { message: 'API rate limit exceeded' }, {
+      'x-ratelimit-remaining': '0',
+      'x-ratelimit-reset': String(reset),
+    })
+    const err = await GitHubAPIError.fromResponse(res, 'Read tree')
+    expect(err.isRateLimit).toBe(true)
+    expect(err.remaining).toBe(0)
+    expect(err.rateLimitReset).toBe(reset)
+    const seconds = err.resetInSeconds()
+    expect(seconds).not.toBeNull()
+    expect(seconds!).toBeGreaterThanOrEqual(599)
+    expect(seconds!).toBeLessThanOrEqual(601)
+  })
+
+  test('429 is a rate-limit regardless of headers', async () => {
+    const err = await GitHubAPIError.fromResponse(makeRes(429), 'Read ref')
+    expect(err.isRateLimit).toBe(true)
+  })
+
+  test('403 without rate-limit headers is NOT a rate-limit', async () => {
+    const err = await GitHubAPIError.fromResponse(makeRes(403, { message: 'Forbidden' }), 'Create commit')
+    expect(err.isRateLimit).toBe(false)
+  })
+
+  test('resetInSeconds returns null when reset is missing', async () => {
+    const err = await GitHubAPIError.fromResponse(makeRes(500), 'List branches')
+    expect(err.resetInSeconds()).toBeNull()
+  })
+
+  test('resetInSeconds returns 0 (not negative) when reset is in the past', async () => {
+    const past = Math.floor(Date.now() / 1000) - 60
+    const res = makeRes(403, null, { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': String(past) })
+    const err = await GitHubAPIError.fromResponse(res, 'Read tree')
+    expect(err.resetInSeconds()).toBe(0)
+  })
+})
+
+describe('ensureOk', () => {
+  test('returns silently on 200', async () => {
+    await expect(ensureOk(makeRes(200, {}), 'op')).resolves.toBeUndefined()
+  })
+
+  test('throws GitHubAPIError on non-ok', async () => {
+    await expect(ensureOk(makeRes(404, { message: 'Not found' }), 'Fetch repo'))
+      .rejects.toBeInstanceOf(GitHubAPIError)
+  })
+})

--- a/src/__tests__/githubFetch.test.ts
+++ b/src/__tests__/githubFetch.test.ts
@@ -14,7 +14,13 @@
  * Headers, Request) is available — jsdom drops these.
  */
 
-import { githubFetch, computeWait } from '../utils/githubFetch'
+import {
+  githubFetch,
+  computeWait,
+  getLastRateLimit,
+  onRateLimit,
+  _resetRateLimitTelemetry,
+} from '../utils/githubFetch'
 
 function makeRes(status: number, headers: Record<string, string> = {}): Response {
   const h = new Headers(headers)
@@ -22,6 +28,9 @@ function makeRes(status: number, headers: Record<string, string> = {}): Response
 }
 
 describe('githubFetch — retry behaviour', () => {
+  beforeEach(() => { _resetRateLimitTelemetry() })
+
+
   test('returns immediately on 200', async () => {
     const fetchMock = jest.fn().mockResolvedValue(makeRes(200))
     global.fetch = fetchMock as unknown as typeof fetch
@@ -119,6 +128,118 @@ describe('githubFetch — retry behaviour', () => {
     const res = await githubFetch('https://example.com', undefined, {
       delayMs: async () => {},
     })
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('githubFetch — 403 rate-limit handling', () => {
+  beforeEach(() => { _resetRateLimitTelemetry() })
+
+  test('treats 403 with x-ratelimit-remaining=0 as transient and retries', async () => {
+    const reset = String(Math.floor(Date.now() / 1000) + 1)
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(makeRes(403, {
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': reset,
+      }))
+      .mockResolvedValueOnce(makeRes(200))
+    global.fetch = fetchMock as unknown as typeof fetch
+    const delays: number[] = []
+    const res = await githubFetch('https://example.com', undefined, {
+      delayMs: async (ms) => { delays.push(ms) },
+    })
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(delays).toHaveLength(1)
+  })
+
+  test('treats 403 with retry-after (secondary rate limit) as transient', async () => {
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(makeRes(403, { 'retry-after': '2' }))
+      .mockResolvedValueOnce(makeRes(200))
+    global.fetch = fetchMock as unknown as typeof fetch
+    const delays: number[] = []
+    const res = await githubFetch('https://example.com', undefined, {
+      delayMs: async (ms) => { delays.push(ms) },
+    })
+    expect(res.status).toBe(200)
+    expect(delays).toEqual([2000])
+  })
+
+  test('does NOT retry a plain 403 with no rate-limit signal', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(403))
+    global.fetch = fetchMock as unknown as typeof fetch
+    const res = await githubFetch('https://example.com', undefined, {
+      delayMs: async () => {},
+    })
+    expect(res.status).toBe(403)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('githubFetch — rate-limit telemetry', () => {
+  beforeEach(() => { _resetRateLimitTelemetry() })
+
+  test('captures x-ratelimit-* headers on successful responses', async () => {
+    const reset = Math.floor(Date.now() / 1000) + 3600
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(200, {
+      'x-ratelimit-limit': '5000',
+      'x-ratelimit-remaining': '4998',
+      'x-ratelimit-reset': String(reset),
+      'x-ratelimit-resource': 'core',
+    }))
+    global.fetch = fetchMock as unknown as typeof fetch
+    await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
+    const snap = getLastRateLimit()
+    expect(snap).not.toBeNull()
+    expect(snap!.limit).toBe(5000)
+    expect(snap!.remaining).toBe(4998)
+    expect(snap!.reset).toBe(reset)
+    expect(snap!.resource).toBe('core')
+  })
+
+  test('notifies subscribers on each captured response', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(200, {
+      'x-ratelimit-limit': '5000',
+      'x-ratelimit-remaining': '4999',
+      'x-ratelimit-reset': '1000',
+    }))
+    global.fetch = fetchMock as unknown as typeof fetch
+    const seen: number[] = []
+    const unsub = onRateLimit((s) => { seen.push(s.remaining) })
+    await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
+    await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
+    unsub()
+    expect(seen).toEqual([4999, 4999])
+  })
+
+  test('skips capture when headers are absent', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(200))
+    global.fetch = fetchMock as unknown as typeof fetch
+    await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
+    expect(getLastRateLimit()).toBeNull()
+  })
+
+  test('skips capture when headers are non-numeric', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(200, {
+      'x-ratelimit-limit': 'banana',
+      'x-ratelimit-remaining': '4999',
+      'x-ratelimit-reset': '1000',
+    }))
+    global.fetch = fetchMock as unknown as typeof fetch
+    await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
+    expect(getLastRateLimit()).toBeNull()
+  })
+
+  test('listener exceptions do not break the fetch', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(200, {
+      'x-ratelimit-limit': '5000',
+      'x-ratelimit-remaining': '1',
+      'x-ratelimit-reset': '999',
+    }))
+    global.fetch = fetchMock as unknown as typeof fetch
+    onRateLimit(() => { throw new Error('boom') })
+    const res = await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
     expect(res.status).toBe(200)
   })
 })

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -16,6 +16,67 @@ export class DeviceFlowError extends Error {
   }
 }
 
+// Typed error thrown by every Git Data API helper below. Carries the HTTP
+// status, the GitHub error message (when the body parses as JSON), and any
+// rate-limit metadata so the UI can show a precise message instead of
+// "Failed to read tree (403)".
+export class GitHubAPIError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly operation: string,
+    public readonly githubMessage: string | null,
+    public readonly rateLimitReset: number | null,
+    public readonly remaining: number | null,
+  ) {
+    const tail = githubMessage ? ` — ${githubMessage}` : ''
+    super(`${operation} failed (${status})${tail}`)
+    this.name = 'GitHubAPIError'
+  }
+
+  /** True when this looks like a primary or secondary GitHub rate-limit hit. */
+  get isRateLimit(): boolean {
+    if (this.status === 429) return true
+    if (this.status === 403 && this.remaining === 0) return true
+    return false
+  }
+
+  /** Human-readable countdown until the rate-limit window resets. */
+  resetInSeconds(now = Date.now()): number | null {
+    if (this.rateLimitReset == null) return null
+    const ms = this.rateLimitReset * 1000 - now
+    return ms > 0 ? Math.ceil(ms / 1000) : 0
+  }
+
+  // Build from a non-ok Response. Best-effort: tries to read the JSON body
+  // for a "message" field, falls back to null. Always consumes the body.
+  static async fromResponse(res: Response, operation: string): Promise<GitHubAPIError> {
+    let githubMessage: string | null = null
+    try {
+      const body = await res.clone().json() as { message?: string }
+      if (typeof body.message === 'string') githubMessage = body.message
+    } catch {
+      // Body wasn't JSON, leave message null.
+    }
+    const reset = res.headers.get('x-ratelimit-reset')
+    const remaining = res.headers.get('x-ratelimit-remaining')
+    const resetN = reset != null ? parseInt(reset, 10) : NaN
+    const remainingN = remaining != null ? parseInt(remaining, 10) : NaN
+    return new GitHubAPIError(
+      res.status,
+      operation,
+      githubMessage,
+      Number.isFinite(resetN) ? resetN : null,
+      Number.isFinite(remainingN) ? remainingN : null,
+    )
+  }
+}
+
+/** Throw if the response isn't ok. Typed so callers can `instanceof` check. */
+export async function ensureOk(res: Response, operation: string): Promise<void> {
+  if (res.ok) return
+  throw await GitHubAPIError.fromResponse(res, operation)
+}
+
 // ── Step 1: ask the proxy to request a device code from GitHub ──────────────
 export async function startDeviceFlow(): Promise<DeviceFlowStart> {
   const res = await githubFetch('/api/github/device-code', { method: 'POST' })
@@ -78,7 +139,7 @@ export async function fetchGitHubUser(token: string): Promise<GitHubUser> {
   const res = await githubFetch('https://api.github.com/user', {
     headers: { 'Authorization': `Bearer ${token}`, 'Accept': 'application/vnd.github+json' },
   })
-  if (!res.ok) throw new Error(`GitHub /user returned ${res.status}`)
+  await ensureOk(res, 'Fetch GitHub user')
   const data = await res.json()
   return {
     id: data.id,
@@ -106,7 +167,7 @@ export async function listUserRepos(token: string): Promise<GitHubRepo[]> {
   for (let page = 1; page <= MAX_PAGES; page++) {
     const url = `https://api.github.com/user/repos?per_page=${PER_PAGE}&sort=updated&affiliation=owner,collaborator,organization_member&page=${page}`
     const res = await githubFetch(url, { headers: GH_HEADERS(token) })
-    if (!res.ok) throw new Error(`Failed to list repos (${res.status})`)
+    await ensureOk(res, 'List repos')
     const batch: GitHubRepo[] = await res.json()
     out.push(...batch)
     if (batch.length < PER_PAGE) break
@@ -119,7 +180,7 @@ export async function listRepoBranches(token: string, owner: string, repo: strin
     `https://api.github.com/repos/${owner}/${repo}/branches?per_page=100`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to list branches (${res.status})`)
+  await ensureOk(res, 'List branches')
   return res.json()
 }
 
@@ -128,7 +189,7 @@ export async function getRepo(token: string, owner: string, repo: string): Promi
     `https://api.github.com/repos/${owner}/${repo}`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to fetch repo (${res.status})`)
+  await ensureOk(res, 'Fetch repo')
   return res.json()
 }
 
@@ -149,11 +210,7 @@ export async function createRepo(
       description: 'Noteser vault',
     }),
   })
-  if (!res.ok) {
-    const errBody = await res.json().catch(() => ({}))
-    const detail = errBody.errors?.[0]?.message ?? errBody.message ?? `HTTP ${res.status}`
-    throw new Error(`Failed to create repo: ${detail}`)
-  }
+  await ensureOk(res, 'Create repo')
   return res.json()
 }
 
@@ -183,7 +240,7 @@ export async function getBranchRefSha(token: string, owner: string, repo: string
   // the path keys on the URL and so always misses.
   const url = `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}?_=${Date.now()}`
   const res = await githubFetch(url, { headers: GH_HEADERS(token), cache: 'no-store' })
-  if (!res.ok) throw new Error(`Failed to read ref (${res.status})`)
+  await ensureOk(res, 'Read ref')
   const data = await res.json()
   // The `/refs/heads/{branch}` endpoint returns an array when the supplied
   // path is a prefix match for multiple refs (e.g. `main` matching both
@@ -201,7 +258,7 @@ export async function getCommitTreeSha(token: string, owner: string, repo: strin
     `https://api.github.com/repos/${owner}/${repo}/git/commits/${commitSha}`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to read commit (${res.status})`)
+  await ensureOk(res, 'Read commit')
   const data = await res.json()
   return data.tree.sha
 }
@@ -212,7 +269,7 @@ export async function getTreeMap(token: string, owner: string, repo: string, tre
     `https://api.github.com/repos/${owner}/${repo}/git/trees/${treeSha}?recursive=1`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to read tree (${res.status})`)
+  await ensureOk(res, 'Read tree')
   const data = await res.json()
   const out = new Map<string, string>()
   for (const entry of data.tree as Array<{ path: string; type: string; sha: string }>) {
@@ -230,7 +287,7 @@ export async function createBlob(token: string, owner: string, repo: string, con
       body: JSON.stringify({ content, encoding: 'utf-8' }),
     },
   )
-  if (!res.ok) throw new Error(`Failed to create blob (${res.status})`)
+  await ensureOk(res, 'Create blob')
   const data = await res.json()
   return data.sha as string
 }
@@ -250,7 +307,7 @@ export async function createTree(
       body: JSON.stringify({ base_tree: baseTreeSha, tree: entries }),
     },
   )
-  if (!res.ok) throw new Error(`Failed to create tree (${res.status})`)
+  await ensureOk(res, 'Create tree')
   const data = await res.json()
   return data.sha as string
 }
@@ -271,7 +328,7 @@ export async function createCommit(
       body: JSON.stringify({ message, tree: treeSha, parents: [parentSha] }),
     },
   )
-  if (!res.ok) throw new Error(`Failed to create commit (${res.status})`)
+  await ensureOk(res, 'Create commit')
   const data = await res.json()
   return { sha: data.sha, html_url: data.html_url }
 }
@@ -291,10 +348,7 @@ export async function updateBranchRef(
       body: JSON.stringify({ sha: commitSha, force: false }),
     },
   )
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}))
-    throw new Error(`Failed to update branch (${res.status}): ${err.message ?? ''}`)
-  }
+  await ensureOk(res, 'Update branch ref')
 }
 
 // Download the repo as a zip archive at a given ref via our own proxy route.
@@ -314,10 +368,7 @@ export async function fetchZipball(token: string, owner: string, repo: string, r
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
     body: JSON.stringify({ owner, repo, ref }),
   })
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}))
-    throw new Error(`Failed to download zipball (${res.status}): ${err.error_description ?? ''}`)
-  }
+  await ensureOk(res, 'Download zipball')
   return res.arrayBuffer()
 }
 
@@ -327,7 +378,7 @@ export async function getBlobContent(token: string, owner: string, repo: string,
     `https://api.github.com/repos/${owner}/${repo}/git/blobs/${sha}`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to read blob ${sha} (${res.status})`)
+  await ensureOk(res, `Read blob ${sha}`)
   const data = await res.json()
   // GitHub may also return content with encoding 'utf-8' for small text blobs,
   // but base64 is the documented default and always safe to decode.
@@ -421,7 +472,7 @@ export async function createBlobBinary(
       body: JSON.stringify({ content: base64, encoding: 'base64' }),
     },
   )
-  if (!res.ok) throw new Error(`Failed to create binary blob (${res.status})`)
+  await ensureOk(res, 'Create binary blob')
   const data = await res.json()
   return data.sha as string
 }
@@ -439,7 +490,7 @@ export async function getBlobBytes(
     `https://api.github.com/repos/${owner}/${repo}/git/blobs/${sha}`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to read binary blob ${sha} (${res.status})`)
+  await ensureOk(res, `Read binary blob ${sha}`)
   const data = await res.json()
   if (data.encoding === 'base64') return base64ToBytes(data.content)
   // Unexpected — UTF-8 encoding on a binary blob would corrupt non-ASCII

--- a/src/utils/githubFetch.ts
+++ b/src/utils/githubFetch.ts
@@ -13,6 +13,23 @@ const MAX_DELAY_MS = 30_000
 
 const TRANSIENT_STATUSES = new Set([429, 500, 502, 503, 504])
 
+// GitHub's *primary* rate limit returns 403 (not 429!) with
+// `x-ratelimit-remaining: 0` plus an `x-ratelimit-reset` epoch. The
+// *secondary* (abuse-detection) limit also returns 403 but with a
+// `retry-after` header instead. Either way it's transient — wait and
+// retry. See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+function isRateLimited403(res: Response): boolean {
+  if (res.status !== 403) return false
+  const remaining = res.headers.get('x-ratelimit-remaining')
+  if (remaining === '0') return true
+  // Secondary rate limit: 403 with a Retry-After hint.
+  return res.headers.has('retry-after')
+}
+
+function isTransient(res: Response): boolean {
+  return TRANSIENT_STATUSES.has(res.status) || isRateLimited403(res)
+}
+
 interface GithubFetchOpts {
   /** Per-call retry cap. Defaults to MAX_RETRIES. */
   maxRetries?: number
@@ -43,7 +60,11 @@ export async function githubFetch(
       continue
     }
 
-    if (!TRANSIENT_STATUSES.has(res.status)) {
+    // Capture rate-limit headers for telemetry on every response that
+    // carries them — both successes and transient errors.
+    recordRateLimitFromResponse(res)
+
+    if (!isTransient(res)) {
       return res
     }
     if (attempt >= maxRetries) return res
@@ -52,6 +73,66 @@ export async function githubFetch(
     await delay(wait)
     attempt += 1
   }
+}
+
+// ── Rate-limit telemetry ────────────────────────────────────────────────────
+// GitHub returns x-ratelimit-{limit,remaining,reset,used,resource} on most
+// API responses. We snapshot the most recent values so the UI can show
+// "You have N requests left this hour" without an extra round-trip.
+
+export interface RateLimitSnapshot {
+  /** Total quota for the resource this window. */
+  limit: number
+  /** Requests left until reset. */
+  remaining: number
+  /** Epoch seconds when the window resets. */
+  reset: number
+  /** Resource bucket — `core`, `search`, `graphql`, etc. */
+  resource: string
+  /** When we captured this (client clock, epoch ms). */
+  capturedAt: number
+}
+
+let lastRateLimit: RateLimitSnapshot | null = null
+const listeners = new Set<(snap: RateLimitSnapshot) => void>()
+
+function recordRateLimitFromResponse(res: Response): void {
+  const limit = res.headers.get('x-ratelimit-limit')
+  const remaining = res.headers.get('x-ratelimit-remaining')
+  const reset = res.headers.get('x-ratelimit-reset')
+  if (limit == null || remaining == null || reset == null) return
+  const limitN = parseInt(limit, 10)
+  const remainingN = parseInt(remaining, 10)
+  const resetN = parseInt(reset, 10)
+  if (!Number.isFinite(limitN) || !Number.isFinite(remainingN) || !Number.isFinite(resetN)) return
+  const snap: RateLimitSnapshot = {
+    limit: limitN,
+    remaining: remainingN,
+    reset: resetN,
+    resource: res.headers.get('x-ratelimit-resource') ?? 'core',
+    capturedAt: Date.now(),
+  }
+  lastRateLimit = snap
+  for (const l of listeners) {
+    try { l(snap) } catch { /* listener errors must not break fetches */ }
+  }
+}
+
+/** Most recent rate-limit snapshot, or null if we haven't seen one yet. */
+export function getLastRateLimit(): RateLimitSnapshot | null {
+  return lastRateLimit
+}
+
+/** Subscribe to rate-limit updates. Returns the unsubscribe function. */
+export function onRateLimit(listener: (snap: RateLimitSnapshot) => void): () => void {
+  listeners.add(listener)
+  return () => { listeners.delete(listener) }
+}
+
+/** Reset state — for tests only. */
+export function _resetRateLimitTelemetry(): void {
+  lastRateLimit = null
+  listeners.clear()
 }
 
 // Reads `Retry-After` (seconds) when present, otherwise falls back to


### PR DESCRIPTION
## Summary

Hits the first sub-item of **Sync robustness** from \`docs/roadmap.md\` → Next: \"explicit rate-limit handling on the GitHub Git Data API\".

- 403 + \`x-ratelimit-remaining: 0\` (primary rate limit) and 403 + \`Retry-After\` (secondary / abuse-detection) are now treated as transient and retried, joining the existing 429 / 5xx paths.
- New typed \`GitHubAPIError\` carries status, GitHub's \`message\` field, the rate-limit reset epoch, and remaining quota — \`ensureOk()\` replaces 14 hand-rolled \`throw new Error\` blocks across every Git Data API helper so the UI can show precise messages.
- New rate-limit telemetry layer: \`getLastRateLimit()\` / \`onRateLimit()\` expose live quota snapshots from \`x-ratelimit-*\` response headers — UI work to surface this comes in a follow-up.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm test\` — 1164 / 1164 (17 new)
- [ ] Smoke a real sync against a personal vault to confirm errors render readably (PR reviewer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)