### PR TITLE
Sync: push progress events + in-tab upload cache for partial-failure retries

### DIFF
--- a/src/__tests__/githubApiError.test.ts
+++ b/src/__tests__/githubApiError.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment node
+ *
+ * GitHubAPIError covers the typed error thrown by every Git Data API
+ * helper. It carries status, GitHub's `message` field, the rate-limit
+ * reset epoch, and a remaining quota — enough for the UI to render a
+ * precise message instead of "Failed (403)".
+ */
+
+import { GitHubAPIError, ensureOk } from '../utils/github'
+
+function makeRes(status: number, body: unknown = null, headers: Record<string, string> = {}): Response {
+  return new Response(body == null ? null : JSON.stringify(body), {
+    status,
+    headers: new Headers({ 'Content-Type': 'application/json', ...headers }),
+  })
+}
+
+describe('GitHubAPIError', () => {
+  test('captures status + operation + GitHub message', async () => {
+    const res = makeRes(422, { message: 'Update is not a fast forward' })
+    const err = await GitHubAPIError.fromResponse(res, 'Update branch ref')
+    expect(err).toBeInstanceOf(GitHubAPIError)
+    expect(err.status).toBe(422)
+    expect(err.operation).toBe('Update branch ref')
+    expect(err.githubMessage).toBe('Update is not a fast forward')
+    expect(err.message).toContain('Update branch ref')
+    expect(err.message).toContain('422')
+    expect(err.message).toContain('Update is not a fast forward')
+  })
+
+  test('handles non-JSON bodies gracefully', async () => {
+    const res = new Response('not json', {
+      status: 500,
+      headers: { 'Content-Type': 'text/html' },
+    })
+    const err = await GitHubAPIError.fromResponse(res, 'Create blob')
+    expect(err.status).toBe(500)
+    expect(err.githubMessage).toBeNull()
+  })
+
+  test('captures rate-limit headers', async () => {
+    const reset = Math.floor(Date.now() / 1000) + 600
+    const res = makeRes(403, { message: 'API rate limit exceeded' }, {
+      'x-ratelimit-remaining': '0',
+      'x-ratelimit-reset': String(reset),
+    })
+    const err = await GitHubAPIError.fromResponse(res, 'Read tree')
+    expect(err.isRateLimit).toBe(true)
+    expect(err.remaining).toBe(0)
+    expect(err.rateLimitReset).toBe(reset)
+    const seconds = err.resetInSeconds()
+    expect(seconds).not.toBeNull()
+    expect(seconds!).toBeGreaterThanOrEqual(599)
+    expect(seconds!).toBeLessThanOrEqual(601)
+  })
+
+  test('429 is a rate-limit regardless of headers', async () => {
+    const err = await GitHubAPIError.fromResponse(makeRes(429), 'Read ref')
+    expect(err.isRateLimit).toBe(true)
+  })
+
+  test('403 without rate-limit headers is NOT a rate-limit', async () => {
+    const err = await GitHubAPIError.fromResponse(makeRes(403, { message: 'Forbidden' }), 'Create commit')
+    expect(err.isRateLimit).toBe(false)
+  })
+
+  test('resetInSeconds returns null when reset is missing', async () => {
+    const err = await GitHubAPIError.fromResponse(makeRes(500), 'List branches')
+    expect(err.resetInSeconds()).toBeNull()
+  })
+
+  test('resetInSeconds returns 0 (not negative) when reset is in the past', async () => {
+    const past = Math.floor(Date.now() / 1000) - 60
+    const res = makeRes(403, null, { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': String(past) })
+    const err = await GitHubAPIError.fromResponse(res, 'Read tree')
+    expect(err.resetInSeconds()).toBe(0)
+  })
+})
+
+describe('ensureOk', () => {
+  test('returns silently on 200', async () => {
+    await expect(ensureOk(makeRes(200, {}), 'op')).resolves.toBeUndefined()
+  })
+
+  test('throws GitHubAPIError on non-ok', async () => {
+    await expect(ensureOk(makeRes(404, { message: 'Not found' }), 'Fetch repo'))
+      .rejects.toBeInstanceOf(GitHubAPIError)
+  })
+})

--- a/src/__tests__/githubFetch.test.ts
+++ b/src/__tests__/githubFetch.test.ts
@@ -14,7 +14,13 @@
  * Headers, Request) is available — jsdom drops these.
  */
 
-import { githubFetch, computeWait } from '../utils/githubFetch'
+import {
+  githubFetch,
+  computeWait,
+  getLastRateLimit,
+  onRateLimit,
+  _resetRateLimitTelemetry,
+} from '../utils/githubFetch'
 
 function makeRes(status: number, headers: Record<string, string> = {}): Response {
   const h = new Headers(headers)
@@ -22,6 +28,9 @@ function makeRes(status: number, headers: Record<string, string> = {}): Response
 }
 
 describe('githubFetch — retry behaviour', () => {
+  beforeEach(() => { _resetRateLimitTelemetry() })
+
+
   test('returns immediately on 200', async () => {
     const fetchMock = jest.fn().mockResolvedValue(makeRes(200))
     global.fetch = fetchMock as unknown as typeof fetch
@@ -119,6 +128,118 @@ describe('githubFetch — retry behaviour', () => {
     const res = await githubFetch('https://example.com', undefined, {
       delayMs: async () => {},
     })
+    expect(res.status).toBe(200)
+  })
+})
+
+describe('githubFetch — 403 rate-limit handling', () => {
+  beforeEach(() => { _resetRateLimitTelemetry() })
+
+  test('treats 403 with x-ratelimit-remaining=0 as transient and retries', async () => {
+    const reset = String(Math.floor(Date.now() / 1000) + 1)
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(makeRes(403, {
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': reset,
+      }))
+      .mockResolvedValueOnce(makeRes(200))
+    global.fetch = fetchMock as unknown as typeof fetch
+    const delays: number[] = []
+    const res = await githubFetch('https://example.com', undefined, {
+      delayMs: async (ms) => { delays.push(ms) },
+    })
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(delays).toHaveLength(1)
+  })
+
+  test('treats 403 with retry-after (secondary rate limit) as transient', async () => {
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(makeRes(403, { 'retry-after': '2' }))
+      .mockResolvedValueOnce(makeRes(200))
+    global.fetch = fetchMock as unknown as typeof fetch
+    const delays: number[] = []
+    const res = await githubFetch('https://example.com', undefined, {
+      delayMs: async (ms) => { delays.push(ms) },
+    })
+    expect(res.status).toBe(200)
+    expect(delays).toEqual([2000])
+  })
+
+  test('does NOT retry a plain 403 with no rate-limit signal', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(403))
+    global.fetch = fetchMock as unknown as typeof fetch
+    const res = await githubFetch('https://example.com', undefined, {
+      delayMs: async () => {},
+    })
+    expect(res.status).toBe(403)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('githubFetch — rate-limit telemetry', () => {
+  beforeEach(() => { _resetRateLimitTelemetry() })
+
+  test('captures x-ratelimit-* headers on successful responses', async () => {
+    const reset = Math.floor(Date.now() / 1000) + 3600
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(200, {
+      'x-ratelimit-limit': '5000',
+      'x-ratelimit-remaining': '4998',
+      'x-ratelimit-reset': String(reset),
+      'x-ratelimit-resource': 'core',
+    }))
+    global.fetch = fetchMock as unknown as typeof fetch
+    await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
+    const snap = getLastRateLimit()
+    expect(snap).not.toBeNull()
+    expect(snap!.limit).toBe(5000)
+    expect(snap!.remaining).toBe(4998)
+    expect(snap!.reset).toBe(reset)
+    expect(snap!.resource).toBe('core')
+  })
+
+  test('notifies subscribers on each captured response', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(200, {
+      'x-ratelimit-limit': '5000',
+      'x-ratelimit-remaining': '4999',
+      'x-ratelimit-reset': '1000',
+    }))
+    global.fetch = fetchMock as unknown as typeof fetch
+    const seen: number[] = []
+    const unsub = onRateLimit((s) => { seen.push(s.remaining) })
+    await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
+    await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
+    unsub()
+    expect(seen).toEqual([4999, 4999])
+  })
+
+  test('skips capture when headers are absent', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(200))
+    global.fetch = fetchMock as unknown as typeof fetch
+    await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
+    expect(getLastRateLimit()).toBeNull()
+  })
+
+  test('skips capture when headers are non-numeric', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(200, {
+      'x-ratelimit-limit': 'banana',
+      'x-ratelimit-remaining': '4999',
+      'x-ratelimit-reset': '1000',
+    }))
+    global.fetch = fetchMock as unknown as typeof fetch
+    await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
+    expect(getLastRateLimit()).toBeNull()
+  })
+
+  test('listener exceptions do not break the fetch', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(makeRes(200, {
+      'x-ratelimit-limit': '5000',
+      'x-ratelimit-remaining': '1',
+      'x-ratelimit-reset': '999',
+    }))
+    global.fetch = fetchMock as unknown as typeof fetch
+    onRateLimit(() => { throw new Error('boom') })
+    const res = await githubFetch('https://example.com', undefined, { delayMs: async () => {} })
     expect(res.status).toBe(200)
   })
 })

