### PR TITLE
docs: add Contributing section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Right-click any note or folder for rename, move, delete, or new subfolder.
 
 See [`docs/roadmap.md`](./docs/roadmap.md) for what is planned (Now / Next / Later).
 
+
+## Contributing
+
+Want to help? We'd love your contribution. Check out the [good first issues](https://github.com/ipapakonstantinou/noteser/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) to get started.
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the full workflow.
+
 ---
 
 ## For developers


### PR DESCRIPTION
## What

Added a short, welcoming Contributing section to README.md between the feature list and the For developers section.

## Why

The README jumps from the user-facing feature list to dev setup. Drive-by contributors who want to help do not know that CONTRIBUTING.md exists or where to find good entry points.

## Changes

- Added 5-line Contributing section above the  separator
- Links to CONTRIBUTING.md and the good-first-issue filter
- Welcoming tone, no jargon

## Acceptance criteria

- [x] New "Contributing" section in the README, around 5-8 lines
- [x] Links to CONTRIBUTING.md and the GitHub good first issue filter
- [x] Welcoming tone — no jargon, no contributor pre-qualification
- [x] Section sits between the user-facing feature list and the dev-section  separator

Closes #33