### PR TITLE
Live collab: Phase A — WebSocket connectivity + presence pill

### DIFF
--- a/src/__tests__/useCollaboration.test.ts
+++ b/src/__tests__/useCollaboration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ *
+ * useCollaboration hook tests. The hook reads NEXT_PUBLIC_YJS_WS_URL
+ * (a build-time env var; jest's process.env stand-in lets us flip it
+ * per test) and opens a WebSocket to that URL when set.
+ *
+ * We mock global.WebSocket so the hook never tries to reach a real
+ * server. Each test wires its mock to dispatch open/close as needed.
+ */
+
+import { renderHook, act } from '@testing-library/react'
+import { useCollaboration } from '../hooks/useCollaboration'
+
+// Test double for window.WebSocket. Captures whichever instance the
+// hook constructs so tests can fire open/close events synchronously.
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static lastConstructorArg = ''
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  readyState = 0
+  url: string
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.lastConstructorArg = url
+    MockWebSocket.instances.push(this)
+  }
+  close() {
+    this.readyState = 3
+    queueMicrotask(() => { this.onclose?.() })
+  }
+  fireOpen() { this.readyState = 1; this.onopen?.() }
+  fireClose() { this.readyState = 3; this.onclose?.() }
+}
+
+const ORIGINAL_WS = global.WebSocket
+const ORIGINAL_URL = process.env.NEXT_PUBLIC_YJS_WS_URL
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  MockWebSocket.lastConstructorArg = ''
+  ;(global as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = MockWebSocket
+})
+
+afterEach(() => {
+  ;(global as unknown as { WebSocket: typeof ORIGINAL_WS }).WebSocket = ORIGINAL_WS
+  if (ORIGINAL_URL == null) delete process.env.NEXT_PUBLIC_YJS_WS_URL
+  else process.env.NEXT_PUBLIC_YJS_WS_URL = ORIGINAL_URL
+})
+
+describe('useCollaboration', () => {
+  test('without NEXT_PUBLIC_YJS_WS_URL: status is "off" and no WS is opened', () => {
+    delete process.env.NEXT_PUBLIC_YJS_WS_URL
+    const { result } = renderHook(() => useCollaboration())
+    expect(result.current.status).toBe('off')
+    expect(result.current.url).toBeNull()
+    expect(MockWebSocket.instances).toHaveLength(0)
+  })
+
+  test('rejects non-ws/wss URLs', () => {
+    process.env.NEXT_PUBLIC_YJS_WS_URL = 'https://not-a-ws.example.com'
+    const { result } = renderHook(() => useCollaboration())
+    expect(result.current.status).toBe('off')
+    expect(result.current.url).toBeNull()
+  })
+
+  test('with wss URL: opens WS, status flips connecting → connected on open', () => {
+    process.env.NEXT_PUBLIC_YJS_WS_URL = 'wss://collab.example.com/room'
+    const { result } = renderHook(() => useCollaboration())
+    expect(result.current.status).toBe('connecting')
+    expect(result.current.url).toBe('wss://collab.example.com/room')
+    expect(MockWebSocket.instances).toHaveLength(1)
+
+    act(() => { MockWebSocket.instances[0].fireOpen() })
+    expect(result.current.status).toBe('connected')
+    expect(result.current.attempts).toBe(0)
+  })
+
+  test('close before open: status flips to disconnected and attempt counter ticks', () => {
+    process.env.NEXT_PUBLIC_YJS_WS_URL = 'wss://collab.example.com/room'
+    const { result } = renderHook(() => useCollaboration())
+    expect(MockWebSocket.instances).toHaveLength(1)
+    act(() => { MockWebSocket.instances[0].fireClose() })
+    expect(result.current.status).toBe('disconnected')
+    expect(result.current.attempts).toBe(1)
+  })
+
+  test('disconnect() halts the reconnect loop', () => {
+    process.env.NEXT_PUBLIC_YJS_WS_URL = 'wss://collab.example.com/room'
+    const { result } = renderHook(() => useCollaboration())
+    act(() => { result.current.disconnect() })
+    expect(result.current.status).toBe('disconnected')
+    // No further attempt should be scheduled.
+    const before = MockWebSocket.instances.length
+    // Advance microtasks — nothing should happen.
+    return new Promise<void>((r) => setTimeout(() => {
+      expect(MockWebSocket.instances.length).toBe(before)
+      r()
+    }, 20))
+  })
+})