--- a/src/__tests__/syncPushProgress.test.ts
+++ b/src/__tests__/syncPushProgress.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @jest-environment node
+ *
+ * Push progress + upload-cache coverage for syncToGitHub.
+ *
+ * We mock the network layer (githubFetch) rather than the higher-level
+ * github.ts helpers so the contract under test is the real one:
+ *
+ *   - The push emits progress events in order: computing →
+ *     uploading-blobs (with running count) → creating-tree →
+ *     creating-commit → updating-ref → done.
+ *   - When a blob upload fails partway through, a retry of syncToGitHub
+ *     (same tab, same repo) skips the blobs the first attempt already
+ *     uploaded — confirmed by counting fetch calls to /git/blobs.
+ *
+ * Notes are intentionally tiny — we're testing the bookkeeping, not the
+ * encoder.
+ */
+
+import { syncToGitHub, _resetUploadedShaCache } from '../utils/githubSync'
+import type { PushProgress } from '../utils/githubSync'
+import type { Note, Folder, SyncRepo } from '@/types'
+
+// Stub IDB-backed helpers that syncToGitHub touches indirectly via
+// dynamic imports. Jest's module mocks intercept them.
+jest.mock('../utils/attachments', () => ({
+  isAttachmentPath: () => false,
+  listAttachmentPaths: async () => [],
+  getAttachmentBlob: async () => null,
+  getAttachmentGitSha: async () => null,
+  getAttachmentTombstones: async () => [],
+  clearAttachmentTombstones: async () => undefined,
+}))
+jest.mock('../utils/lastPushedContent', () => ({
+  setLastPushedContent: async () => undefined,
+  getLastPushedContent: async () => null,
+}))
+jest.mock('../stores/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({ localGitignoreOverlay: '' }) },
+}))
+
+const REPO: SyncRepo = { owner: 'o', name: 'r', branch: 'main' }
+
+function makeNote(id: string, title: string, content: string): Note {
+  return {
+    id,
+    title,
+    content,
+    folderId: null,
+    tags: [],
+    createdAt: 0,
+    updatedAt: 0,
+    isDeleted: false,
+    deletedAt: null,
+    isPinned: false,
+    templateId: null,
+    gitPath: null,
+    gitLastPushedSha: null,
+  }
+}
+
+// Each fetch call lands here. The handlers below dispatch based on URL.
+function makeFetchMock(opts: {
+  onCreateBlob?: (attemptIdx: number) => Promise<Response> | Response
+  remoteTreeBlobs?: Map<string, string>
+} = {}) {
+  let blobAttempt = 0
+  const remoteBlobs = opts.remoteTreeBlobs ?? new Map()
+  const createBlobHandler = opts.onCreateBlob ?? (() => new Response(JSON.stringify({ sha: `blob-${blobAttempt}` }), { status: 201 }))
+
+  return jest.fn(async (url: string | URL, init?: RequestInit) => {
+    const u = String(url)
+    // GET branch ref → parent commit sha
+    if (u.includes('/git/refs/heads/main')) {
+      return new Response(JSON.stringify({ ref: 'refs/heads/main', object: { sha: 'parent-commit' } }), { status: 200 })
+    }
+    // GET commit → tree sha
+    if (u.match(/\/git\/commits\/parent-commit/)) {
+      return new Response(JSON.stringify({ tree: { sha: 'base-tree' } }), { status: 200 })
+    }
+    // GET tree recursive
+    if (u.includes('/git/trees/base-tree?recursive=1')) {
+      const tree = Array.from(remoteBlobs.entries()).map(([path, sha]) => ({ path, type: 'blob', sha }))
+      return new Response(JSON.stringify({ tree }), { status: 200 })
+    }
+    // POST /git/blobs — only when CREATING (init.method === 'POST'). The
+    // create handler is allowed to throw / 5xx so we can simulate partial
+    // failure.
+    if (u.endsWith('/git/blobs') && init?.method === 'POST') {
+      blobAttempt++
+      return createBlobHandler(blobAttempt - 1)
+    }
+    // POST /git/trees
+    if (u.endsWith('/git/trees') && init?.method === 'POST') {
+      return new Response(JSON.stringify({ sha: 'new-tree' }), { status: 201 })
+    }
+    // POST /git/commits
+    if (u.endsWith('/git/commits') && init?.method === 'POST') {
+      return new Response(JSON.stringify({ sha: 'new-commit', html_url: 'https://github.com/x' }), { status: 201 })
+    }
+    // PATCH /git/refs/heads/main
+    if (u.includes('/git/refs/heads/main') && init?.method === 'PATCH') {
+      return new Response(JSON.stringify({}), { status: 200 })
+    }
+    return new Response('not mocked: ' + u, { status: 500 })
+  })
+}
+
+describe('syncToGitHub — push progress events', () => {
+  beforeEach(() => { _resetUploadedShaCache() })
+
+  test('emits the full phase sequence on a clean push of 2 new notes', async () => {
+    const fetchMock = makeFetchMock()
+    global.fetch = fetchMock as unknown as typeof fetch
+    const phases: PushProgress[] = []
+    await syncToGitHub({
+      token: 't',
+      repo: REPO,
+      notes: [makeNote('1', 'A', 'aaaa'), makeNote('2', 'B', 'bbbb')],
+      folders: [] as Folder[],
+      onProgress: e => { phases.push(e) },
+    })
+
+    expect(phases[0]).toEqual({ phase: 'computing' })
+    // At least one uploading-blobs event with total === 2.
+    const uploading = phases.filter((p): p is Extract<PushProgress, { phase: 'uploading-blobs' }> => p.phase === 'uploading-blobs')
+    expect(uploading.length).toBeGreaterThan(0)
+    expect(uploading[0].total).toBe(2)
+    expect(uploading[uploading.length - 1].uploaded).toBe(2)
+    expect(uploading[uploading.length - 1].skipped).toBe(0)
+
+    // Order check: every "uploading-blobs" event must precede tree/commit/ref/done.
+    const phaseOrder = phases.map(p => p.phase)
+    expect(phaseOrder).toEqual(expect.arrayContaining(['creating-tree', 'creating-commit', 'updating-ref', 'done']))
+    expect(phaseOrder.indexOf('creating-tree')).toBeGreaterThan(phaseOrder.lastIndexOf('uploading-blobs'))
+    expect(phaseOrder.indexOf('done')).toBe(phaseOrder.length - 1)
+  })
+
+  test('upload cache: retry after partial failure skips uploaded blobs', async () => {
+    // Push 3 notes. The first blob upload succeeds, the second 5xx's
+    // (after exhausting githubFetch's own retries), the third never
+    // runs because the loop throws first. The retry call sees the cache
+    // and skips the first blob.
+    const failedOnce = { fired: false }
+    const fetchMock = makeFetchMock({
+      onCreateBlob: (idx) => {
+        if (idx === 0) {
+          return new Response(JSON.stringify({ sha: 'sha-A' }), { status: 201 })
+        }
+        // 422 is non-transient — githubFetch returns it immediately
+        // without burning real setTimeout, and ensureOk throws.
+        failedOnce.fired = true
+        return new Response(JSON.stringify({ message: 'simulated' }), { status: 422 })
+      },
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+    const notes = [makeNote('1', 'A', 'aa'), makeNote('2', 'B', 'bb'), makeNote('3', 'C', 'cc')]
+
+    // First attempt — expect a thrown error mid-loop.
+    await expect(syncToGitHub({
+      token: 't',
+      repo: REPO,
+      notes,
+      folders: [] as Folder[],
+    })).rejects.toThrow()
+    expect(failedOnce.fired).toBe(true)
+
+    // Retry: make every blob upload succeed. The cache should mean
+    // blob A is NOT re-uploaded.
+    fetchMock.mockClear()
+    let calls = 0
+    global.fetch = (jest.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = String(url)
+      if (u.endsWith('/git/blobs') && init?.method === 'POST') {
+        calls++
+        return new Response(JSON.stringify({ sha: `sha-retry-${calls}` }), { status: 201 })
+      }
+      // Reuse the prior tree-reading handlers via the original mock.
+      return fetchMock(url, init)
+    })) as unknown as typeof fetch
+
+    await syncToGitHub({
+      token: 't',
+      repo: REPO,
+      notes,
+      folders: [] as Folder[],
+    })
+    // Notes 2 + 3 are not in the cache (their localSha was never
+    // successfully uploaded). Note 1 is in the cache and should NOT be
+    // re-uploaded. So expect exactly 2 createBlob POSTs.
+    expect(calls).toBe(2)
+  })
+
+  test('cache is cleared after a successful push', async () => {
+    const fetchMock = makeFetchMock()
+    global.fetch = fetchMock as unknown as typeof fetch
+    const notes = [makeNote('1', 'A', 'one')]
+    await syncToGitHub({ token: 't', repo: REPO, notes, folders: [] as Folder[] })
+
+    // Force a deliberate cache miss by changing the remote tree's view.
+    // The 2nd push should upload again because the cache is empty.
+    const fetchMock2 = makeFetchMock()
+    global.fetch = fetchMock2 as unknown as typeof fetch
+    await syncToGitHub({ token: 't', repo: REPO, notes, folders: [] as Folder[] })
+    const blobPosts2 = fetchMock2.mock.calls.filter(c => String(c[0]).endsWith('/git/blobs') && (c[1] as RequestInit | undefined)?.method === 'POST').length
+    expect(blobPosts2).toBe(1)
+  })
+})

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -16,6 +16,67 @@ export class DeviceFlowError extends Error {
   }
 }
 
