### PR TITLE
Security: scope wss:/ws: CSP to NEXT_PUBLIC_YJS_WS_URL (audit finding 5)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,31 @@
 /** @type {import('next').NextConfig} */
 
+// Derive a single WS origin from NEXT_PUBLIC_YJS_WS_URL so CSP only allows
+// the collaboration server the operator opted into. Anything malformed (or
+// unset) collapses to "no WS connections at all" — the old `wss: ws:` bare
+// wildcards would let an XSS payload exfiltrate localStorage to any host.
+function deriveCollabWsOrigin(raw) {
+  if (!raw) return null
+  try {
+    const url = new URL(raw)
+    if (url.protocol !== 'ws:' && url.protocol !== 'wss:') return null
+    return `${url.protocol}//${url.host}`
+  } catch {
+    return null
+  }
+}
+
+const collabWsOrigin = deriveCollabWsOrigin(process.env.NEXT_PUBLIC_YJS_WS_URL)
+
+const connectSrc = [
+  "'self'",
+  'https://api.github.com',
+  'https://github.com',
+  'https://api.anthropic.com',
+  'https://api.openai.com',
+  ...(collabWsOrigin ? [collabWsOrigin] : []),
+].join(' ')
+
 // Security headers applied to every response. CSP is permissive enough to
 // keep the app working (CodeMirror + react-syntax-highlighter use inline
 // styles, Tailwind injects style tags, BYO AI APIs hit Anthropic / OpenAI
@@ -21,8 +47,9 @@ const securityHeaders = [
       "font-src 'self' data:",
       // Browser-direct API surfaces: github.com for OAuth fallbacks, the
       // GitHub Git Data API, Anthropic + OpenAI for BYO-key AI features.
-      // wss/ws for the optional self-hosted Yjs server.
-      "connect-src 'self' https://api.github.com https://github.com https://api.anthropic.com https://api.openai.com wss: ws:",
+      // The optional Yjs collab server is added only when
+      // NEXT_PUBLIC_YJS_WS_URL is a valid ws:// or wss:// URL.
+      `connect-src ${connectSrc}`,
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",
@@ -49,4 +76,7 @@ const nextConfig = {
   },
 }
 
+// Exported for tests so the CSP string can be exercised without spinning up
+// a Next server. Not part of the Next runtime contract.
+export { deriveCollabWsOrigin, securityHeaders }
 export default nextConfig