--- a/src/components/editor/EditorFooter.tsx
+++ b/src/components/editor/EditorFooter.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import { useMemo } from 'react'
-import { ArrowPathIcon, FireIcon } from '@heroicons/react/24/outline'
+import { ArrowPathIcon, FireIcon, SignalIcon, SignalSlashIcon } from '@heroicons/react/24/outline'
 import { extractTags } from '@/utils/tags'
 import { useGitHubStore, useNoteStore, useUIStore, useSettingsStore } from '@/stores'
 import { classifyPendingChanges, totalPendingCount } from '@/utils/syncChanges'
 import { computeStreakFromDateStrings, dailyDateSet } from '@/utils/dailyStreak'
+import { useCollaboration } from '@/hooks/useCollaboration'
 import type { Note } from '@/types'
 
 interface EditorFooterProps {
@@ -110,6 +111,7 @@ export const EditorFooter = ({ note }: EditorFooterProps) => {
         )}
       </div>
       <div className="flex items-center gap-4 shrink-0">
+        <CollabPill />
         {streak.length >= 2 && (
           <span
             className="flex items-center gap-1 text-orange-400"
@@ -128,6 +130,39 @@ export const EditorFooter = ({ note }: EditorFooterProps) => {
         <span>Modified {formatDate(note.updatedAt)}</span>
       </div>
     </div>
+  )
+}
+
+// Tiny presence pill — shows the live-collab WebSocket health when
+// NEXT_PUBLIC_YJS_WS_URL is configured. Hidden when collab is off so
+// the footer stays uncluttered for the default single-user case.
+function CollabPill() {
+  const { status, attempts, url } = useCollaboration()
+  if (status === 'off' || url == null) return null
+
+  const labelByStatus: Record<Exclude<typeof status, 'off'>, string> = {
+    connecting: 'Live: connecting…',
+    connected: 'Live: on',
+    disconnected: attempts > 0 ? `Live: retrying (${attempts}/5)` : 'Live: paused',
+    error: 'Live: unreachable',
+  }
+  const colorByStatus: Record<Exclude<typeof status, 'off'>, string> = {
+    connecting: 'text-amber-400',
+    connected: 'text-green-500',
+    disconnected: 'text-amber-400',
+    error: 'text-red-400',
+  }
+  const Icon = status === 'connected' ? SignalIcon : SignalSlashIcon
+
+  return (
+    <span
+      className={`flex items-center gap-1 ${colorByStatus[status]}`}
+      title={`${labelByStatus[status]} · ${url}`}
+      data-testid="status-bar-collab"
+    >
+      <Icon className="w-3 h-3" />
+      <span>{labelByStatus[status]}</span>
+    </span>
   )
 }
 

--- a/src/hooks/useCollaboration.ts
+++ b/src/hooks/useCollaboration.ts
@@ -1,0 +1,153 @@
+'use client'
+
+// Phase A of live collaboration: a connectivity probe to the configured
+// Yjs websocket endpoint. NO document sync yet — opening a WS just
+// proves the user has a reachable server. Future PRs layer Y.Doc +
+// awareness + remote-cursor decorations on top of this.
+//
+// The hook is opt-in: it only attempts a connection when
+// NEXT_PUBLIC_YJS_WS_URL is set. Without it, status is permanently
+// 'off' and no WebSocket is ever opened.
+//
+// Reconnect strategy: 5 attempts, 1s → 2s → 4s → 8s → 16s. After the
+// last attempt fails the status sticks at 'error' until the user
+// triggers a manual reconnect (or reloads).
+
+import { useEffect, useState, useRef, useCallback } from 'react'
+
+export type CollabStatus = 'off' | 'connecting' | 'connected' | 'disconnected' | 'error'
+
+export interface CollabState {
+  status: CollabStatus
+  // Diagnostic: how many reconnect attempts we've burned through.
+  // Resets to 0 once a connection succeeds. Useful for the UI to show
+  // "Retrying… (2 of 5)" without exposing the full retry policy.
+  attempts: number
+  // The configured URL, exposed so the UI can show it in the status
+  // tooltip and skip rendering when null.
+  url: string | null
+  // User-triggered reconnect. No-op when status is 'connecting' or
+  // 'off'.
+  reconnect: () => void
+  // User-triggered disconnect — closes the socket and stops the
+  // reconnect loop until reconnect() is called.
+  disconnect: () => void
+}
+
+const MAX_ATTEMPTS = 5
+
+function getConfiguredUrl(): string | null {
+  if (typeof process === 'undefined') return null
+  const raw = process.env.NEXT_PUBLIC_YJS_WS_URL
+  if (!raw) return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  // Reject anything that isn't a ws:// or wss:// URL — keeps the CSP
+  // tight scope (see audit finding 5) honest at runtime too.
+  try {
+    const u = new URL(trimmed)
+    if (u.protocol !== 'ws:' && u.protocol !== 'wss:') return null
+    return trimmed
+  } catch {
+    return null
+  }
+}
+
+export function useCollaboration(): CollabState {
+  const url = getConfiguredUrl()
+  const [status, setStatus] = useState<CollabStatus>(url ? 'connecting' : 'off')
+  const [attempts, setAttempts] = useState(0)
+
+  const wsRef = useRef<WebSocket | null>(null)
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const intentRef = useRef<'connect' | 'disconnect'>('connect')
+  const attemptsRef = useRef(0)
+
+  const cleanup = useCallback(() => {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current)
+      retryTimerRef.current = null
+    }
+    if (wsRef.current) {
+      try { wsRef.current.close() } catch { /* ignore */ }
+      wsRef.current = null
+    }
+  }, [])
+
+  const connect = useCallback(() => {
+    if (!url) {
+      setStatus('off')
+      return
+    }
+    if (intentRef.current === 'disconnect') return
+    cleanup()
+    setStatus('connecting')
+    let ws: WebSocket
+    try {
+      ws = new WebSocket(url)
+    } catch {
+      setStatus('error')
+      return
+    }
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      attemptsRef.current = 0
+      setAttempts(0)
+      setStatus('connected')
+    }
+    ws.onclose = () => {
+      if (intentRef.current === 'disconnect') {
+        setStatus('disconnected')
+        return
+      }
+      // Schedule a reconnect with exponential backoff.
+      const a = attemptsRef.current + 1
+      attemptsRef.current = a
+      setAttempts(a)
+      if (a > MAX_ATTEMPTS) {
+        setStatus('error')
+        return
+      }
+      const delay = Math.min(1000 * Math.pow(2, a - 1), 16_000)
+      setStatus('disconnected')
+      retryTimerRef.current = setTimeout(() => {
+        if (intentRef.current === 'connect') connect()
+      }, delay)
+    }
+    ws.onerror = () => {
+      // onerror fires before onclose; let onclose handle reconnect so
+      // the backoff logic lives in one place.
+    }
+  }, [url, cleanup])
+
+  const reconnect = useCallback(() => {
+    if (!url) return
+    intentRef.current = 'connect'
+    attemptsRef.current = 0
+    setAttempts(0)
+    connect()
+  }, [url, connect])
+
+  const disconnect = useCallback(() => {
+    intentRef.current = 'disconnect'
+    cleanup()
+    setStatus('disconnected')
+  }, [cleanup])
+
+  useEffect(() => {
+    if (!url) return
+    intentRef.current = 'connect'
+    connect()
+    return () => {
+      intentRef.current = 'disconnect'
+      cleanup()
+    }
+    // url is read once at mount via the module-level helper — the env
+    // var doesn't change at runtime in a Next.js client component, so
+    // re-binding the effect on it is unnecessary noise.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return { status, attempts, url, reconnect, disconnect }
+}


### PR DESCRIPTION
First slice of the **Live collaboration** roadmap item. Just the foundation — no Yjs document sync yet. Opening a WebSocket to the configured server proves the plumbing works; real-time editing, awareness, and remote cursors land in follow-up PRs on top of this.

## What ships

- `useCollaboration()` hook. Reads `NEXT_PUBLIC_YJS_WS_URL` at mount, opens a WebSocket when set (and only when set). Status: `off | connecting | connected | disconnected | error`. Exponential backoff: 5 attempts at 1s → 2s → 4s → 8s → 16s. User-triggered `reconnect()` and `disconnect()` also exposed.
- URL validation: only `ws://` and `wss://` pass. Keeps the CSP scope (audit finding 5) honest at runtime too.
- EditorFooter **"Live" pill**: hidden when collab is off, green when connected, amber while retrying, red on error. Tooltip surfaces the configured URL.

## What's next (separate PRs)

- Phase B: Y.Doc binding + Y.Awareness — actual document sync.
- Phase C: y-codemirror.next integration → remote cursors in the editor.
- Phase D: invite-link generator + presence avatars.

## Test plan

- [x] 5 `useCollaboration` tests via @testing-library/react against a mocked WebSocket: no-config / non-ws-url rejection / connecting-then-connected / close-flips-disconnected / disconnect-halts-reconnect.
- [x] `npm test` — 80 / 80 suites, 1152 / 1152 tests
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)