+// Typed error thrown by every Git Data API helper below. Carries the HTTP
+// status, the GitHub error message (when the body parses as JSON), and any
+// rate-limit metadata so the UI can show a precise message instead of
+// "Failed to read tree (403)".
+export class GitHubAPIError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly operation: string,
+    public readonly githubMessage: string | null,
+    public readonly rateLimitReset: number | null,
+    public readonly remaining: number | null,
+  ) {
+    const tail = githubMessage ? ` — ${githubMessage}` : ''
+    super(`${operation} failed (${status})${tail}`)
+    this.name = 'GitHubAPIError'
+  }
+
+  /** True when this looks like a primary or secondary GitHub rate-limit hit. */
+  get isRateLimit(): boolean {
+    if (this.status === 429) return true
+    if (this.status === 403 && this.remaining === 0) return true
+    return false
+  }
+
+  /** Human-readable countdown until the rate-limit window resets. */
+  resetInSeconds(now = Date.now()): number | null {
+    if (this.rateLimitReset == null) return null
+    const ms = this.rateLimitReset * 1000 - now
+    return ms > 0 ? Math.ceil(ms / 1000) : 0
+  }
+
+  // Build from a non-ok Response. Best-effort: tries to read the JSON body
+  // for a "message" field, falls back to null. Always consumes the body.
+  static async fromResponse(res: Response, operation: string): Promise<GitHubAPIError> {
+    let githubMessage: string | null = null
+    try {
+      const body = await res.clone().json() as { message?: string }
+      if (typeof body.message === 'string') githubMessage = body.message
+    } catch {
+      // Body wasn't JSON, leave message null.
+    }
+    const reset = res.headers.get('x-ratelimit-reset')
+    const remaining = res.headers.get('x-ratelimit-remaining')
+    const resetN = reset != null ? parseInt(reset, 10) : NaN
+    const remainingN = remaining != null ? parseInt(remaining, 10) : NaN
+    return new GitHubAPIError(
+      res.status,
+      operation,
+      githubMessage,
+      Number.isFinite(resetN) ? resetN : null,
+      Number.isFinite(remainingN) ? remainingN : null,
+    )
+  }
+}
+
+/** Throw if the response isn't ok. Typed so callers can `instanceof` check. */
+export async function ensureOk(res: Response, operation: string): Promise<void> {
+  if (res.ok) return
+  throw await GitHubAPIError.fromResponse(res, operation)
+}
+
 // ── Step 1: ask the proxy to request a device code from GitHub ──────────────
 export async function startDeviceFlow(): Promise<DeviceFlowStart> {
   const res = await githubFetch('/api/github/device-code', { method: 'POST' })
@@ -78,7 +139,7 @@ export async function fetchGitHubUser(token: string): Promise<GitHubUser> {
   const res = await githubFetch('https://api.github.com/user', {
     headers: { 'Authorization': `Bearer ${token}`, 'Accept': 'application/vnd.github+json' },
   })
-  if (!res.ok) throw new Error(`GitHub /user returned ${res.status}`)
+  await ensureOk(res, 'Fetch GitHub user')
   const data = await res.json()
   return {
     id: data.id,
@@ -106,7 +167,7 @@ export async function listUserRepos(token: string): Promise<GitHubRepo[]> {
   for (let page = 1; page <= MAX_PAGES; page++) {
     const url = `https://api.github.com/user/repos?per_page=${PER_PAGE}&sort=updated&affiliation=owner,collaborator,organization_member&page=${page}`
     const res = await githubFetch(url, { headers: GH_HEADERS(token) })
-    if (!res.ok) throw new Error(`Failed to list repos (${res.status})`)
+    await ensureOk(res, 'List repos')
     const batch: GitHubRepo[] = await res.json()
     out.push(...batch)
     if (batch.length < PER_PAGE) break
@@ -119,7 +180,7 @@ export async function listRepoBranches(token: string, owner: string, repo: strin
     `https://api.github.com/repos/${owner}/${repo}/branches?per_page=100`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to list branches (${res.status})`)
+  await ensureOk(res, 'List branches')
   return res.json()
 }
 
@@ -128,7 +189,7 @@ export async function getRepo(token: string, owner: string, repo: string): Promi
     `https://api.github.com/repos/${owner}/${repo}`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to fetch repo (${res.status})`)
+  await ensureOk(res, 'Fetch repo')
   return res.json()
 }
 
@@ -149,11 +210,7 @@ export async function createRepo(
       description: 'Noteser vault',
     }),
   })
-  if (!res.ok) {
-    const errBody = await res.json().catch(() => ({}))
-    const detail = errBody.errors?.[0]?.message ?? errBody.message ?? `HTTP ${res.status}`
-    throw new Error(`Failed to create repo: ${detail}`)
-  }
+  await ensureOk(res, 'Create repo')
   return res.json()
 }
 
@@ -183,7 +240,7 @@ export async function getBranchRefSha(token: string, owner: string, repo: string
   // the path keys on the URL and so always misses.
   const url = `https://api.github.com/repos/${owner}/${repo}/git/refs/heads/${branch}?_=${Date.now()}`
   const res = await githubFetch(url, { headers: GH_HEADERS(token), cache: 'no-store' })
-  if (!res.ok) throw new Error(`Failed to read ref (${res.status})`)
+  await ensureOk(res, 'Read ref')
   const data = await res.json()
   // The `/refs/heads/{branch}` endpoint returns an array when the supplied
   // path is a prefix match for multiple refs (e.g. `main` matching both
@@ -201,7 +258,7 @@ export async function getCommitTreeSha(token: string, owner: string, repo: strin
     `https://api.github.com/repos/${owner}/${repo}/git/commits/${commitSha}`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to read commit (${res.status})`)
+  await ensureOk(res, 'Read commit')
   const data = await res.json()
   return data.tree.sha
 }
@@ -212,7 +269,7 @@ export async function getTreeMap(token: string, owner: string, repo: string, tre
     `https://api.github.com/repos/${owner}/${repo}/git/trees/${treeSha}?recursive=1`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to read tree (${res.status})`)
+  await ensureOk(res, 'Read tree')
   const data = await res.json()
   const out = new Map<string, string>()
   for (const entry of data.tree as Array<{ path: string; type: string; sha: string }>) {
@@ -230,7 +287,7 @@ export async function createBlob(token: string, owner: string, repo: string, con
       body: JSON.stringify({ content, encoding: 'utf-8' }),
     },
   )
-  if (!res.ok) throw new Error(`Failed to create blob (${res.status})`)
+  await ensureOk(res, 'Create blob')
   const data = await res.json()
   return data.sha as string
 }
@@ -250,7 +307,7 @@ export async function createTree(
       body: JSON.stringify({ base_tree: baseTreeSha, tree: entries }),
     },
   )
-  if (!res.ok) throw new Error(`Failed to create tree (${res.status})`)
+  await ensureOk(res, 'Create tree')
   const data = await res.json()
   return data.sha as string
 }
