### PR TITLE
Fix: escape note body before HTML export (XSS, security audit finding 1)

### DIFF
--- a/src/__tests__/exportXssGuard.test.ts
+++ b/src/__tests__/exportXssGuard.test.ts
@@ -1,0 +1,54 @@
+/**
+ * exportXssGuard.test.ts
+ *
+ * Locks down the HTML export paths against XSS. The export module has
+ * two HTML generators — `buildPrintableHtml` (used by the in-browser
+ * "Print / PDF" path) and `convertToHTML` (used by the ZIP export when
+ * format='html'). Both must run note bodies through `escapeHTML` BEFORE
+ * the naive markdown→HTML regex pass, otherwise a `<script>` or
+ * `<img onerror=...>` in note content ends up executable in the file
+ * delivered to the recipient.
+ *
+ * The static-source check guarantees the call shape doesn't regress; we
+ * don't import the private generators directly since they're not
+ * exported. A future contributor who refactors should preserve the
+ * `convertMarkdownToHTML(escapeHTML(...))` pattern.
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const EXPORT_TS = readFileSync(join(__dirname, '..', 'utils', 'export.ts'), 'utf8')
+
+describe('export HTML XSS guards (static-source)', () => {
+  test('every convertMarkdownToHTML call escapes its input', () => {
+    // Find every call site of convertMarkdownToHTML in export.ts. Each
+    // must wrap the argument in escapeHTML(...). The function is local
+    // to that file so the file-scoped scan is exhaustive.
+    const pattern = /convertMarkdownToHTML\(([^)]+(?:\([^)]*\)[^)]*)*)\)/g
+    const offenders: string[] = []
+    let m: RegExpExecArray | null
+    while ((m = pattern.exec(EXPORT_TS)) !== null) {
+      const arg = m[1].trim()
+      // The function's own definition: `const convertMarkdownToHTML = (markdown: string)`
+      // — skip when matching that line.
+      if (/^markdown: string/.test(arg)) continue
+      // Acceptable: escapeHTML(...) — possibly with nested args.
+      if (/^escapeHTML\(/.test(arg)) continue
+      offenders.push(arg)
+    }
+    expect(offenders).toEqual([])
+  })
+
+  test('escapeHTML helper still encodes the dangerous characters', () => {
+    // The static check above only catches the call-shape; this asserts
+    // the helper actually does the work. If `escapeHTML` ever stops
+    // covering one of these, both export paths regress silently.
+    const code = EXPORT_TS
+    expect(code).toMatch(/escapeHTML\s*=\s*\(str: string\)/)
+    expect(code).toMatch(/replace\(\/&\/g/)
+    expect(code).toMatch(/replace\(\/</g)
+    expect(code).toMatch(/replace\(\/>/g)
+    expect(code).toMatch(/replace\(\/"/g)
+  })
+})

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -266,7 +266,7 @@ const convertToHTML = (note: Note, _tags: Tag[], includeTags: boolean): string =
   <h1>${escapeHTML(note.title)}</h1>
   ${tagsHTML}
   <div class="content">
-    ${convertMarkdownToHTML(note.content)}
+    ${convertMarkdownToHTML(escapeHTML(note.content))}
   </div>
 </body>
 </html>`


### PR DESCRIPTION
## Summary

One-line fix for the high-severity finding in `docs/research/security-audit-2026-05-21.md`.

`convertToHTML` (the ZIP-mode HTML export path, `src/utils/export.ts:269`) was interpolating `note.content` raw into an HTML document template. A note containing `<script>` tags or `<img onerror=...>` produced a self-contained XSS file that executed in the recipient's browser when they opened the exported `.html`. The in-browser print/PDF generator (`buildPrintableHtml` at line 157) already escaped correctly — the ZIP path silently diverged.

Fix mirrors the existing pattern:
```ts
convertMarkdownToHTML(escapeHTML(note.content))
```

Adds `src/__tests__/exportXssGuard.test.ts` that statically scans every `convertMarkdownToHTML(...)` call site in `export.ts` and asserts each one wraps its argument in `escapeHTML`. A future contributor who copy-pastes a new template gets a clear failure instead of a silent regression.

## Test plan

- [x] `npm test` — 1166 / 1166 (2 new in exportXssGuard)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Manual: export a note containing `<script>alert(1)</script>` as ZIP+HTML and confirm the rendered file shows the tags as literal text, not as executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)