### PR TITLE
Vault crypto: passphrase-based encryption module + tests

### DIFF
--- a/src/__tests__/vaultCrypto.test.ts
+++ b/src/__tests__/vaultCrypto.test.ts
@@ -1,0 +1,202 @@
+/**
+ * vaultCrypto.test.ts
+ *
+ * Covers the passphrase-based encryption module that the upcoming "encrypted
+ * backup" mode will sit on top of. The module is pure — no DOM, no store —
+ * but it does need WebCrypto + TextEncoder/Decoder, neither of which jsdom
+ * ships natively. We polyfill from Node before importing the module under
+ * test, mirroring the pattern used in `attachments.test.ts`.
+ */
+
+// ── Web-API polyfills ───────────────────────────────────────────────────────
+import { TextEncoder, TextDecoder } from 'util'
+import { webcrypto } from 'crypto'
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  ;(globalThis as unknown as { TextEncoder: typeof TextEncoder }).TextEncoder = TextEncoder
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  ;(globalThis as unknown as { TextDecoder: typeof TextDecoder }).TextDecoder = TextDecoder
+}
+if (typeof globalThis.crypto === 'undefined' || !globalThis.crypto.subtle) {
+  Object.defineProperty(globalThis, 'crypto', { value: webcrypto, writable: true })
+}
+
+import {
+  deriveKey,
+  encryptNoteContent,
+  decryptNoteContent,
+  isEncryptedContent,
+  generateSalt,
+  saltToString,
+  saltFromString,
+} from '@/utils/vaultCrypto'
+
+// PBKDF2 at 600k iterations is intentionally slow. A handful of derivations
+// per test is fine; bumping the jest timeout keeps CI honest on slower boxes.
+jest.setTimeout(30_000)
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+// We can't directly compare two non-extractable CryptoKeys for equality, so
+// instead we encrypt-with-A → decrypt-with-B. If the keys are functionally
+// the same, the roundtrip succeeds; if not, AES-GCM throws an auth-tag
+// `OperationError`.
+async function keysAreEquivalent(a: CryptoKey, b: CryptoKey): Promise<boolean> {
+  const probe = 'noteser-equivalence-probe'
+  const encrypted = await encryptNoteContent(probe, a)
+  try {
+    const out = await decryptNoteContent(encrypted, b)
+    return out === probe
+  } catch {
+    return false
+  }
+}
+
+// Deterministic salt for the deriveKey tests so we aren't at the mercy of
+// `crypto.getRandomValues` for assertions about determinism.
+function fixedSalt(): Uint8Array {
+  const salt = new Uint8Array(16)
+  for (let i = 0; i < salt.length; i++) salt[i] = i + 1
+  return salt
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+
+describe('vaultCrypto.deriveKey', () => {
+  it('is deterministic for the same passphrase + salt', async () => {
+    const salt = fixedSalt()
+    const k1 = await deriveKey('correct horse battery staple', salt)
+    const k2 = await deriveKey('correct horse battery staple', salt)
+    expect(await keysAreEquivalent(k1, k2)).toBe(true)
+  })
+
+  it('returns different keys for different salts', async () => {
+    const passphrase = 'correct horse battery staple'
+    const saltA = fixedSalt()
+    const saltB = generateSalt() // statistically distinct from fixedSalt()
+    const kA = await deriveKey(passphrase, saltA)
+    const kB = await deriveKey(passphrase, saltB)
+    expect(await keysAreEquivalent(kA, kB)).toBe(false)
+  })
+
+  it('returns different keys for different passphrases', async () => {
+    const salt = fixedSalt()
+    const kA = await deriveKey('alpha', salt)
+    const kB = await deriveKey('beta', salt)
+    expect(await keysAreEquivalent(kA, kB)).toBe(false)
+  })
+})
+
+describe('vaultCrypto.encrypt / decrypt roundtrip', () => {
+  it('roundtrips ASCII plaintext faithfully', async () => {
+    const key = await deriveKey('passphrase', fixedSalt())
+    const plaintext = '# Hello\n\nThis is a normal markdown note.\n'
+    const encrypted = await encryptNoteContent(plaintext, key)
+    const decrypted = await decryptNoteContent(encrypted, key)
+    expect(decrypted).toBe(plaintext)
+  })
+
+  it('roundtrips an empty string', async () => {
+    const key = await deriveKey('passphrase', fixedSalt())
+    const encrypted = await encryptNoteContent('', key)
+    const decrypted = await decryptNoteContent(encrypted, key)
+    expect(decrypted).toBe('')
+  })
+
+  it('roundtrips Unicode (Greek, Chinese, emoji) faithfully', async () => {
+    const key = await deriveKey('passphrase', fixedSalt())
+    const plaintext =
+      'Καλημέρα κόσμε! 你好，世界！🦊🔐\n\nMixed: ABC δεφ 漢字 🎉'
+    const encrypted = await encryptNoteContent(plaintext, key)
+    const decrypted = await decryptNoteContent(encrypted, key)
+    expect(decrypted).toBe(plaintext)
+  })
+
+  it('produces non-deterministic ciphertext for the same plaintext + key (IV varies)', async () => {
+    const key = await deriveKey('passphrase', fixedSalt())
+    const plaintext = 'identical input every time'
+    const c1 = await encryptNoteContent(plaintext, key)
+    const c2 = await encryptNoteContent(plaintext, key)
+    expect(c1).not.toBe(c2)
+    // but both must decrypt to the same plaintext.
+    expect(await decryptNoteContent(c1, key)).toBe(plaintext)
+    expect(await decryptNoteContent(c2, key)).toBe(plaintext)
+  })
+
+  it('fails to decrypt with the wrong key', async () => {
+    const salt = fixedSalt()
+    const keyRight = await deriveKey('correct passphrase', salt)
+    const keyWrong = await deriveKey('incorrect passphrase', salt)
+    const encrypted = await encryptNoteContent('secret stuff', keyRight)
+    await expect(decryptNoteContent(encrypted, keyWrong)).rejects.toThrow()
+  })
+
+  it('emits a banner that downstream consumers can detect', async () => {
+    const key = await deriveKey('passphrase', fixedSalt())
+    const encrypted = await encryptNoteContent('payload', key)
+    expect(encrypted.startsWith('---\nnoteser-encrypted: 1\n---\n')).toBe(true)
+  })
+})
+
+describe('vaultCrypto.isEncryptedContent', () => {
+  it('returns true for an encrypted envelope', async () => {
+    const key = await deriveKey('passphrase', fixedSalt())
+    const encrypted = await encryptNoteContent('hi', key)
+    expect(isEncryptedContent(encrypted)).toBe(true)
+  })
+
+  it('returns false for plain markdown', () => {
+    expect(isEncryptedContent('# Just a heading\n\nWith body.\n')).toBe(false)
+  })
+
+  it('returns false for markdown with non-noteser frontmatter', () => {
+    const plain = '---\ntitle: My Note\ntags: [a, b]\n---\n\nBody\n'
+    expect(isEncryptedContent(plain)).toBe(false)
+  })
+
+  it('returns false for the empty string', () => {
+    expect(isEncryptedContent('')).toBe(false)
+  })
+})
+
+describe('vaultCrypto salt helpers', () => {
+  it('generateSalt returns 16 random bytes', () => {
+    const a = generateSalt()
+    const b = generateSalt()
+    expect(a.length).toBe(16)
+    expect(b.length).toBe(16)
+    // Astronomically unlikely to be equal — guards against an all-zero impl.
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(false)
+  })
+
+  it('saltToString / saltFromString are inverse', () => {
+    const original = generateSalt()
+    const encoded = saltToString(original)
+    expect(typeof encoded).toBe('string')
+    const decoded = saltFromString(encoded)
+    expect(Array.from(decoded)).toEqual(Array.from(original))
+  })
+
+  it('saltFromString tolerates surrounding whitespace (file I/O leniency)', () => {
+    const original = generateSalt()
+    const encoded = saltToString(original)
+    const decoded = saltFromString(`  ${encoded}\n`)
+    expect(Array.from(decoded)).toEqual(Array.from(original))
+  })
+})
+
+describe('vaultCrypto.decryptNoteContent — error paths', () => {
+  it('throws when the input is not an encrypted envelope', async () => {
+    const key = await deriveKey('passphrase', fixedSalt())
+    await expect(decryptNoteContent('# plain markdown', key)).rejects.toThrow(
+      /not a noteser-encrypted payload/
+    )
+  })
+
+  it('throws when the envelope body is corrupted base64', async () => {
+    const key = await deriveKey('passphrase', fixedSalt())
+    const bogus = '---\nnoteser-encrypted: 1\n---\n!!!not-base64!!!\n'
+    await expect(decryptNoteContent(bogus, key)).rejects.toThrow()
+  })
+})

--- a/src/utils/vaultCrypto.ts
+++ b/src/utils/vaultCrypto.ts
@@ -1,0 +1,198 @@
+// Passphrase-based encryption building blocks for the optional "encrypted
+// backup" mode. None of this is wired into the sync pipeline yet — that is a
+// follow-up branch. This module exposes pure functions that a future
+// integration can call between "serialise note to markdown" and
+// `createBlob(content)` in `githubSync.ts`.
+//
+// Design:
+//   * Key derivation:  PBKDF2-SHA256, 600 000 iterations (current OWASP
+//                      recommendation for PBKDF2-SHA256, 2023+), 256-bit
+//                      AES-GCM key, per-vault 16-byte salt.
+//   * Symmetric cipher: AES-GCM with a fresh 12-byte IV per encryption.
+//   * Envelope on disk: a JSON object `{ v, iv, ct }` base64-encoded inside a
+//                      tiny YAML banner so the file still parses as markdown
+//                      with frontmatter — keeping the GitHub repo "looks like
+//                      noteser" rather than "looks like opaque binary".
+//
+// We deliberately avoid any third-party crypto: WebCrypto is part of the
+// browser + Node 22 standard libraries.
+
+const PBKDF2_ITERATIONS = 600_000
+const PBKDF2_HASH = 'SHA-256'
+const AES_KEY_LENGTH_BITS = 256
+const AES_IV_LENGTH_BYTES = 12
+const SALT_LENGTH_BYTES = 16
+const ENVELOPE_VERSION = 1
+
+const ENCRYPTED_BANNER_OPEN = '---\nnoteser-encrypted: 1\n---\n'
+
+// ── base64 helpers ───────────────────────────────────────────────────────────
+// We use `btoa`/`atob` since both browsers and Node 22 expose them globally.
+// They operate on binary strings, so we marshal `Uint8Array` through
+// `String.fromCharCode` (chunked to avoid blowing the argument limit on large
+// payloads).
+
+function bytesToBase64(bytes: Uint8Array): string {
+  const CHUNK = 0x8000
+  let binary = ''
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    const slice = bytes.subarray(i, i + CHUNK)
+    binary += String.fromCharCode(...slice)
+  }
+  return btoa(binary)
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64)
+  const out = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i)
+  return out
+}
+
+// ── salt helpers ─────────────────────────────────────────────────────────────
+
+// Generate a fresh 16-byte salt. Called once when the user first enables
+// encryption for a vault; persisted alongside the encrypted blobs in
+// `.noteser/vault-salt`.
+export function generateSalt(): Uint8Array {
+  const salt = new Uint8Array(SALT_LENGTH_BYTES)
+  crypto.getRandomValues(salt)
+  return salt
+}
+
+export function saltToString(salt: Uint8Array): string {
+  return bytesToBase64(salt)
+}
+
+export function saltFromString(s: string): Uint8Array {
+  return base64ToBytes(s.trim())
+}
+
+// ── key derivation ───────────────────────────────────────────────────────────
+
+// Derive a 256-bit AES-GCM key from `passphrase` + `salt` via PBKDF2-SHA256.
+// Deterministic: same inputs → same key (verified by tests). The returned
+// `CryptoKey` is non-extractable and usable for encrypt+decrypt.
+export async function deriveKey(passphrase: string, salt: Uint8Array): Promise<CryptoKey> {
+  const encoder = new TextEncoder()
+  const passphraseBytes = encoder.encode(passphrase)
+
+  const baseKey = await crypto.subtle.importKey(
+    'raw',
+    passphraseBytes as unknown as ArrayBuffer,
+    { name: 'PBKDF2' },
+    false,
+    ['deriveKey']
+  )
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: salt as unknown as ArrayBuffer,
+      iterations: PBKDF2_ITERATIONS,
+      hash: PBKDF2_HASH,
+    },
+    baseKey,
+    { name: 'AES-GCM', length: AES_KEY_LENGTH_BITS },
+    false,
+    ['encrypt', 'decrypt']
+  )
+}
+
+// ── envelope ─────────────────────────────────────────────────────────────────
+
+interface EncryptedEnvelope {
+  v: number
+  iv: string // base64
+  ct: string // base64
+}
+
+function isEnvelope(value: unknown): value is EncryptedEnvelope {
+  if (typeof value !== 'object' || value === null) return false
+  const obj = value as Record<string, unknown>
+  return (
+    typeof obj.v === 'number' &&
+    typeof obj.iv === 'string' &&
+    typeof obj.ct === 'string'
+  )
+}
+
+// Cheap synchronous check used by the pull path. Matches the banner only —
+// validating the inner envelope (and decrypting) is the caller's job.
+export function isEncryptedContent(content: string): boolean {
+  if (typeof content !== 'string') return false
+  return content.startsWith(ENCRYPTED_BANNER_OPEN)
+}
+
+function extractEnvelopeBody(content: string): string {
+  // Strip the banner; everything after it is the base64-encoded envelope.
+  // Trim trailing whitespace/newlines that an editor might have introduced.
+  return content.slice(ENCRYPTED_BANNER_OPEN.length).trim()
+}
+
+// ── encrypt / decrypt ────────────────────────────────────────────────────────
+
+// Encrypt a UTF-8 string. Returns the full `.md` payload (banner + base64
+// envelope) ready to write to the repo.
+export async function encryptNoteContent(plaintext: string, key: CryptoKey): Promise<string> {
+  const iv = new Uint8Array(AES_IV_LENGTH_BYTES)
+  crypto.getRandomValues(iv)
+
+  const plaintextBytes = new TextEncoder().encode(plaintext)
+
+  const ciphertextBuf = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: iv as unknown as ArrayBuffer },
+    key,
+    plaintextBytes as unknown as ArrayBuffer
+  )
+
+  const envelope: EncryptedEnvelope = {
+    v: ENVELOPE_VERSION,
+    iv: bytesToBase64(iv),
+    ct: bytesToBase64(new Uint8Array(ciphertextBuf)),
+  }
+
+  const envelopeJson = JSON.stringify(envelope)
+  const envelopeB64 = bytesToBase64(new TextEncoder().encode(envelopeJson))
+
+  return ENCRYPTED_BANNER_OPEN + envelopeB64 + '\n'
+}
+
+// Decrypt a noteser-encrypted payload. Throws if the input is malformed or
+// the key is wrong (the underlying WebCrypto error bubbles up — AES-GCM
+// auth-tag failure throws `OperationError`).
+export async function decryptNoteContent(
+  maybeCiphertext: string,
+  key: CryptoKey
+): Promise<string> {
+  if (!isEncryptedContent(maybeCiphertext)) {
+    throw new Error('vaultCrypto: input is not a noteser-encrypted payload')
+  }
+
+  const envelopeB64 = extractEnvelopeBody(maybeCiphertext)
+  let envelope: unknown
+  try {
+    const envelopeJson = new TextDecoder().decode(base64ToBytes(envelopeB64))
+    envelope = JSON.parse(envelopeJson)
+  } catch {
+    throw new Error('vaultCrypto: encrypted envelope is malformed')
+  }
+
+  if (!isEnvelope(envelope)) {
+    throw new Error('vaultCrypto: encrypted envelope is missing required fields')
+  }
+  if (envelope.v !== ENVELOPE_VERSION) {
+    throw new Error(`vaultCrypto: unsupported envelope version ${envelope.v}`)
+  }
+
+  const iv = base64ToBytes(envelope.iv)
+  const ct = base64ToBytes(envelope.ct)
+
+  const plaintextBuf = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: iv as unknown as ArrayBuffer },
+    key,
+    ct as unknown as ArrayBuffer
+  )
+
+  return new TextDecoder().decode(plaintextBuf)
+}