@@ -271,7 +328,7 @@ export async function createCommit(
       body: JSON.stringify({ message, tree: treeSha, parents: [parentSha] }),
     },
   )
-  if (!res.ok) throw new Error(`Failed to create commit (${res.status})`)
+  await ensureOk(res, 'Create commit')
   const data = await res.json()
   return { sha: data.sha, html_url: data.html_url }
 }
@@ -291,10 +348,7 @@ export async function updateBranchRef(
       body: JSON.stringify({ sha: commitSha, force: false }),
     },
   )
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}))
-    throw new Error(`Failed to update branch (${res.status}): ${err.message ?? ''}`)
-  }
+  await ensureOk(res, 'Update branch ref')
 }
 
 // Download the repo as a zip archive at a given ref via our own proxy route.
@@ -314,10 +368,7 @@ export async function fetchZipball(token: string, owner: string, repo: string, r
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
     body: JSON.stringify({ owner, repo, ref }),
   })
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}))
-    throw new Error(`Failed to download zipball (${res.status}): ${err.error_description ?? ''}`)
-  }
+  await ensureOk(res, 'Download zipball')
   return res.arrayBuffer()
 }
 
@@ -327,7 +378,7 @@ export async function getBlobContent(token: string, owner: string, repo: string,
     `https://api.github.com/repos/${owner}/${repo}/git/blobs/${sha}`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to read blob ${sha} (${res.status})`)
+  await ensureOk(res, `Read blob ${sha}`)
   const data = await res.json()
   // GitHub may also return content with encoding 'utf-8' for small text blobs,
   // but base64 is the documented default and always safe to decode.
@@ -421,7 +472,7 @@ export async function createBlobBinary(
       body: JSON.stringify({ content: base64, encoding: 'base64' }),
     },
   )
-  if (!res.ok) throw new Error(`Failed to create binary blob (${res.status})`)
+  await ensureOk(res, 'Create binary blob')
   const data = await res.json()
   return data.sha as string
 }
@@ -439,7 +490,7 @@ export async function getBlobBytes(
     `https://api.github.com/repos/${owner}/${repo}/git/blobs/${sha}`,
     { headers: GH_HEADERS(token) },
   )
-  if (!res.ok) throw new Error(`Failed to read binary blob ${sha} (${res.status})`)
+  await ensureOk(res, `Read binary blob ${sha}`)
   const data = await res.json()
   if (data.encoding === 'base64') return base64ToBytes(data.content)
   // Unexpected — UTF-8 encoding on a binary blob would corrupt non-ASCII

--- a/src/utils/githubFetch.ts
+++ b/src/utils/githubFetch.ts
@@ -13,6 +13,23 @@ const MAX_DELAY_MS = 30_000
 
 const TRANSIENT_STATUSES = new Set([429, 500, 502, 503, 504])
 
+// GitHub's *primary* rate limit returns 403 (not 429!) with
+// `x-ratelimit-remaining: 0` plus an `x-ratelimit-reset` epoch. The
+// *secondary* (abuse-detection) limit also returns 403 but with a
+// `retry-after` header instead. Either way it's transient — wait and
+// retry. See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+function isRateLimited403(res: Response): boolean {
+  if (res.status !== 403) return false
+  const remaining = res.headers.get('x-ratelimit-remaining')
+  if (remaining === '0') return true
+  // Secondary rate limit: 403 with a Retry-After hint.
+  return res.headers.has('retry-after')
+}
+
+function isTransient(res: Response): boolean {
+  return TRANSIENT_STATUSES.has(res.status) || isRateLimited403(res)
+}
+
 interface GithubFetchOpts {
   /** Per-call retry cap. Defaults to MAX_RETRIES. */
   maxRetries?: number
@@ -43,7 +60,11 @@ export async function githubFetch(
       continue
     }
 
-    if (!TRANSIENT_STATUSES.has(res.status)) {
+    // Capture rate-limit headers for telemetry on every response that
+    // carries them — both successes and transient errors.
+    recordRateLimitFromResponse(res)
+
+    if (!isTransient(res)) {
       return res
     }
     if (attempt >= maxRetries) return res
@@ -52,6 +73,66 @@ export async function githubFetch(
     await delay(wait)
     attempt += 1
   }
+}
+
+// ── Rate-limit telemetry ────────────────────────────────────────────────────
+// GitHub returns x-ratelimit-{limit,remaining,reset,used,resource} on most
+// API responses. We snapshot the most recent values so the UI can show
+// "You have N requests left this hour" without an extra round-trip.
+
+export interface RateLimitSnapshot {
+  /** Total quota for the resource this window. */
+  limit: number
+  /** Requests left until reset. */
+  remaining: number
+  /** Epoch seconds when the window resets. */
+  reset: number
+  /** Resource bucket — `core`, `search`, `graphql`, etc. */
+  resource: string
+  /** When we captured this (client clock, epoch ms). */
+  capturedAt: number
+}
+
+let lastRateLimit: RateLimitSnapshot | null = null
+const listeners = new Set<(snap: RateLimitSnapshot) => void>()
+
+function recordRateLimitFromResponse(res: Response): void {
+  const limit = res.headers.get('x-ratelimit-limit')
+  const remaining = res.headers.get('x-ratelimit-remaining')
+  const reset = res.headers.get('x-ratelimit-reset')
+  if (limit == null || remaining == null || reset == null) return
+  const limitN = parseInt(limit, 10)
+  const remainingN = parseInt(remaining, 10)
+  const resetN = parseInt(reset, 10)
+  if (!Number.isFinite(limitN) || !Number.isFinite(remainingN) || !Number.isFinite(resetN)) return
+  const snap: RateLimitSnapshot = {
+    limit: limitN,
+    remaining: remainingN,
+    reset: resetN,
+    resource: res.headers.get('x-ratelimit-resource') ?? 'core',
+    capturedAt: Date.now(),
+  }
+  lastRateLimit = snap
+  for (const l of listeners) {
+    try { l(snap) } catch { /* listener errors must not break fetches */ }
+  }
+}
+
+/** Most recent rate-limit snapshot, or null if we haven't seen one yet. */
+export function getLastRateLimit(): RateLimitSnapshot | null {
+  return lastRateLimit
+}
+
+/** Subscribe to rate-limit updates. Returns the unsubscribe function. */
+export function onRateLimit(listener: (snap: RateLimitSnapshot) => void): () => void {
+  listeners.add(listener)
+  return () => { listeners.delete(listener) }
+}
+
+/** Reset state — for tests only. */
+export function _resetRateLimitTelemetry(): void {
+  lastRateLimit = null
+  listeners.clear()
 }
 
 // Reads `Retry-After` (seconds) when present, otherwise falls back to

--- a/src/utils/githubSync.ts
+++ b/src/utils/githubSync.ts
@@ -718,6 +718,14 @@ export function takeZipballAttachmentBytes(
 
 // ── Sync orchestrator ───────────────────────────────────────────────────────
 
+export type PushProgress =
+  | { phase: 'computing' }
+  | { phase: 'uploading-blobs'; uploaded: number; total: number; skipped: number }
+  | { phase: 'creating-tree' }
+  | { phase: 'creating-commit' }
+  | { phase: 'updating-ref' }
+  | { phase: 'done' }
+
 export interface SyncInput {
   token: string
   repo: SyncRepo
@@ -744,6 +752,36 @@ export interface SyncInput {
   // Pass undefined when the user hasn't touched the editor — the
   // remote file is left alone.
   vaultGitignoreDraft?: string | null
+  // Push-progress hook so the UI can surface "uploading 47 / 200 blobs"
+  // and tell the user which step failed when an error bubbles. Optional.
+  onProgress?: (event: PushProgress) => void
+}
+
+// In-memory cache of blob SHAs we've already uploaded to GitHub in this
+// tab session. Git blob SHAs are content-addressable, so a hit here
+// means GitHub already has that content — skip the redundant network
+// round-trip. Survives across syncToGitHub calls within the tab but is
+// cleared when the user reloads. Indexed per-repo so two different
+// vaults don't share state.
+const uploadedBlobShaCache = new Map<string, Set<string>>()
+
+function repoCacheKey(repo: SyncRepo): string {
+  return `${repo.owner}/${repo.name}#${repo.branch}`
+}
+
+function getUploadedShas(repo: SyncRepo): Set<string> {
+  const key = repoCacheKey(repo)
+  let set = uploadedBlobShaCache.get(key)
+  if (!set) {
+    set = new Set()
+    uploadedBlobShaCache.set(key, set)
+  }
+  return set
+}
+
+/** Test hook. Drops the in-memory upload cache. */
+export function _resetUploadedShaCache(): void {
+  uploadedBlobShaCache.clear()
 }
 
 export type GitPathUpdate = {
@@ -771,8 +809,10 @@ export interface SyncOutcome {
 }
 
 export async function syncToGitHub(input: SyncInput): Promise<SyncOutcome> {
-  const { token, repo, notes, folders, commitMessage, vaultSettings, vaultGitignoreDraft } = input
+  const { token, repo, notes, folders, commitMessage, vaultSettings, vaultGitignoreDraft, onProgress } = input
   const { owner, name, branch } = repo
+  const uploadedShas = getUploadedShas(repo)
+  onProgress?.({ phase: 'computing' })
 
   // 1. Compute desired files for every active note.
   const activeNotes = notes.filter(n => !n.isDeleted)
@@ -830,26 +870,64 @@ export async function syncToGitHub(input: SyncInput): Promise<SyncOutcome> {
   // avoid serial awaits per note.
   const lastPushedToSnapshot: Array<{ noteId: string; content: string }> = []
 
+  // Pre-pass: classify every desired path into "skip" (remote already
+  // has this SHA, or our in-tab cache says we uploaded it) vs "needs
+  // upload". Keeping the pre-pass separate lets us emit a stable
+  // `total` to the progress callback.
+  interface NoteBlobPlan { path: string; content: string; note: Note; localSha: string; remoteSha: string | undefined }
+  const noteBlobPlan: NoteBlobPlan[] = []
   for (const [path, { content, note }] of desired) {
-    // Skip ignored paths entirely (gi9n). The user's .gitignore — or
-    // the default OS-junk preset when no file exists — should never
-    // see ignored notes uploaded.
     if (pushMatcher.isIgnored(path)) continue
     const localSha = await gitBlobSha(content)
     const remoteSha = remoteTree.get(path)
-    let finalSha = remoteSha ?? null
-    if (remoteSha !== localSha) {
-      // Need to upload a blob for the new content.
-      finalSha = await createBlob(token, owner, name, content)
-      entries.push({ path, mode: '100644', type: 'blob', sha: finalSha })
-      if (remoteSha) updated++; else created++
+    noteBlobPlan.push({ path, content, note, localSha, remoteSha })
+  }
+  const noteBlobsToUpload = noteBlobPlan.filter(p => p.remoteSha !== p.localSha && !uploadedShas.has(p.localSha))
+  const noteBlobsCached   = noteBlobPlan.filter(p => p.remoteSha !== p.localSha &&  uploadedShas.has(p.localSha))
+
+  let blobsUploaded = 0
+  let blobsSkipped = noteBlobsCached.length
+  // Use a single running `total` that we refine after the attachment
+  // pre-pass below. For now: just notes.
+  let blobsTotal = noteBlobsToUpload.length
+
+  const emitBlobProgress = () => {
+    onProgress?.({ phase: 'uploading-blobs', uploaded: blobsUploaded, total: blobsTotal, skipped: blobsSkipped })
+  }
+
+  // Apply the cached-skip entries first — no network, just emit tree entries
+  // and bookkeeping.
+  for (const plan of noteBlobsCached) {
+    entries.push({ path: plan.path, mode: '100644', type: 'blob', sha: plan.localSha })
+    if (plan.remoteSha) updated++; else created++
+  }
+  // Pure-skip entries (remote has this SHA): no entry, no upload, but the
+  // note's path metadata may still need an update.
+  for (const plan of noteBlobPlan) {
+    const skipped = plan.remoteSha === plan.localSha
+    const finalSha = skipped ? plan.remoteSha! : plan.localSha
+    if (skipped && (plan.note.gitPath !== plan.path || plan.note.gitLastPushedSha !== finalSha)) {
+      pathUpdates.push({ noteId: plan.note.id, gitPath: plan.path, gitLastPushedSha: finalSha })
     }
-    // Record the path + last-pushed SHA on the note. We always update this so
-    // first-time pushes (and content-equal-but-path-changed) write the field.
-    if (note.gitPath !== path || note.gitLastPushedSha !== finalSha) {
-      pathUpdates.push({ noteId: note.id, gitPath: path, gitLastPushedSha: finalSha ?? localSha })
+    lastPushedToSnapshot.push({ noteId: plan.note.id, content: plan.content })
+  }
+
+  // Upload the genuinely-changed blobs.
+  if (blobsTotal > 0) emitBlobProgress()
+  for (const plan of noteBlobsToUpload) {
+    const finalSha = await createBlob(token, owner, name, plan.content)
+    // Cache by LOCAL SHA — that's what the next iteration computes from
+    // the same content. (In production localSha === serverSha because
+    // both follow git's content-addressing, but the local key is what
+    // gates the next cache lookup.)
+    uploadedShas.add(plan.localSha)
+    entries.push({ path: plan.path, mode: '100644', type: 'blob', sha: finalSha })
+    if (plan.remoteSha) updated++; else created++
+    if (plan.note.gitPath !== plan.path || plan.note.gitLastPushedSha !== finalSha) {
+      pathUpdates.push({ noteId: plan.note.id, gitPath: plan.path, gitLastPushedSha: finalSha })
     }
-    lastPushedToSnapshot.push({ noteId: note.id, content })
+    blobsUploaded++
+    emitBlobProgress()
   }
 
   // Fire-and-forget the per-note snapshot writes. The gutter will pick
@@ -865,19 +943,38 @@ export async function syncToGitHub(input: SyncInput): Promise<SyncOutcome> {
   // 3b. Local attachments → binary blob entries. Push uploads any local
   // attachment whose SHA differs from the remote. Files only present
   // locally get created remotely; files present in both get updated when
-  // their content drifts.
+  // their content drifts. Same upload-cache + progress treatment as notes.
   const localAttachmentPaths = await listAttachmentPaths()
+  interface AttachmentPlan { path: string; localSha: string; remoteSha: string | undefined }
+  const attachmentPlan: AttachmentPlan[] = []
   for (const path of localAttachmentPaths) {
     if (pushMatcher.isIgnored(path)) continue
     const localSha = await getAttachmentGitSha(path)
     if (!localSha) continue
     const remoteSha = remoteTree.get(path)
-    if (remoteSha === localSha) continue
-    const blob = await getAttachmentBlob(path)
+    attachmentPlan.push({ path, localSha, remoteSha })
+  }
+  const attachmentsToUpload = attachmentPlan.filter(p => p.remoteSha !== p.localSha && !uploadedShas.has(p.localSha))
+  const attachmentsCached   = attachmentPlan.filter(p => p.remoteSha !== p.localSha &&  uploadedShas.has(p.localSha))
+  blobsTotal += attachmentsToUpload.length
+  blobsSkipped += attachmentsCached.length
+  if (blobsTotal > 0 || blobsSkipped > 0) emitBlobProgress()
+
+  for (const plan of attachmentsCached) {
+    entries.push({ path: plan.path, mode: '100644', type: 'blob', sha: plan.localSha })
+    if (plan.remoteSha) updated++; else created++
+  }
+  for (const plan of attachmentsToUpload) {
+    const blob = await getAttachmentBlob(plan.path)
     if (!blob) continue
     const uploadedSha = await createBlobBinary(token, owner, name, blob)
-    entries.push({ path, mode: '100644', type: 'blob', sha: uploadedSha })
-    if (remoteSha) updated++; else created++
+    // See the note loop above: cache the LOCAL sha for the next-pass
+    // lookup, which uses local-side hashing.
+    uploadedShas.add(plan.localSha)
+    entries.push({ path: plan.path, mode: '100644', type: 'blob', sha: uploadedSha })
+    if (plan.remoteSha) updated++; else created++
+    blobsUploaded++
+    emitBlobProgress()
   }
 
   // 3c. Apply attachment tombstones — paths the user explicitly deleted
@@ -963,16 +1060,25 @@ export async function syncToGitHub(input: SyncInput): Promise<SyncOutcome> {
     }
   }
 
-  // 5. Create new tree → commit → fast-forward branch.
+  // 5. Create new tree → commit → fast-forward branch. Each step gets
+  // its own progress event so the UI (and any error) can pinpoint where
+  // a failure happened.
+  onProgress?.({ phase: 'creating-tree' })
   const newTreeSha = await createTree(token, owner, name, baseTreeSha, entries)
   const total = created + updated + deleted
   const autoMessage = `Sync from Noteser (${total} change${total === 1 ? '' : 's'})`
   const message = commitMessage && commitMessage.length > 0 ? commitMessage : autoMessage
+  onProgress?.({ phase: 'creating-commit' })
   const { sha: commitSha, html_url } = await createCommit(token, owner, name, message, newTreeSha, parentCommitSha)
+  onProgress?.({ phase: 'updating-ref' })
   await updateBranchRef(token, owner, name, branch, commitSha)
 
-  // Push succeeded — drop tombstones whose deletes are now in the commit.
+  // Push succeeded — drop tombstones whose deletes are now in the commit
+  // AND clear the upload cache for this repo. The next push will start
+  // from scratch (which is fine — remote tree will be consulted again).
   if (consumedTombstones.length > 0) await clearAttachmentTombstones(consumedTombstones)
+  uploadedShas.clear()
+  onProgress?.({ phase: 'done' })
 
   return {
     result: { unchanged: false, created, updated, deleted, commitSha, commitUrl: html_url },


### PR DESCRIPTION
Second sub-item of **Sync robustness** from the roadmap: "partial-failure recovery for multi-blob pushes that 502 halfway through".

## What ships

1. **`SyncInput.onProgress`** — typed `PushProgress` events: `computing` → `uploading-blobs { uploaded, total, skipped }` (running counts) → `creating-tree` → `creating-commit` → `updating-ref` → `done`. The UI can now surface "47/200 blobs uploaded" and pinpoint which step failed when an error bubbles.
2. **Per-repo upload cache** (`uploadedBlobShaCache`, module-level Map keyed by `owner/repo#branch`). If a push fails after uploading 100/200 blobs, the retry skips the 100 already-done blobs and only re-uploads the missing 100 + recreates the tree/commit/ref. Cleared on a successful push so the next push starts from a clean remote tree.

The push loop is restructured into pre-pass (classify all desired paths) + upload pass so the progress event's `total` is stable from the first emission. Attachments get the same treatment as note bodies.

## Builds on

- PR #12 (typed `GitHubAPIError` + 403-rate-limit retry) — same branch base.

## Test plan

- [x] 3 new tests in `src/__tests__/syncPushProgress.test.ts`: phase-sequence emission, retry-after-failure skipping uploaded blobs, cache cleared after success.
- [x] `npm test` — 1167 / 1167 passing
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)