--- a/src/__tests__/cspHeader.test.ts
+++ b/src/__tests__/cspHeader.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Locks down the connect-src directive in next.config.mjs so the bare
+ * `wss: ws:` wildcards can't sneak back in. Finding 5 of the 2026-05-21
+ * security audit: the wildcards would let an XSS payload exfiltrate
+ * localStorage (GitHub token, AI keys) to any attacker-controlled WS host.
+ *
+ * The module reads `process.env.NEXT_PUBLIC_YJS_WS_URL` at evaluation time,
+ * so for the env-set branches we exercise the exported helper
+ * (`deriveCollabWsOrigin`). The default-env directive is also asserted as a
+ * snapshot of the loaded module so the bare wildcards can't slip back in.
+ */
+
+// next.config.mjs is the test target; the import is type-only here and
+// resolved by jest at runtime via dynamic import below.
+type ConfigModule = {
+  deriveCollabWsOrigin: (raw: string | undefined) => string | null
+  securityHeaders: Array<{ key: string; value: string }>
+}
+
+function getConnectSrc(headers: ConfigModule['securityHeaders']): string {
+  const csp = headers.find((h) => h.key === 'Content-Security-Policy')
+  if (!csp) throw new Error('no CSP header')
+  const directive = csp.value
+    .split(';')
+    .map((s) => s.trim())
+    .find((d) => d.startsWith('connect-src'))
+  if (!directive) throw new Error('no connect-src directive')
+  return directive
+}
+
+let mod: ConfigModule
+
+beforeAll(async () => {
+  // Ensure the module evaluates with no NEXT_PUBLIC_YJS_WS_URL so the
+  // snapshot below reflects the "WS disabled" branch.
+  delete process.env.NEXT_PUBLIC_YJS_WS_URL
+  // next.config.mjs has no .d.ts and intentionally exports unannotated
+  // helpers; cast through unknown to keep typecheck happy.
+  mod = (await import('../../next.config.mjs' as string)) as unknown as ConfigModule
+})
+
+describe('deriveCollabWsOrigin', () => {
+  it('returns null for unset/empty input', () => {
+    expect(mod.deriveCollabWsOrigin(undefined)).toBeNull()
+    expect(mod.deriveCollabWsOrigin('')).toBeNull()
+  })
+
+  it('returns the origin for a valid wss:// URL', () => {
+    expect(mod.deriveCollabWsOrigin('wss://collab.noteser.dev/room/foo')).toBe(
+      'wss://collab.noteser.dev'
+    )
+  })
+
+  it('returns the origin for a valid wss:// URL with a port', () => {
+    expect(mod.deriveCollabWsOrigin('wss://collab.noteser.dev:8443/room')).toBe(
+      'wss://collab.noteser.dev:8443'
+    )
+  })
+
+  it('returns the origin for a valid ws:// URL', () => {
+    expect(mod.deriveCollabWsOrigin('ws://localhost:1234/yjs')).toBe('ws://localhost:1234')
+  })
+
+  it('rejects non-ws schemes (no http/https/javascript/etc.)', () => {
+    expect(mod.deriveCollabWsOrigin('https://collab.noteser.dev')).toBeNull()
+    expect(mod.deriveCollabWsOrigin('http://collab.noteser.dev')).toBeNull()
+    expect(mod.deriveCollabWsOrigin('javascript:alert(1)')).toBeNull()
+    expect(mod.deriveCollabWsOrigin('data:text/plain,foo')).toBeNull()
+  })
+
+  it('rejects malformed URLs', () => {
+    expect(mod.deriveCollabWsOrigin('not a url')).toBeNull()
+    expect(mod.deriveCollabWsOrigin('wss://')).toBeNull()
+  })
+})
+
+describe('connect-src CSP directive (default, no NEXT_PUBLIC_YJS_WS_URL)', () => {
+  it('omits ws:/wss: entirely', () => {
+    const directive = getConnectSrc(mod.securityHeaders)
+    // No bare scheme wildcards anywhere in the directive.
+    expect(directive).not.toContain('wss:')
+    expect(directive).not.toContain('ws:')
+  })
+
+  it('keeps the originally-scoped HTTPS surfaces', () => {
+    const directive = getConnectSrc(mod.securityHeaders)
+    expect(directive).toContain("'self'")
+    expect(directive).toContain('https://api.github.com')
+    expect(directive).toContain('https://github.com')
+    expect(directive).toContain('https://api.anthropic.com')
+    expect(directive).toContain('https://api.openai.com')
+  })
+
+  it('exposes the directive at the start of the value', () => {
+    const directive = getConnectSrc(mod.securityHeaders)
+    expect(directive.startsWith('connect-src ')).toBe(true)
+  })
+})
+
+describe('connect-src CSP directive (with NEXT_PUBLIC_YJS_WS_URL)', () => {
+  // The module-level env was read once at import. For the env-set branch we
+  // rely on the helper (which is the only branching logic) plus the fact
+  // that the connect-src list interpolates exactly its return value.
+  it('would add the exact origin (and nothing else) for a valid wss URL', () => {
+    const origin = mod.deriveCollabWsOrigin('wss://collab.noteser.dev/room/x')
+    expect(origin).toBe('wss://collab.noteser.dev')
+    // The directive composition: `connect-src <fixed list> <origin>`.
+    // Confirms no bare wildcard appears.
+    expect(origin).not.toContain('*')
+    expect(origin).not.toMatch(/^wss:\s*$/)
+    expect(origin).not.toMatch(/^ws:\s*$/)
+  })
+
+  it('falls back to null (= no WS in directive) when malformed', () => {
+    expect(mod.deriveCollabWsOrigin('https://not-a-ws-url.example')).toBeNull()
+    expect(mod.deriveCollabWsOrigin('totally bogus')).toBeNull()
+  })
+})


### PR DESCRIPTION
Implements Finding 5 of `docs/research/security-audit-2026-05-21.md`.

`connect-src` previously included bare `wss: ws:` wildcards, permitting browser-initiated WebSocket connections to ANY host — i.e. trivial exfiltration channel if XSS ever lands. Now:

- **Default** (`NEXT_PUBLIC_YJS_WS_URL` unset / empty / malformed): no WebSocket scheme in `connect-src` at all.
- **With valid `NEXT_PUBLIC_YJS_WS_URL`**: exactly one origin appended, e.g. `wss://collab.noteser.dev`. Path and query are stripped.

11 new unit tests in `src/__tests__/cspHeader.test.ts` cover both env states + malformed inputs (bare `wss://`, `https://...`, non-URL strings) — all fall back safely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)