### PR TITLE
Add lenient done today task query option

### DIFF
--- a/src/__tests__/taskQuery.test.ts
+++ b/src/__tests__/taskQuery.test.ts
@@ -47,9 +47,10 @@ function makeNote(
   title: string,
   content: string,
   folderId: string | null = null,
-  isDeleted = false
+  isDeleted = false,
+  updatedAt?: number
 ) {
-  return { id, title, content, folderId, isDeleted }
+  return { id, title, content, folderId, isDeleted, updatedAt }
 }
 
 // ── parseTaskQuery ────────────────────────────────────────────────────────────
@@ -356,6 +357,29 @@ describe('executeTaskQuery', () => {
       today: '2026-05-18',
     })
     expect(result).toHaveLength(0)
+  })
+
+  test('doneToday lenient mode includes undated completed tasks from notes updated today', () => {
+    const updatedToday = new Date(2026, 4, 18, 10, 30).getTime()
+    const updatedYesterday = new Date(2026, 4, 17, 23, 30).getTime()
+    const notes = [
+      makeNote('n1', 'Today', '- [x] unstamped today', null, false, updatedToday),
+      makeNote('n2', 'Yesterday', '- [x] unstamped old', null, false, updatedYesterday),
+      makeNote('n3', 'Open', '- [ ] open task', null, false, updatedToday),
+    ]
+    const q = parseTaskQuery('done today')
+    const strict = executeTaskQuery(q, { notes, folders: [], today: '2026-05-18' })
+    const lenient = executeTaskQuery(q, {
+      notes,
+      folders: [],
+      today: '2026-05-18',
+      lenientDoneToday: true,
+    })
+
+    expect(strict).toHaveLength(0)
+    expect(lenient).toHaveLength(1)
+    expect(lenient[0].text).toBe('unstamped today')
+    expect(lenient[0].completedDate).toBe('2026-05-18')
   })
 
   test('pathIncludes filter is case-insensitive (folder name)', () => {

--- a/src/components/editor/TaskQueryBlock.tsx
+++ b/src/components/editor/TaskQueryBlock.tsx
@@ -23,13 +23,14 @@ export const TaskQueryBlock = ({ source }: { source: string }) => {
   const updateNote = useNoteStore(s => s.updateNote)
   const openNote = useWorkspaceStore(s => s.openNote)
   const density = useSettingsStore(s => s.taskListDensity)
+  const lenientDoneToday = useSettingsStore(s => s.taskQueryLenientDoneToday)
   const isComfortable = density === 'comfortable'
 
   const { query, groups } = useMemo(() => {
     const query = parseTaskQuery(source)
-    const tasks = executeTaskQuery(query, { notes, folders })
+    const tasks = executeTaskQuery(query, { notes, folders, lenientDoneToday })
     return { query, groups: groupTasks(tasks, query.groupBy, query.sortBy) }
-  }, [source, notes, folders])
+  }, [source, notes, folders, lenientDoneToday])
 
   const handleToggle = (task: ExecutedTask) => {
     const note = notes.find(n => n.id === task.noteId)

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -545,6 +545,8 @@ function normalizeForPicker(value: string, fallback: string): string {
 function EditorPanel() {
   const taskListDensity = useSettingsStore(s => s.taskListDensity)
   const setTaskListDensity = useSettingsStore(s => s.setTaskListDensity)
+  const taskQueryLenientDoneToday = useSettingsStore(s => s.taskQueryLenientDoneToday)
+  const setTaskQueryLenientDoneToday = useSettingsStore(s => s.setTaskQueryLenientDoneToday)
   const notesOpenInPreviewMode = useSettingsStore(s => s.notesOpenInPreviewMode)
   const setNotesOpenInPreviewMode = useSettingsStore(s => s.setNotesOpenInPreviewMode)
   const editorAutocorrect = useSettingsStore(s => s.editorAutocorrect)
@@ -593,6 +595,15 @@ function EditorPanel() {
             { value: 'compact', label: 'Compact' },
             { value: 'comfortable', label: 'Comfortable' },
           ]}
+        />
+      </Field>
+      <Field
+        label="Match completed tasks without a `✅ YYYY-MM-DD` stamp as done today"
+        description="When ON, `done today` also matches completed tasks without a completion date if their note was updated today. Leave OFF to require an explicit completion date."
+      >
+        <SettingsCheckbox
+          checked={taskQueryLenientDoneToday}
+          onChange={setTaskQueryLenientDoneToday}
         />
       </Field>
     </div>

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -35,6 +35,7 @@ export const DEFAULT_AI_MODEL: Record<Exclude<AIProvider, 'off'>, string> = {
 export interface SettingsState {
   folderSortMode: FolderSortMode
   taskListDensity: TaskListDensity
+  taskQueryLenientDoneToday: boolean
   // Show folders flagged as hidden (currently: the synthetic `attachments/`
   // folder). When false, those folders are suppressed from the sidebar.
   showHiddenFolders: boolean
@@ -284,6 +285,7 @@ export interface SettingsState {
 
   setFolderSortMode: (mode: FolderSortMode) => void
   setTaskListDensity: (density: TaskListDensity) => void
+  setTaskQueryLenientDoneToday: (value: boolean) => void
   setShowHiddenFolders: (value: boolean) => void
   setAttachmentsFolder: (folder: string) => void
   setAutoSyncOnStart: (value: boolean) => void
@@ -399,6 +401,7 @@ export type VaultSettingKey = (typeof VAULT_SETTING_KEYS)[number]
 const DEFAULTS = {
   folderSortMode: 'alphabetical' as FolderSortMode,
   taskListDensity: 'comfortable' as TaskListDensity,
+  taskQueryLenientDoneToday: false,
   showHiddenFolders: true,
   attachmentsFolder: 'Files',
   autoSyncOnStart: true,
@@ -476,6 +479,7 @@ export const useSettingsStore = create<SettingsState>()(
         ...DEFAULTS,
         setFolderSortMode: (folderSortMode) => setVault({ folderSortMode }),
         setTaskListDensity: (taskListDensity) => setVault({ taskListDensity }),
+        setTaskQueryLenientDoneToday: (taskQueryLenientDoneToday) => set({ taskQueryLenientDoneToday }),
         setShowHiddenFolders: (showHiddenFolders) => setVault({ showHiddenFolders }),
         setAttachmentsFolder: (attachmentsFolder) => setVault({ attachmentsFolder }),
         setAutoSyncOnStart: (autoSyncOnStart) => set({ autoSyncOnStart }),

--- a/src/utils/taskQuery.ts
+++ b/src/utils/taskQuery.ts
@@ -221,6 +221,17 @@ export interface ExecuteContext {
   notes: TaskSourceNote[]
   folders: Folder[]
   today?: string
+  lenientDoneToday?: boolean
+}
+
+function isSameLocalDay(timestamp: number | undefined, isoDate: string): boolean {
+  if (typeof timestamp !== 'number') return false
+  const d = new Date(timestamp)
+  if (Number.isNaN(d.getTime())) return false
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}` === isoDate
 }
 
 function buildFolderPath(folderId: string | null, folderById: Map<string, Folder>): string {
@@ -249,14 +260,18 @@ export function executeTaskQuery(query: TaskQuery, ctx: ExecuteContext): Execute
   for (const note of ctx.notes) {
     if (note.isDeleted) continue
     const noteTasks = extractTasks([note])
-    const meta = note as { folderId?: string | null; title?: string; createdAt?: number; content?: string }
+    const meta = note as { folderId?: string | null; title?: string; createdAt?: number; updatedAt?: number; content?: string }
     const folderPath = buildFolderPath(meta.folderId ?? null, folderById)
     const title = meta.title || 'Untitled'
     const path = folderPath ? `${folderPath}/${title}` : title
     const noteCreatedAt = typeof meta.createdAt === 'number' ? meta.createdAt : 0
     const tags = extractTags(meta.content ?? '')
     for (const t of noteTasks) {
-      all.push({ ...t, path, noteTitle: title, folderPath, noteCreatedAt, tags })
+      const completedDate =
+        ctx.lenientDoneToday && t.completed && !t.completedDate && isSameLocalDay(meta.updatedAt, today)
+          ? today
+          : t.completedDate
+      all.push({ ...t, completedDate, path, noteTitle: title, folderPath, noteCreatedAt, tags })
     }
   }
 


### PR DESCRIPTION
## Summary
- add a persisted Editor setting for lenient `done today` matching
- let task queries treat completed tasks without a completion stamp as done today when their note was updated today
- cover strict-vs-lenient behavior with a task query unit test

Closes #29

## Validation
- `npx jest src/__tests__/taskQuery.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint`