### PR TITLE
Vault encryption: integrate crypto module into sync push + pull

### DIFF
--- a/src/__tests__/vaultEncryptionRoundtrip.test.ts
+++ b/src/__tests__/vaultEncryptionRoundtrip.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @jest-environment node
+ *
+ * End-to-end: push encrypts → pull decrypts. We exercise the wiring in
+ * githubSync.ts (maybeEncryptForPush / maybeDecryptFromPull) by mocking
+ * the network layer, unlocking the vault with a known passphrase, then
+ * comparing what gets POSTed to /git/blobs against what comes back from
+ * a subsequent getBlobContent fetch.
+ */
+
+import { syncToGitHub } from '../utils/githubSync'
+import { generateSalt, saltToString, isEncryptedContent, decryptNoteContent, deriveKey } from '../utils/vaultCrypto'
+import { unlockVault, lockVault, _resetVaultKeyForTests, VaultLockedError } from '../utils/vaultKey'
+import type { Note, Folder, SyncRepo } from '@/types'
+
+jest.mock('../utils/attachments', () => ({
+  isAttachmentPath: () => false,
+  listAttachmentPaths: async () => [],
+  getAttachmentBlob: async () => null,
+  getAttachmentGitSha: async () => null,
+  getAttachmentTombstones: async () => [],
+  clearAttachmentTombstones: async () => undefined,
+}))
+jest.mock('../utils/lastPushedContent', () => ({
+  setLastPushedContent: async () => undefined,
+  getLastPushedContent: async () => null,
+}))
+// Mutable flag that the mocked store reads each call. Tests flip it
+// via setMockEncryption(true|false).
+const mockEncryptionEnabled = { value: false }
+function setMockEncryption(v: boolean): void { mockEncryptionEnabled.value = v }
+
+jest.mock('../stores/settingsStore', () => ({
+  useSettingsStore: {
+    getState: () => ({
+      localGitignoreOverlay: '',
+      vaultEncryptionEnabled: mockEncryptionEnabled.value,
+    }),
+  },
+}))
+
+const REPO: SyncRepo = { owner: 'o', name: 'r', branch: 'main', isPrivate: true }
+const PASSPHRASE = 'correct horse battery staple'
+
+function makeNote(id: string, title: string, content: string): Note {
+  return {
+    id, title, content, folderId: null,
+    createdAt: 0, updatedAt: 0, isDeleted: false, deletedAt: null,
+    isPinned: false, templateId: null,
+    gitPath: null, gitLastPushedSha: null,
+  }
+}
+
+// Records bytes uploaded per path so we can read them back later.
+function makeFetchMock() {
+  const uploadedBlobs = new Map<string, string>() // sha → content
+  let nextSha = 100
+  let treePathToSha = new Map<string, string>() // path → blob sha (post-commit state)
+  let pendingTreeEntries: Array<{ path: string; sha: string }> = []
+
+  const fetchMock = jest.fn(async (url: string | URL, init?: RequestInit) => {
+    const u = String(url)
+    if (u.includes('/git/refs/heads/main') && (init?.method ?? 'GET') === 'GET') {
+      return new Response(JSON.stringify({ ref: 'refs/heads/main', object: { sha: 'parent-commit' } }), { status: 200 })
+    }
+    if (u.match(/\/git\/commits\/parent-commit/)) {
+      return new Response(JSON.stringify({ tree: { sha: 'base-tree' } }), { status: 200 })
+    }
+    if (u.includes('/git/trees/base-tree?recursive=1')) {
+      const tree = Array.from(treePathToSha.entries()).map(([path, sha]) => ({ path, type: 'blob', sha }))
+      return new Response(JSON.stringify({ tree }), { status: 200 })
+    }
+    if (u.endsWith('/git/blobs') && init?.method === 'POST') {
+      const body = JSON.parse(init.body as string) as { content: string }
+      const sha = `blob-${nextSha++}`
+      uploadedBlobs.set(sha, body.content)
+      pendingTreeEntries.push({ path: '', sha })
+      return new Response(JSON.stringify({ sha }), { status: 201 })
+    }
+    if (u.match(/\/git\/blobs\/blob-/)) {
+      const sha = u.split('/').pop()!
+      const content = uploadedBlobs.get(sha) ?? ''
+      // Match createBlob's `encoding: 'utf-8'` behaviour — return as utf-8 string.
+      return new Response(JSON.stringify({ content, encoding: 'utf-8' }), { status: 200 })
+    }
+    if (u.endsWith('/git/trees') && init?.method === 'POST') {
+      const body = JSON.parse(init.body as string) as { tree: Array<{ path: string; sha: string }> }
+      for (const entry of body.tree) {
+        treePathToSha.set(entry.path, entry.sha)
+      }
+      pendingTreeEntries = []
+      return new Response(JSON.stringify({ sha: 'new-tree' }), { status: 201 })
+    }
+    if (u.endsWith('/git/commits') && init?.method === 'POST') {
+      return new Response(JSON.stringify({ sha: 'new-commit', html_url: 'https://x' }), { status: 201 })
+    }
+    if (u.includes('/git/refs/heads/main') && init?.method === 'PATCH') {
+      return new Response(JSON.stringify({}), { status: 200 })
+    }
+    return new Response('not mocked: ' + u, { status: 500 })
+  })
+
+  return { fetchMock, uploadedBlobs, treePathToSha }
+}
+
+describe('vault encryption roundtrip', () => {
+  beforeEach(() => {
+    _resetVaultKeyForTests()
+    setMockEncryption(false)
+  })
+
+  test('with encryption ON: pushed blob is wire-encoded, decryptable with the same passphrase', async () => {
+    const salt = generateSalt()
+    setMockEncryption(true)
+    await unlockVault(PASSPHRASE, saltToString(salt))
+
+    const { fetchMock, uploadedBlobs } = makeFetchMock()
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await syncToGitHub({
+      token: 't',
+      repo: REPO,
+      notes: [makeNote('1', 'A', 'Secret note body 🔐')],
+      folders: [] as Folder[],
+    })
+
+    expect(uploadedBlobs.size).toBe(1)
+    const [[, raw]] = Array.from(uploadedBlobs.entries())
+    expect(isEncryptedContent(raw)).toBe(true)
+
+    // A peer with the same passphrase + salt can read it.
+    const key = await deriveKey(PASSPHRASE, salt)
+    const decoded = await decryptNoteContent(raw, key)
+    expect(decoded).toBe('Secret note body 🔐\n') // normalizeForPush adds a trailing \n
+  })
+
+  test('with encryption OFF: pushed blob is plain markdown (back-compat)', async () => {
+    const { fetchMock, uploadedBlobs } = makeFetchMock()
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await syncToGitHub({
+      token: 't',
+      repo: REPO,
+      notes: [makeNote('1', 'A', 'just plain text')],
+      folders: [] as Folder[],
+    })
+
+    expect(uploadedBlobs.size).toBe(1)
+    const [[, raw]] = Array.from(uploadedBlobs.entries())
+    expect(isEncryptedContent(raw)).toBe(false)
+    expect(raw).toContain('just plain text')
+  })
+
+  test('with encryption ON but vault locked: push throws VaultLockedError', async () => {
+    setMockEncryption(true)
+    lockVault()
+
+    const { fetchMock } = makeFetchMock()
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await expect(syncToGitHub({
+      token: 't',
+      repo: REPO,
+      notes: [makeNote('1', 'A', 'cannot push')],
+      folders: [] as Folder[],
+    })).rejects.toBeInstanceOf(VaultLockedError)
+  })
+})

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -169,6 +169,22 @@ export interface SettingsState {
   // re-uploading the file).
   vaultSettingsLastPushedHash: string
 
+  // ── Backup encryption (bke1) ──────────────────────────────────────────
+  // When true, note `.md` bodies are AES-GCM encrypted before push and
+  // decrypted on pull. The DERIVED KEY is held only in memory (see
+  // src/utils/vaultKey.ts); the passphrase is never persisted anywhere.
+  // The 16-byte salt is shared across devices so the same passphrase
+  // derives the same key everywhere.
+  //
+  // VAULT-SYNCED so a fresh client picking up the repo knows it needs to
+  // prompt for a passphrase rather than silently treating encrypted
+  // bodies as garbage markdown.
+  vaultEncryptionEnabled: boolean
+  // Base64-encoded 16-byte salt for PBKDF2. Generated once per vault on
+  // first enabling; never rotated. null = encryption disabled OR the
+  // user hasn't completed first-time setup yet.
+  vaultEncryptionSalt: string | null
+
   // ── Custom theme (th3m) ────────────────────────────────────────────────
   // Per-token color overrides applied as CSS variables on :root at
   // runtime. Keys come from THEME_TOKEN_KEYS; values are any valid
@@ -242,6 +258,10 @@ export interface SettingsState {
   setLocalGitignoreOverlay: (text: string) => void
   setVaultGitignoreDraft: (text: string | null) => void
   setVaultGitignoreRemoteSnapshot: (text: string | null) => void
+  // Enable encryption with a fresh salt; clears salt + flag when
+  // disabling. The derived key lives in `vaultKey.ts` — this setter
+  // ONLY touches the persisted flag + salt.
+  setVaultEncryption: (enabled: boolean, saltBase64: string | null) => void
   setShareDefaultExpiryDays: (days: number) => void
   setShareDefaultBurn: (value: boolean) => void
   setThemeOverrides: (overrides: Record<string, string>) => void
@@ -283,6 +303,11 @@ export const VAULT_SETTING_KEYS = [
   'betaEnabled',
   'betaFlags',
   'themeOverrides',
+  // Encryption flag + salt are vault-synced so a fresh device picks
+  // them up from the repo's settings.json and knows to unlock the vault
+  // before applying remote notes.
+  'vaultEncryptionEnabled',
+  'vaultEncryptionSalt',
 ] as const
 
 export type VaultSettingKey = (typeof VAULT_SETTING_KEYS)[number]
@@ -329,6 +354,8 @@ const DEFAULTS = {
   shareDefaultExpiryDays: 0,
   shareDefaultBurn: false,
   themeOverrides: {} as Record<string, string>,
+  vaultEncryptionEnabled: false,
+  vaultEncryptionSalt: null as string | null,
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -390,6 +417,8 @@ export const useSettingsStore = create<SettingsState>()(
         setLocalGitignoreOverlay: (localGitignoreOverlay) => set({ localGitignoreOverlay }),
         setVaultGitignoreDraft: (vaultGitignoreDraft) => set({ vaultGitignoreDraft }),
         setVaultGitignoreRemoteSnapshot: (vaultGitignoreRemoteSnapshot) => set({ vaultGitignoreRemoteSnapshot }),
+        setVaultEncryption: (vaultEncryptionEnabled, vaultEncryptionSalt) =>
+          setVault({ vaultEncryptionEnabled, vaultEncryptionSalt }),
         setShareDefaultExpiryDays: (shareDefaultExpiryDays) => set({ shareDefaultExpiryDays }),
         setShareDefaultBurn: (shareDefaultBurn) => set({ shareDefaultBurn }),
         // Theme is part of the vault-synced slice — going through

--- a/src/utils/githubSync.ts
+++ b/src/utils/githubSync.ts
@@ -26,6 +26,42 @@ import {
   getAttachmentTombstones,
   clearAttachmentTombstones,
 } from './attachments'
+import { encryptNoteContent, decryptNoteContent, isEncryptedContent } from './vaultCrypto'
+import { getVaultKey, VaultLockedError } from './vaultKey'
+
+// Encrypt note body for push, if the vault is unlocked AND encryption
+// is enabled at the settings layer. Returns the original content when
+// encryption is off — keeps the call sites tidy and ensures push works
+// in the default (unencrypted) configuration.
+async function maybeEncryptForPush(content: string): Promise<string> {
+  let enabled = false
+  try {
+    const { useSettingsStore } = await import('@/stores/settingsStore')
+    enabled = useSettingsStore.getState().vaultEncryptionEnabled
+  } catch {
+    // Test envs without the store — treat as disabled.
+  }
+  if (!enabled) return content
+  const key = getVaultKey()
+  if (!key) {
+    // Encryption is on but the user hasn't unlocked. Bail with a typed
+    // error the UI can catch to prompt for the passphrase.
+    throw new VaultLockedError('Push aborted — vault is encrypted but locked. Unlock to continue.')
+  }
+  return await encryptNoteContent(content, key)
+}
+
+// Decrypt remote note content on pull. Pass-through when the content
+// isn't an encrypted envelope. Throws VaultLockedError when an
+// envelope is present but the user hasn't unlocked yet — caller catches.
+async function maybeDecryptFromPull(content: string): Promise<string> {
+  if (!isEncryptedContent(content)) return content
+  const key = getVaultKey()
+  if (!key) {
+    throw new VaultLockedError('Pull skipped — remote blob is encrypted but vault is locked.')
+  }
+  return await decryptNoteContent(content, key)
+}
 
 export interface SyncResult {
   unchanged: boolean
@@ -351,10 +387,15 @@ export async function pullFromGitHub(input: {
       continue
     }
 
-    // Fetch the remote content lazily — only when we need it.
+    // Fetch the remote content lazily — only when we need it. bke1:
+    // decrypt the envelope when encryption is on; throws VaultLockedError
+    // upstream if the user hasn't unlocked.
     let remoteContent: string | null = null
     const loadRemote = async () => {
-      if (remoteContent === null) remoteContent = await getBlobContent(token, owner, name, remoteSha)
+      if (remoteContent === null) {
+        const raw = await getBlobContent(token, owner, name, remoteSha)
+        remoteContent = await maybeDecryptFromPull(raw)
+      }
       return remoteContent
     }
 
@@ -395,7 +436,8 @@ export async function pullFromGitHub(input: {
       let autoMerged: string | null = null
       if (lastPushed) {
         try {
-          const ancestor = await getBlobContent(token, owner, name, lastPushed)
+          const ancestorRaw = await getBlobContent(token, owner, name, lastPushed)
+          const ancestor = await maybeDecryptFromPull(ancestorRaw)
           const merged = threeWayMerge(ancestor, localContent, content)
           if (merged.ok) autoMerged = merged.merged
         } catch {
@@ -671,8 +713,12 @@ export async function pullFromZipball(input: {
     const path = rel.slice(slashIdx + 1)
 
     if (path.endsWith('.md')) {
-      const content = await file.async('string')
-      const remoteSha = await gitBlobSha(content)
+      const raw = await file.async('string')
+      // bke1: zipball blobs were written in the encrypted wire form. We
+      // compute the remoteSha against that wire form (matches what
+      // GitHub stored) but feed parseNote the decrypted body.
+      const remoteSha = await gitBlobSha(raw)
+      const content = await maybeDecryptFromPull(raw)
       const parsed = parseNote(content)
 
       classifications.push({
@@ -835,12 +881,16 @@ export async function syncToGitHub(input: SyncInput): Promise<SyncOutcome> {
     // the default OS-junk preset when no file exists — should never
     // see ignored notes uploaded.
     if (pushMatcher.isIgnored(path)) continue
-    const localSha = await gitBlobSha(content)
+    // bke1: when encryption is enabled, the wire form is what we hash
+    // and upload. plaintext stays available for the editor's gutter
+    // snapshot (it compares against the unencrypted body).
+    const wireContent = await maybeEncryptForPush(content)
+    const localSha = await gitBlobSha(wireContent)
     const remoteSha = remoteTree.get(path)
     let finalSha = remoteSha ?? null
     if (remoteSha !== localSha) {
       // Need to upload a blob for the new content.
-      finalSha = await createBlob(token, owner, name, content)
+      finalSha = await createBlob(token, owner, name, wireContent)
       entries.push({ path, mode: '100644', type: 'blob', sha: finalSha })
       if (remoteSha) updated++; else created++
     }

--- a/src/utils/vaultKey.ts
+++ b/src/utils/vaultKey.ts
@@ -1,0 +1,103 @@
+// In-memory holder for the derived vault encryption key.
+//
+// The passphrase is never persisted. The derived CryptoKey lives only in
+// this module's closure — cleared on lockVault(), gone on page refresh.
+// Callers should call `unlockVault(passphrase)` once when the user
+// types their passphrase, then `getVaultKey()` from the sync codepath.
+//
+// The settings store holds the salt + enabled flag (vault-synced via
+// settings.json). This module mediates between user-facing
+// "passphrase" and the WebCrypto key the sync layer needs.
+
+import { deriveKey, saltFromString } from './vaultCrypto'
+import type { SettingsState } from '@/stores/settingsStore'
+
+interface KeyHolder {
+  key: CryptoKey | null
+  // The saltBase64 + passphrase hash that produced this key, so a salt
+  // rotation invalidates the cached key automatically.
+  saltKey: string | null
+}
+
+const holder: KeyHolder = { key: null, saltKey: null }
+const listeners = new Set<() => void>()
+
+function notify(): void {
+  for (const l of listeners) {
+    try { l() } catch { /* listener errors must not break the sync */ }
+  }
+}
+
+/** True when the vault is currently unlocked (key is in memory). */
+export function isVaultUnlocked(): boolean {
+  return holder.key !== null
+}
+
+/** The active vault key, or null when locked. */
+export function getVaultKey(): CryptoKey | null {
+  return holder.key
+}
+
+/**
+ * Derive the AES-GCM key from a passphrase + the vault's stored salt.
+ * Resolves true when the key was derived; false when the salt is missing
+ * (encryption not yet set up). Throws only if the underlying WebCrypto
+ * primitive errors — that's a runtime bug, not a wrong-passphrase
+ * situation (wrong passphrase produces a key that simply fails to
+ * decrypt later).
+ */
+export async function unlockVault(passphrase: string, saltBase64: string): Promise<boolean> {
+  if (!saltBase64) return false
+  const salt = saltFromString(saltBase64)
+  const key = await deriveKey(passphrase, salt)
+  holder.key = key
+  holder.saltKey = saltBase64
+  notify()
+  return true
+}
+
+/** Clear the in-memory key. Idempotent. */
+export function lockVault(): void {
+  if (holder.key === null) return
+  holder.key = null
+  holder.saltKey = null
+  notify()
+}
+
+/**
+ * If the vault's salt has changed (e.g. a remote sync brought in a new
+ * vault-settings file whose salt differs from what we unlocked with),
+ * the cached key is now wrong. Call this after applying remote vault
+ * settings — it locks the vault if the salt rotated, leaving it
+ * unlocked when the salt is unchanged.
+ */
+export function invalidateKeyIfSaltChanged(currentSalt: string | null): void {
+  if (holder.key == null) return
+  if (holder.saltKey === currentSalt) return
+  lockVault()
+}
+
+/** Subscribe to lock/unlock transitions. Returns the unsubscribe fn. */
+export function onVaultLockChange(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => { listeners.delete(listener) }
+}
+
+/** Test hook. Clears state without firing listeners. */
+export function _resetVaultKeyForTests(): void {
+  holder.key = null
+  holder.saltKey = null
+  listeners.clear()
+}
+
+/**
+ * Thrown by the sync layer when an operation needs an unlocked vault
+ * but the user hasn't supplied a passphrase yet. The UI catches this
+ * to pop the unlock modal.
+ */
+export class VaultLockedError extends Error {
+  constructor(message = 'Vault is encrypted but no key is loaded') {
+    super(message)
+    this.name = 'VaultLockedError'
+  }
+}


### PR DESCRIPTION
Phase A of the **Backup encryption** roadmap item. Builds on PR #16 (`feat/vault-crypto-module`) — that PR lands the crypto primitives, this one wires them into the sync codepath.

## What ships

**Settings store** (vault-synced via `settings.json`):
- `vaultEncryptionEnabled: boolean`
- `vaultEncryptionSalt: string | null` (base64 16-byte PBKDF2 salt)

**In-memory key holder** (`src/utils/vaultKey.ts`):
- `unlockVault(passphrase, salt)` — derives the AES-GCM key, caches it
- `lockVault()`, `getVaultKey()`, `isVaultUnlocked()`, `invalidateKeyIfSaltChanged()`
- `VaultLockedError` — typed error the UI can catch to prompt for the passphrase

**Sync integration** (`src/utils/githubSync.ts`):
- Push: `maybeEncryptForPush` wraps the body before `gitBlobSha` + `createBlob`. `localSha` therefore matches the encrypted wire form, so the in-tab upload cache from PR #17 keys on the same bytes GitHub stored.
- Pull: `maybeDecryptFromPull` runs after every `getBlobContent` for note bodies, inside the zipball path, and on the three-way-merge ancestor fetch.
- Skip-list: `.gitignore`, `.noteser/settings.json`, attachments are NOT encrypted in v1.

## What's NOT in this PR

- Settings UI (Phase B — follow-up branch).
- Salt sharing via `.noteser/vault-salt` repo file (deferred — settings.json already carries the salt since both fields are vault-tagged).
- Attachment encryption (deferred to v2).

## Test plan

- [x] 3 new round-trip tests in `src/__tests__/vaultEncryptionRoundtrip.test.ts`: push-encrypts + peer-decrypts, encryption-off back-compat, locked-vault throws VaultLockedError.
- [x] `npm test` — 1168 / 1168
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)