### PR DESCRIPTION
Lands the building blocks for the **Backup encryption** roadmap item. **No integration with sync yet** — that's a follow-up branch.

## What ships

`src/utils/vaultCrypto.ts` exposes:

| Function | What |
|---|---|
| `deriveKey(passphrase, salt)` | PBKDF2-SHA256 → 256-bit AES-GCM key (600k iters, OWASP) |
| `encryptNoteContent(plaintext, key)` | `{ v, iv, ct }` JSON envelope, wrapped in a `noteser-encrypted: 1` frontmatter banner so the file still looks like noteser markdown |
| `decryptNoteContent(ciphertext, key)` | Inverse; throws on banner-mismatch, malformed envelope, or wrong key |
| `isEncryptedContent(content)` | Cheap sync guard for the pull path |
| `generateSalt()` / `saltToString` / `saltFromString` | Per-vault salt helpers — store under `.noteser/vault-salt` |

## Test plan

- [x] 18 / 18 vaultCrypto tests passing (roundtrip, wrong-key reject, non-determinism, unicode, empty string, salt symmetry)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Full suite still 1147 + 18 = 1165 passing

## What's next

The integration branch (`feat/backup-encryption-integration`) will: add Settings UI for enable + passphrase, persist the derived key in memory only (never localStorage), hook into the push path between markdown serialization and `createBlob`, hook into the pull path between `getBlobContent` and `syncApply`, store the per-vault salt at `.noteser/vault-salt`. Attachments will NOT be encrypted in v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)