### PR TITLE
feat(sidebar+calendar): cross-sidebar drag + W column + weekly notes

### DIFF
--- a/src/__tests__/calendarGrid.test.ts
+++ b/src/__tests__/calendarGrid.test.ts
@@ -7,7 +7,12 @@
  * the grid is off by a column.
  */
 
-import { dayHeadersForWeekStart, leadingBlankCount } from '../utils/calendarGrid'
+import {
+  dayHeadersForWeekStart,
+  isoWeekNumber,
+  leadingBlankCount,
+  mondayOfIsoWeek,
+} from '../utils/calendarGrid'
 
 describe('dayHeadersForWeekStart', () => {
   test('Sunday start (0) → Su…Sa', () => {
@@ -64,5 +69,61 @@ describe('leadingBlankCount', () => {
     expect(leadingBlankCount(firstWeekday, 0)).toBe(5)
     // Monday-first: Friday is column 4 → 4 blanks before day 1.
     expect(leadingBlankCount(firstWeekday, 1)).toBe(4)
+  })
+})
+
+describe('isoWeekNumber', () => {
+  test('mid-year reference dates return expected ISO week', () => {
+    // 2026-01-05 (Monday) is the start of ISO week 2 (week 1 contains
+    // 2026-01-01..04 because Jan 1 2026 is a Thursday).
+    expect(isoWeekNumber(new Date(2026, 0, 5))).toBe(2)
+    // 2026-06-04 (Thursday) → week 23.
+    expect(isoWeekNumber(new Date(2026, 5, 4))).toBe(23)
+    // 2026-12-28 (Monday) is week 53 — 2026 has a long year.
+    expect(isoWeekNumber(new Date(2026, 11, 28))).toBe(53)
+  })
+
+  test('year-boundary edge cases follow ISO 8601', () => {
+    // 2023-01-01 is a Sunday → still belongs to week 52 of 2022.
+    expect(isoWeekNumber(new Date(2023, 0, 1))).toBe(52)
+    // 2021-01-01 is a Friday → ISO week 53 of 2020.
+    expect(isoWeekNumber(new Date(2021, 0, 1))).toBe(53)
+    // 2024-12-30 (Monday) → week 1 of 2025 (because Jan 1 2025 is a
+    // Wednesday, meaning week 1 starts Mon 2024-12-30).
+    expect(isoWeekNumber(new Date(2024, 11, 30))).toBe(1)
+    // 2025-12-29 (Monday) → week 1 of 2026.
+    expect(isoWeekNumber(new Date(2025, 11, 29))).toBe(1)
+  })
+
+  test('returns a value in [1, 53]', () => {
+    // Sample every day of 2025 — the result must stay in range.
+    const start = new Date(2025, 0, 1).getTime()
+    for (let i = 0; i < 365; i++) {
+      const d = new Date(start + i * 86400000)
+      const w = isoWeekNumber(d)
+      expect(w).toBeGreaterThanOrEqual(1)
+      expect(w).toBeLessThanOrEqual(53)
+    }
+  })
+})
+
+describe('mondayOfIsoWeek', () => {
+  test('returns the Monday of the current ISO week for a Thursday', () => {
+    // 2026-06-04 (Thursday) → Monday is 2026-06-01.
+    const monday = mondayOfIsoWeek(new Date(2026, 5, 4))
+    expect(monday.getFullYear()).toBe(2026)
+    expect(monday.getMonth()).toBe(5) // June
+    expect(monday.getDate()).toBe(1)
+  })
+
+  test('Sunday maps to the PRECEDING Monday (ISO weeks start Monday)', () => {
+    // 2026-06-07 (Sunday) → Monday 2026-06-01 (six days earlier).
+    const monday = mondayOfIsoWeek(new Date(2026, 5, 7))
+    expect(monday.getDate()).toBe(1)
+  })
+
+  test('Monday is a no-op (returns same calendar day)', () => {
+    const monday = mondayOfIsoWeek(new Date(2026, 5, 1))
+    expect(monday.getDate()).toBe(1)
   })
 })

--- a/src/__tests__/calendarWeeks.test.tsx
+++ b/src/__tests__/calendarWeeks.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * calendarWeeks.test.tsx
+ *
+ * Calendar W-column + weekly notes (Feature B on the fetch-timeouts
+ * branch, 2026-06-04):
+ *
+ *   - The W column renders to the LEFT of the day-of-week headers
+ *     with one cell per calendar row showing the ISO week number.
+ *   - Clicking a W cell creates the weekly note in the configured
+ *     folder + format.
+ *   - Clicking the same W cell again OPENS the existing note (no
+ *     duplicate).
+ *   - Right-click on a W cell opens the same context menu shape as a
+ *     day cell, with labels reading "weekly note" in week mode.
+ *
+ * idb-keyval is mocked so Zustand persist doesn't hit IndexedDB
+ * (unavailable in jsdom).
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+  keys: jest.fn().mockResolvedValue([]),
+}))
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { CalendarView } from '../components/sidebar/CalendarView'
+import { useNoteStore } from '../stores/noteStore'
+import { useFolderStore } from '../stores/folderStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { useUIStore } from '../stores/uiStore'
+import { useWorkspaceStore } from '../stores/workspaceStore'
+
+jest.mock('../hooks', () => ({
+  useHydration: () => true,
+}))
+
+beforeEach(() => {
+  useNoteStore.setState({ notes: [], selectedNoteId: null })
+  useFolderStore.setState({
+    folders: [],
+    activeFolderId: null,
+    expandedFolders: {},
+    deletedFolderPaths: [],
+  })
+  useSettingsStore.setState({
+    dailyNotesFolder: 'Notes/Daily',
+    dailyNoteDateFormat: 'YYYY-MM-DD',
+    dailyNoteTemplateId: null,
+    weeklyNotesFolder: 'Notes/Weekly',
+    weeklyNoteDateFormat: 'YYYY-WW',
+    weeklyNoteTemplateId: null,
+    calendarWeekStartDay: 1,
+    confirmBeforeTrash: true,
+    trashMode: 'trash',
+  })
+  useUIStore.setState({ modal: { type: null } })
+  useWorkspaceStore.setState({
+    panes: [{ id: 'p1', tabs: [], activeTabId: null }],
+    activePaneId: 'p1',
+  })
+})
+
+describe('Calendar W column', () => {
+  test('renders a W header cell + at least 4 ISO week-number cells', () => {
+    render(<CalendarView />)
+    // The header. We look it up by text rather than testid because
+    // the header is a div, not a button.
+    expect(screen.getByLabelText('ISO week number')).toBeInTheDocument()
+    // Every visible month has at least 4 calendar rows → at least 4
+    // W cells.
+    const weekButtons = screen.getAllByLabelText(/Open weekly note for week/i)
+    expect(weekButtons.length).toBeGreaterThanOrEqual(4)
+  })
+})
+
+describe('W cell click — open / create weekly note', () => {
+  test('first click creates the weekly note in the configured folder', () => {
+    render(<CalendarView />)
+    const weekButtons = screen.getAllByLabelText(/Open weekly note for week/i)
+    expect(weekButtons.length).toBeGreaterThan(0)
+    fireEvent.click(weekButtons[0])
+
+    const notes = useNoteStore.getState().notes
+    expect(notes.length).toBe(1)
+    // The note title matches the YYYY-WW format.
+    expect(notes[0].title).toMatch(/^\d{4}-\d{2}$/)
+    // It lives under Notes/Weekly — i.e. the folderId chain reaches a
+    // folder named "Weekly" with parent "Notes".
+    const folder = useFolderStore.getState().folders.find(f => f.id === notes[0].folderId)
+    expect(folder?.name).toBe('Weekly')
+    const parent = useFolderStore.getState().folders.find(f => f.id === folder?.parentId)
+    expect(parent?.name).toBe('Notes')
+  })
+
+  test('second click on the same week OPENS the existing note (no duplicate)', () => {
+    render(<CalendarView />)
+    const weekButtons = screen.getAllByLabelText(/Open weekly note for week/i)
+    fireEvent.click(weekButtons[0])
+    fireEvent.click(weekButtons[0])
+    expect(useNoteStore.getState().notes).toHaveLength(1)
+  })
+
+  test('weekly-note template seeds the new note body', () => {
+    // Pre-seed a template note and point the setting at it.
+    const templateNote = useNoteStore.getState().addNote({
+      title: 'Weekly Template',
+      folderId: null,
+      content: '## TODO\n- weekly review',
+    })
+    useSettingsStore.setState({ weeklyNoteTemplateId: templateNote.id })
+
+    render(<CalendarView />)
+    const weekButtons = screen.getAllByLabelText(/Open weekly note for week/i)
+    fireEvent.click(weekButtons[0])
+
+    // The created note's content should match the template.
+    const created = useNoteStore.getState().notes.find(
+      n => n.id !== templateNote.id && !n.isDeleted,
+    )
+    expect(created?.content).toBe('## TODO\n- weekly review')
+  })
+})
+
+describe('W cell right-click — weekly context menu', () => {
+  test('shows "Create weekly note" when no weekly note exists yet', () => {
+    render(<CalendarView />)
+    const weekButtons = screen.getAllByLabelText(/Open weekly note for week/i)
+    fireEvent.contextMenu(weekButtons[0])
+
+    const create = screen.getByTestId('calendar-day-context-create')
+    // The label should say "weekly note" (not "daily note").
+    expect(create.textContent).toMatch(/weekly note/i)
+  })
+
+  test('shows "Delete weekly note" when a weekly note exists', () => {
+    render(<CalendarView />)
+    const weekButtons = screen.getAllByLabelText(/Open weekly note for week/i)
+    // Create first.
+    fireEvent.click(weekButtons[0])
+    // Then right-click.
+    fireEvent.contextMenu(weekButtons[0])
+
+    const del = screen.getByTestId('calendar-day-context-delete')
+    expect(del.textContent).toMatch(/delete weekly note/i)
+  })
+
+  test('delete via context menu (confirmBeforeTrash=false) soft-deletes the weekly note', () => {
+    useSettingsStore.setState({ confirmBeforeTrash: false, trashMode: 'trash' })
+    render(<CalendarView />)
+    const weekButtons = screen.getAllByLabelText(/Open weekly note for week/i)
+    fireEvent.click(weekButtons[0])
+    fireEvent.contextMenu(weekButtons[0])
+    fireEvent.click(screen.getByTestId('calendar-day-context-delete'))
+
+    const notes = useNoteStore.getState().notes
+    expect(notes[0].isDeleted).toBe(true)
+  })
+})

--- a/src/__tests__/crossSidebarMove.test.tsx
+++ b/src/__tests__/crossSidebarMove.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * crossSidebarMove.test.tsx
+ *
+ * Locks the 2026-06-04 cross-sidebar drag refactor (Feature A on the
+ * fetch-timeouts branch). Coverage:
+ *
+ *   1. Drag a tab from the left activity bar onto a right group's
+ *      mini-strip → appears in rightSidebarGroups + disappears from
+ *      sidebarGroups.
+ *   2. Drag from the right side onto a left group's strip → opposite
+ *      direction works the same way (no MIME mismatch).
+ *   3. moveTabAcrossSidebars used by the right-click "Move to other
+ *      sidebar" path creates a singleton group on the OTHER side.
+ *   4. Activity-bar dedup: a panel parked in ANY group (either side)
+ *      hides its icon from BOTH the left and right ribbons.
+ *
+ * idb-keyval is mocked so Zustand persist doesn't hit IndexedDB
+ * (unavailable in jsdom).
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+  keys: jest.fn().mockResolvedValue([]),
+}))
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { Ribbon } from '../components/sidebar/Ribbon'
+import { RightRibbon } from '../components/sidebar/RightRibbon'
+import { SidebarStack } from '../components/sidebar/SidebarStack'
+import { RightSidebarStack } from '../components/sidebar/RightSidebarStack'
+import { useSettingsStore } from '../stores/settingsStore'
+import { useUIStore } from '../stores/uiStore'
+import { moveTabAcrossSidebars } from '../components/sidebar/sidebarGroupActions'
+import {
+  TAB_DRAG_MIME,
+} from '../components/sidebar/sidebarPanelRegistry'
+import {
+  RIGHT_TAB_DRAG_MIME,
+} from '../components/sidebar/rightPanelRegistry'
+
+class FakeDataTransfer {
+  effectAllowed: string = ''
+  dropEffect: string = ''
+  types: string[] = []
+  private data: Map<string, string> = new Map()
+  getData(key: string): string { return this.data.get(key) ?? '' }
+  setData(key: string, value: string): void {
+    this.data.set(key, value)
+    if (!this.types.includes(key)) this.types.push(key)
+  }
+  items = { add: jest.fn(), clear: jest.fn(), remove: jest.fn(), length: 0 }
+}
+
+;(globalThis as unknown as Record<string, unknown>).DataTransfer = FakeDataTransfer
+
+function fireDragEventWithPayload(
+  el: HTMLElement,
+  eventName: 'dragOver' | 'drop',
+  payload: { mime: string; id: string },
+): void {
+  const patchListener = (e: Event) => {
+    const dragEv = e as DragEvent
+    const fdt = new FakeDataTransfer()
+    fdt.setData(payload.mime, payload.id)
+    Object.defineProperty(dragEv, 'dataTransfer', { value: fdt, configurable: true })
+  }
+  el.addEventListener(eventName.toLowerCase(), patchListener, { capture: true })
+  if (eventName === 'dragOver') fireEvent.dragOver(el)
+  else fireEvent.drop(el)
+  el.removeEventListener(eventName.toLowerCase(), patchListener, { capture: true })
+}
+
+function seedBothSides(): void {
+  useSettingsStore.setState({
+    sidebarGroups: [
+      { id: 'gL1', tabs: ['calendar'], activeTab: 'calendar', collapsed: false },
+    ],
+    rightSidebarGroups: [
+      { id: 'gR1', tabs: ['properties'], activeTab: 'properties', collapsed: false },
+    ],
+    hiddenSidebarTabs: [],
+    ribbonOrder: [],
+  })
+  useUIStore.setState({
+    sidebarCollapsed: false,
+    rightSidebarCollapsed: false,
+    lastFocusedGroupId: 'gL1',
+    lastFocusedRightGroupId: 'gR1',
+  })
+}
+
+describe('Drag MIME is unified across both sides', () => {
+  test('RIGHT_TAB_DRAG_MIME equals TAB_DRAG_MIME (single payload shape)', () => {
+    expect(RIGHT_TAB_DRAG_MIME).toBe(TAB_DRAG_MIME)
+  })
+})
+
+describe('Drag left → right (panel icon onto right group strip)', () => {
+  beforeEach(() => seedBothSides())
+
+  test('drop on the right group strip moves the tab across', () => {
+    render(<RightSidebarStack />)
+    const strips = screen.getAllByTestId('right-sidebar-pinned-strip')
+    expect(strips).toHaveLength(1)
+    fireDragEventWithPayload(strips[0], 'dragOver', { mime: TAB_DRAG_MIME, id: 'calendar' })
+    fireDragEventWithPayload(strips[0], 'drop', { mime: TAB_DRAG_MIME, id: 'calendar' })
+
+    const state = useSettingsStore.getState()
+    // Calendar should now live on the right side.
+    expect(state.rightSidebarGroups[0].tabs).toEqual(
+      expect.arrayContaining(['properties', 'calendar']),
+    )
+    // The left group held only `calendar` — it should be dropped now
+    // that it's empty.
+    expect(state.sidebarGroups).toHaveLength(0)
+  })
+
+  test('drop on the right trailing inter-group zone spawns a new right group', () => {
+    render(<RightSidebarStack />)
+    const zones = screen.getAllByTestId('right-sidebar-inter-group-dropzone')
+    const trailing = zones[zones.length - 1]
+    fireDragEventWithPayload(trailing, 'dragOver', { mime: TAB_DRAG_MIME, id: 'calendar' })
+    fireDragEventWithPayload(trailing, 'drop', { mime: TAB_DRAG_MIME, id: 'calendar' })
+
+    const state = useSettingsStore.getState()
+    // 2 right groups: original + new one with calendar.
+    expect(state.rightSidebarGroups).toHaveLength(2)
+    expect(state.rightSidebarGroups.some(g => g.tabs.includes('calendar'))).toBe(true)
+    // Left side lost it.
+    expect(state.sidebarGroups).toHaveLength(0)
+  })
+})
+
+describe('Drag right → left', () => {
+  beforeEach(() => seedBothSides())
+
+  test('drop on a left group strip moves the right-side tab across', () => {
+    render(<SidebarStack onRightClick={jest.fn()} />)
+    const strips = screen.getAllByTestId('sidebar-pinned-strip')
+    expect(strips).toHaveLength(1)
+    fireDragEventWithPayload(strips[0], 'dragOver', { mime: TAB_DRAG_MIME, id: 'properties' })
+    fireDragEventWithPayload(strips[0], 'drop', { mime: TAB_DRAG_MIME, id: 'properties' })
+
+    const state = useSettingsStore.getState()
+    expect(state.sidebarGroups[0].tabs).toEqual(
+      expect.arrayContaining(['calendar', 'properties']),
+    )
+    expect(state.rightSidebarGroups).toHaveLength(0)
+  })
+})
+
+describe('moveTabAcrossSidebars (right-click "Move to other sidebar")', () => {
+  beforeEach(() => seedBothSides())
+
+  test('left → right: removes from left, creates singleton on right', () => {
+    moveTabAcrossSidebars('calendar', 'right', null)
+    const state = useSettingsStore.getState()
+    expect(state.sidebarGroups).toHaveLength(0)
+    // Two right groups: original properties + a fresh singleton with calendar.
+    expect(state.rightSidebarGroups).toHaveLength(2)
+    expect(state.rightSidebarGroups.some(g => g.tabs.includes('calendar'))).toBe(true)
+  })
+
+  test('right → left: removes from right, creates singleton on left', () => {
+    moveTabAcrossSidebars('properties', 'left', null)
+    const state = useSettingsStore.getState()
+    expect(state.rightSidebarGroups).toHaveLength(0)
+    expect(state.sidebarGroups).toHaveLength(2)
+    expect(state.sidebarGroups.some(g => g.tabs.includes('properties'))).toBe(true)
+  })
+
+  test('is a no-op when the tab is not on the other side', () => {
+    // calendar is already on the left; asking to move-to-left is a
+    // no-op.
+    const before = useSettingsStore.getState()
+    moveTabAcrossSidebars('calendar', 'left', null)
+    const after = useSettingsStore.getState()
+    expect(after.sidebarGroups).toEqual(before.sidebarGroups)
+    expect(after.rightSidebarGroups).toEqual(before.rightSidebarGroups)
+  })
+})
+
+describe('Activity-bar dedup across both sides', () => {
+  test('a panel in a LEFT group does not render an icon on EITHER bar', () => {
+    useSettingsStore.setState({
+      sidebarGroups: [
+        { id: 'gL1', tabs: ['plugins'], activeTab: 'plugins', collapsed: false },
+      ],
+      rightSidebarGroups: [],
+      hiddenSidebarTabs: [],
+      ribbonOrder: [],
+    })
+    useUIStore.setState({ sidebarCollapsed: false, rightSidebarCollapsed: false })
+    const { unmount } = render(<Ribbon />)
+    expect(screen.queryByTestId('activity-bar-panel-plugins')).toBeNull()
+    unmount()
+    render(<RightRibbon />)
+    // The right ribbon never showed Plugins (it's not a right default)
+    // — but neither does it show Properties unless Properties is
+    // missing from every group. Confirm Plugins is absent regardless.
+    expect(screen.queryByTestId('right-activity-bar-panel-plugins')).toBeNull()
+  })
+
+  test('a right-default panel dragged to the LEFT side hides from the RIGHT bar', () => {
+    // Properties starts on the right; user drags it to the left side.
+    useSettingsStore.setState({
+      sidebarGroups: [
+        { id: 'gL1', tabs: ['calendar', 'properties'], activeTab: 'properties', collapsed: false },
+      ],
+      rightSidebarGroups: [],
+      hiddenSidebarTabs: [],
+      ribbonOrder: [],
+    })
+    useUIStore.setState({ sidebarCollapsed: false, rightSidebarCollapsed: false })
+    render(<RightRibbon />)
+    expect(screen.queryByTestId('right-activity-bar-panel-properties')).toBeNull()
+  })
+
+  test('a left-default panel dragged to the RIGHT side hides from the LEFT bar', () => {
+    // Plugins lives on the right side (after a cross-sidebar drag).
+    // The left ribbon should no longer show Plugins.
+    useSettingsStore.setState({
+      sidebarGroups: [
+        { id: 'gL1', tabs: ['calendar'], activeTab: 'calendar', collapsed: false },
+      ],
+      rightSidebarGroups: [
+        { id: 'gR1', tabs: ['properties', 'plugins'], activeTab: 'plugins', collapsed: false },
+      ],
+      hiddenSidebarTabs: [],
+      ribbonOrder: [],
+    })
+    useUIStore.setState({ sidebarCollapsed: false, rightSidebarCollapsed: false })
+    render(<Ribbon />)
+    expect(screen.queryByTestId('activity-bar-panel-plugins')).toBeNull()
+    // calendar is still in the left group, so its icon is also hidden.
+    expect(screen.queryByTestId('activity-bar-panel-calendar')).toBeNull()
+    // But other panels (e.g. files) that aren't in any group ARE shown.
+    expect(screen.getByTestId('activity-bar-panel-files')).toBeTruthy()
+  })
+})

--- a/src/components/editor/markdownLivePreview.ts
+++ b/src/components/editor/markdownLivePreview.ts
@@ -248,7 +248,9 @@ const livePreviewTheme = EditorView.baseTheme({
   },
   '.cm-lp-strike': { textDecoration: 'line-through', opacity: '0.7' },
   '.cm-lp-blockquote': {
-    borderLeft: '3px solid hsl(217, 88%, 50%)',
+    // Left bar removed per user feedback (2026-06-04, option 2γ).
+    // Italic + dim colour still differentiates quoted content; the
+    // 3px blue accent read as visual noise.
     paddingLeft: '12px',
     fontStyle: 'italic',
     color: '#a8a8a8',

--- a/src/components/modals/DailyNotesSection.tsx
+++ b/src/components/modals/DailyNotesSection.tsx
@@ -25,8 +25,18 @@ export const DailyNotesSection = () => {
   const setDateFormat = useSettingsStore(s => s.setDailyNoteDateFormat)
   const setWeekStartDay = useSettingsStore(s => s.setCalendarWeekStartDay)
 
+  // Weekly notes (2026-06-04 — companion to the new calendar W
+  // column). Folder + title format mirror the daily fields; the
+  // weekly-note template is set in the Templates section below
+  // (keeps all template pickers together).
+  const weeklyFolder = useSettingsStore(s => s.weeklyNotesFolder)
+  const weeklyFormat = useSettingsStore(s => s.weeklyNoteDateFormat)
+  const setWeeklyFolder = useSettingsStore(s => s.setWeeklyNotesFolder)
+  const setWeeklyFormat = useSettingsStore(s => s.setWeeklyNoteDateFormat)
+
   return (
     <>
+      <h3 className="text-sm font-medium text-obsidianText mb-2">Daily notes</h3>
       <Field
         label="Folder"
         description="Where new daily notes are created. Defaults to `Daily Notes`."
@@ -62,6 +72,30 @@ export const DailyNotesSection = () => {
           ]}
         />
       </Field>
+
+      <h3 className="text-sm font-medium text-obsidianText mt-6 mb-2">Weekly notes</h3>
+      <Field
+        label="Folder"
+        description="Where new weekly notes are created. Defaults to `Notes/Weekly`."
+      >
+        <SettingsTextInput
+          value={weeklyFolder}
+          onCommit={(v) => setWeeklyFolder(normalizeFolder(v) || 'Notes/Weekly')}
+          placeholder="Notes/Weekly"
+          mono
+        />
+      </Field>
+      <Field
+        label="Title format"
+        description="Title format for weekly notes. Tokens include `WW` / `W` (ISO week number). Example: `YYYY-[W]WW` → 2026-W23."
+      >
+        <SettingsTextInput
+          value={weeklyFormat}
+          onCommit={(v) => setWeeklyFormat(v.trim() || 'YYYY-WW')}
+          placeholder="YYYY-WW"
+          mono
+        />
+      </Field>
     </>
   )
 }
@@ -70,8 +104,10 @@ export const TemplatesSection = () => {
   const notes = useNoteStore(s => s.notes)
   const templatesFolder = useSettingsStore(s => s.templatesFolder)
   const dailyTemplateId = useSettingsStore(s => s.dailyNoteTemplateId)
+  const weeklyTemplateId = useSettingsStore(s => s.weeklyNoteTemplateId)
   const setTemplatesFolder = useSettingsStore(s => s.setTemplatesFolder)
   const setDailyTemplateId = useSettingsStore(s => s.setDailyNoteTemplateId)
+  const setWeeklyTemplateId = useSettingsStore(s => s.setWeeklyNoteTemplateId)
 
   // Re-run when notes change so the dropdown reflects fresh template
   // files. listTemplateNotes reads from useNoteStore.getState() +
@@ -113,6 +149,16 @@ export const TemplatesSection = () => {
         <SettingsSelect<string>
           value={dailyTemplateId ?? NONE}
           onChange={(v) => setDailyTemplateId(v === NONE ? null : v)}
+          options={options}
+        />
+      </Field>
+      <Field
+        label="Weekly note template"
+        description="When a weekly note is created (calendar W-column click), its content is seeded from this note."
+      >
+        <SettingsSelect<string>
+          value={weeklyTemplateId ?? NONE}
+          onChange={(v) => setWeeklyTemplateId(v === NONE ? null : v)}
           options={options}
         />
       </Field>

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -76,7 +76,7 @@ const CATEGORIES: readonly CategoryDef[] = [
   { id: 'editor',      label: 'Editor',      Icon: PencilSquareIcon },
   { id: 'sidebar',     label: 'Sidebar',     Icon: ViewColumnsIcon },
   { id: 'attachments', label: 'Attachments', Icon: PaperClipIcon },
-  { id: 'daily-notes', label: 'Daily notes', Icon: CalendarDaysIcon },
+  { id: 'daily-notes', label: 'Daily & weekly notes', Icon: CalendarDaysIcon },
   { id: 'templates',   label: 'Templates',   Icon: DocumentDuplicateIcon },
   { id: 'github',      label: 'GitHub sync', Icon: CloudIcon },
   { id: 'local-folder', label: 'Local folder', Icon: FolderOpenIcon },

--- a/src/components/sidebar/CalendarDayContextMenu.tsx
+++ b/src/components/sidebar/CalendarDayContextMenu.tsx
@@ -31,6 +31,12 @@ export interface CalendarDayContextMenuProps {
   y: number
   hasDailyNote: boolean
   isBookmarked: boolean
+  // Cell mode (2026-06-04). Drives the open / delete / create labels
+  // so a right-click on the new W-column week cell reads naturally
+  // ("Open weekly note" / "Delete weekly note") without forking the
+  // whole menu component. Defaults to 'day' for back-compat with the
+  // existing call site.
+  mode?: 'day' | 'week'
   onOpenDailyNote: () => void
   onOpenInNewPane: () => void
   onCopyWikilink: () => void
@@ -45,6 +51,7 @@ export const CalendarDayContextMenu = ({
   y,
   hasDailyNote,
   isBookmarked,
+  mode = 'day',
   onOpenDailyNote,
   onOpenInNewPane,
   onCopyWikilink,
@@ -53,6 +60,10 @@ export const CalendarDayContextMenu = ({
   onCreateDailyNote,
   onDismiss,
 }: CalendarDayContextMenuProps) => {
+  // Reads more naturally on the W column without forking the menu.
+  // 'note' is the noun ("daily note" vs "weekly note"); we drop in
+  // the appropriate one for the open/delete/create labels.
+  const noun = mode === 'week' ? 'weekly note' : 'daily note'
   const menuRef = useRef<HTMLDivElement>(null)
 
   // Outside-click + Escape dismiss. Item-clicks call their own action
@@ -108,7 +119,7 @@ export const CalendarDayContextMenu = ({
             data-testid="calendar-day-context-open"
           >
             <DocumentTextIcon className="w-4 h-4" />
-            Open daily note
+            Open {noun}
           </button>
           <button
             type="button"
@@ -149,7 +160,7 @@ export const CalendarDayContextMenu = ({
             data-testid="calendar-day-context-delete"
           >
             <TrashIcon className="w-4 h-4" />
-            Delete daily note
+            Delete {noun}
           </button>
         </>
       ) : (
@@ -161,7 +172,7 @@ export const CalendarDayContextMenu = ({
           data-testid="calendar-day-context-create"
         >
           <DocumentPlusIcon className="w-4 h-4" />
-          Create daily note
+          Create {noun}
         </button>
       )}
     </div>

--- a/src/components/sidebar/CalendarView.tsx
+++ b/src/components/sidebar/CalendarView.tsx
@@ -1,12 +1,18 @@
 'use client'
 
-import { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
 import { useNoteStore, useFolderStore, useWorkspaceStore, useSettingsStore, useUIStore } from '@/stores'
 import { useHydration } from '@/hooks'
 import { dailyNotesFolder } from '@/utils/systemFolder'
 import { formatDate } from '@/utils/dateFormat'
-import { dayHeadersForWeekStart, leadingBlankCount } from '@/utils/calendarGrid'
+import {
+  dayHeadersForWeekStart,
+  leadingBlankCount,
+  isoWeekNumber,
+  mondayOfIsoWeek,
+} from '@/utils/calendarGrid'
+import { openWeekNote, findWeeklyNoteId } from '@/utils/periodicNotes'
 import { CalendarDayContextMenu } from './CalendarDayContextMenu'
 
 const MONTH_NAMES = [
@@ -14,12 +20,18 @@ const MONTH_NAMES = [
   'July', 'August', 'September', 'October', 'November', 'December',
 ]
 
-// Context-menu state for the right-click flow. `day` is the 1-indexed
-// day of the month being acted on, `title` is the formatted daily-note
-// title (used as the wikilink target + the lookup key), `noteId` is
-// the existing daily-note id (or null when the day has no note yet).
-interface DayMenuState {
-  day: number
+// Context-menu state for the right-click flow. `mode` distinguishes a
+// click on a day cell (default) from a click on the new W-column
+// week-number cell (2026-06-04 — the menu now works for weekly notes
+// too). For 'day' mode `day` is the 1-indexed day-of-month; for
+// 'week' mode `weekStart` is the Monday of the row's ISO week.
+// `title` is the formatted target-note title (used as the wikilink +
+// the lookup key), `noteId` is the existing daily/weekly note id (or
+// null when no note exists yet).
+interface CellMenuState {
+  mode: 'day' | 'week'
+  day: number | null      // day-of-month for 'day' mode
+  weekStart: Date | null  // Monday of the row for 'week' mode
   title: string
   noteId: string | null
   x: number
@@ -42,7 +54,7 @@ export const CalendarView = () => {
   const dailyTemplateId = useSettingsStore(s => s.dailyNoteTemplateId)
   const weekStartDay = useSettingsStore(s => s.calendarWeekStartDay)
 
-  const [menu, setMenu] = useState<DayMenuState | null>(null)
+  const [menu, setMenu] = useState<CellMenuState | null>(null)
 
   const year = viewDate.getFullYear()
   const month = viewDate.getMonth()
@@ -130,7 +142,22 @@ export const CalendarView = () => {
   const onDayContextMenu = (e: React.MouseEvent, day: number) => {
     e.preventDefault()
     const { id, title } = findDailyNoteId(day)
-    setMenu({ day, title, noteId: id, x: e.clientX, y: e.clientY })
+    setMenu({ mode: 'day', day, weekStart: null, title, noteId: id, x: e.clientX, y: e.clientY })
+  }
+
+  // Click handler for a W-column cell. Resolves the Monday of the
+  // row's ISO week from the leftmost real day in that row, then opens
+  // / creates the weekly note via openWeekNote. The row's leftmost
+  // cell may be a leading blank when the row spans a month boundary —
+  // in that case we anchor on the FIRST non-blank day of the row.
+  const openWeek = (weekStart: Date) => {
+    openWeekNote(weekStart)
+  }
+
+  const onWeekContextMenu = (e: React.MouseEvent, weekStart: Date) => {
+    e.preventDefault()
+    const { id, title } = findWeeklyNoteId(weekStart)
+    setMenu({ mode: 'week', day: null, weekStart, title, noteId: id, x: e.clientX, y: e.clientY })
   }
 
   const closeMenu = () => setMenu(null)
@@ -206,7 +233,11 @@ export const CalendarView = () => {
 
   const handleCreateDailyNote = () => {
     if (!menu) return
-    openDay(menu.day)
+    if (menu.mode === 'week' && menu.weekStart) {
+      openWeek(menu.weekStart)
+    } else if (menu.mode === 'day' && menu.day != null) {
+      openDay(menu.day)
+    }
     closeMenu()
   }
 
@@ -237,8 +268,17 @@ export const CalendarView = () => {
         </button>
       </div>
 
-      {/* Day-of-week headers */}
-      <div className="grid grid-cols-7 mb-1">
+      {/* Headers row: W column on the far left, then the 7 day-of-week
+          headers. `[auto_repeat(7,_1fr)]` keeps the W column tight to
+          its content while the 7 day columns share the remaining
+          width equally — same per-row layout as the day grid below. */}
+      <div className="grid grid-cols-[auto_repeat(7,_1fr)] mb-1">
+        <div
+          className="text-center text-[10px] text-obsidianSecondaryText/60 py-1 pr-1"
+          aria-label="ISO week number"
+        >
+          W
+        </div>
         {dayHeaders.map(d => (
           <div
             key={d}
@@ -249,31 +289,72 @@ export const CalendarView = () => {
         ))}
       </div>
 
-      {/* Day grid */}
-      <div className="grid grid-cols-7 gap-y-0.5">
-        {cells.map((day, i) => {
-          if (!day) return <div key={`e-${i}`} />
-
-          const isToday = isCurrentMonth && day === today.getDate()
-          const hasNote = notedDays.has(day)
+      {/* Day grid — chunked into rows so the W column can prepend a
+          per-row cell. Each row is 1 W cell + 7 day cells; rows that
+          start with a leading blank still anchor on the row's first
+          REAL day (the Monday derived from that day is always the
+          row's ISO-week Monday). */}
+      <div className="grid grid-cols-[auto_repeat(7,_1fr)] gap-y-0.5">
+        {Array.from({ length: Math.ceil(cells.length / 7) }, (_, rowIdx) => {
+          const rowStart = rowIdx * 7
+          const rowCells = cells.slice(rowStart, rowStart + 7)
+          // Find the row's anchor date: the first non-null day. Every
+          // calendar row has at least one — the leading-blank rows
+          // start the month at day 1, and trailing rows by definition
+          // contain the last days of the month.
+          const firstDayInRow = rowCells.find((d): d is number => d !== null)
+          const anchorDate = firstDayInRow != null
+            ? new Date(year, month, firstDayInRow)
+            : null
+          const weekMonday = anchorDate ? mondayOfIsoWeek(anchorDate) : null
+          const weekNumber = anchorDate ? isoWeekNumber(anchorDate) : null
 
           return (
-            <button
-              key={day}
-              onClick={() => openDay(day)}
-              onContextMenu={(e) => onDayContextMenu(e, day)}
-              className={`relative flex flex-col items-center justify-center rounded py-1 text-xs transition-colors ${
-                isToday
-                  ? 'bg-obsidianAccentPurple text-white font-semibold'
-                  : 'text-obsidianSecondaryText hover:bg-obsidianHighlight hover:text-obsidianText'
-              }`}
-              data-testid={`calendar-day-${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`}
-            >
-              {day}
-              {hasNote && !isToday && (
-                <span className="absolute bottom-0.5 w-1 h-1 rounded-full bg-obsidianAccentPurple" />
+            <React.Fragment key={`row-${rowIdx}`}>
+              {/* W column cell — small text button, muted compared to
+                  day cells. Click opens / creates the weekly note;
+                  right-click opens the same context menu the day cell
+                  uses, but in 'week' mode. */}
+              {weekNumber != null && weekMonday ? (
+                <button
+                  onClick={() => openWeek(weekMonday)}
+                  onContextMenu={(e) => onWeekContextMenu(e, weekMonday)}
+                  className="flex items-center justify-center rounded py-1 pr-1 text-[10px] text-obsidianSecondaryText/70 hover:bg-obsidianHighlight hover:text-obsidianText transition-colors"
+                  data-testid={`calendar-week-${weekMonday.getFullYear()}-W${String(weekNumber).padStart(2, '0')}`}
+                  title={`Week ${weekNumber} — open or create weekly note`}
+                  aria-label={`Open weekly note for week ${weekNumber}`}
+                >
+                  {weekNumber}
+                </button>
+              ) : (
+                <div />
               )}
-            </button>
+              {rowCells.map((day, i) => {
+                if (!day) return <div key={`e-${rowIdx}-${i}`} />
+
+                const isToday = isCurrentMonth && day === today.getDate()
+                const hasNote = notedDays.has(day)
+
+                return (
+                  <button
+                    key={day}
+                    onClick={() => openDay(day)}
+                    onContextMenu={(e) => onDayContextMenu(e, day)}
+                    className={`relative flex flex-col items-center justify-center rounded py-1 text-xs transition-colors ${
+                      isToday
+                        ? 'bg-obsidianAccentPurple text-white font-semibold'
+                        : 'text-obsidianSecondaryText hover:bg-obsidianHighlight hover:text-obsidianText'
+                    }`}
+                    data-testid={`calendar-day-${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`}
+                  >
+                    {day}
+                    {hasNote && !isToday && (
+                      <span className="absolute bottom-0.5 w-1 h-1 rounded-full bg-obsidianAccentPurple" />
+                    )}
+                  </button>
+                )
+              })}
+            </React.Fragment>
           )
         })}
       </div>
@@ -292,6 +373,7 @@ export const CalendarView = () => {
         <CalendarDayContextMenu
           x={menu.x}
           y={menu.y}
+          mode={menu.mode}
           hasDailyNote={menu.noteId !== null}
           isBookmarked={menuTargetBookmarked}
           onOpenDailyNote={handleOpenDailyNote}

--- a/src/components/sidebar/Ribbon.tsx
+++ b/src/components/sidebar/Ribbon.tsx
@@ -115,28 +115,34 @@ export const Ribbon = () => {
     ribbonOrder,
     setRibbonOrder,
     sidebarGroups,
+    rightSidebarGroups,
     hiddenSidebarTabs,
     hideSidebarTab,
   } = useSettingsStore(useShallow(s => ({
     ribbonOrder: s.ribbonOrder,
     setRibbonOrder: s.setRibbonOrder,
     sidebarGroups: s.sidebarGroups,
+    rightSidebarGroups: s.rightSidebarGroups,
     hiddenSidebarTabs: s.hiddenSidebarTabs,
     hideSidebarTab: s.hideSidebarTab,
   })))
 
-  // Set of panel ids currently parked in ANY sidebar group. Per user
-  // feedback (2026-06-04): a panel that is already showing in the
-  // sidebar should NOT also have an icon in the activity bar — the
-  // group's own mini-strip is its switcher. The activity bar becomes
-  // a list of "panels you can OPEN", not "all panels everywhere".
+  // Set of panel ids currently parked in ANY sidebar group on EITHER
+  // side. Per user feedback (2026-06-04): a panel showing somewhere in
+  // the UI should NOT also have an icon in the activity bar — the
+  // group's own mini-strip is its switcher. So a left-side panel that
+  // was dragged to the right (e.g. Plugins) disappears from BOTH bars
+  // until it's evicted via the tab context menu.
   const inAnyGroup = useMemo(() => {
     const set = new Set<string>()
     for (const g of sidebarGroups) {
       for (const t of g.tabs) set.add(t)
     }
+    for (const g of rightSidebarGroups) {
+      for (const t of g.tabs) set.add(t)
+    }
     return set
-  }, [sidebarGroups])
+  }, [sidebarGroups, rightSidebarGroups])
 
   // Hidden set — panels in `hiddenSidebarTabs` are filtered out of the
   // activity bar entirely (Settings → Sidebar can restore them).

--- a/src/components/sidebar/RightMiniStrip.tsx
+++ b/src/components/sidebar/RightMiniStrip.tsx
@@ -2,8 +2,8 @@
 
 import { useRef, useState } from 'react'
 import {
-  RIGHT_PANELS,
   RIGHT_TAB_DRAG_MIME,
+  rightPanelDef,
   type RightSidebarTabId,
 } from './rightPanelRegistry'
 
@@ -107,7 +107,7 @@ export const RightMiniStrip = ({
     >
       {leadingSlot}
       {ids.map((id, idx) => {
-        const def = RIGHT_PANELS.find(p => p.id === id)
+        const def = rightPanelDef(id)
         if (!def) return null
         const Icon = def.Icon
         const active = id === activeId

--- a/src/components/sidebar/RightRibbon.tsx
+++ b/src/components/sidebar/RightRibbon.tsx
@@ -42,20 +42,28 @@ export const RightRibbon = () => {
 
   const {
     rightSidebarGroups,
+    sidebarGroups,
   } = useSettingsStore(useShallow(s => ({
     rightSidebarGroups: s.rightSidebarGroups,
+    sidebarGroups: s.sidebarGroups,
   })))
 
   // Same rule as the left ribbon — a panel currently shown in a
   // group does NOT get an icon in the activity bar; the group's
-  // mini-strip is its switcher.
+  // mini-strip is its switcher. Updated 2026-06-04 to inspect BOTH
+  // sides: a panel parked in a LEFT group is also hidden from the
+  // right bar (otherwise the user could conjure a duplicate by
+  // dragging a left panel across and then clicking the right icon).
   const inAnyGroup = useMemo(() => {
     const set = new Set<string>()
     for (const g of rightSidebarGroups) {
       for (const t of g.tabs) set.add(t)
     }
+    for (const g of sidebarGroups) {
+      for (const t of g.tabs) set.add(t)
+    }
     return set
-  }, [rightSidebarGroups])
+  }, [rightSidebarGroups, sidebarGroups])
   const visiblePanels = useMemo(
     () => RIGHT_PANELS.filter(p => !inAnyGroup.has(p.id)),
     [inAnyGroup],
@@ -117,16 +125,20 @@ export const RightRibbon = () => {
       >
         {visiblePanels.map(def => {
           const Icon = def.Icon
+          // RIGHT_PANELS is the source of visiblePanels — every id in
+          // it is a right-native id ('properties' | 'backlinks'),
+          // which the wider RightSidebarTabId union includes.
+          const id = def.id as RightSidebarTabId
           return (
             <div
               key={`right-panel-${def.id}`}
               draggable
-              onDragStart={onPanelDragStart(def.id)}
+              onDragStart={onPanelDragStart(id)}
               data-testid={`right-activity-bar-panel-${def.id}`}
             >
               <RibbonButton
-                onClick={() => onPanelClick(def.id)}
-                onContextMenu={(e) => openPanelMenu(def.id, e)}
+                onClick={() => onPanelClick(id)}
+                onContextMenu={(e) => openPanelMenu(id, e)}
                 title={`${def.title} — drag to a right sidebar group, right-click for options`}
               >
                 <Icon className="w-5 h-5" />

--- a/src/components/sidebar/RightSidebarGroup.tsx
+++ b/src/components/sidebar/RightSidebarGroup.tsx
@@ -3,12 +3,13 @@
 import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
 import { RightMiniStrip } from './RightMiniStrip'
 import {
-  RIGHT_PANELS,
   RightPanelBody,
+  rightPanelDef,
   type RightSidebarTabId,
 } from './rightPanelRegistry'
 import { useSettingsStore, useUIStore, type SidebarGroupState } from '@/stores'
 import { moveTabToRightGroup } from './rightSidebarGroupActions'
+import { moveTabAcrossSidebars } from './sidebarGroupActions'
 
 // Right-side leaf-model group — mirror of `SidebarGroup` but bound to
 // the right-side registry + setters. Same chrome (strip + chevron +
@@ -33,7 +34,7 @@ export const RightSidebarGroup = ({
     ? group.activeTab
     : tabs[0]) as RightSidebarTabId
 
-  const activePanelTitle = RIGHT_PANELS.find(p => p.id === activeTab)?.title ?? activeTab
+  const activePanelTitle = rightPanelDef(activeTab)?.title ?? activeTab
   const isCollapsed = group.collapsed
 
   const onActivate = (id: RightSidebarTabId) => {
@@ -41,8 +42,18 @@ export const RightSidebarGroup = ({
     setLastFocusedRightGroupId(group.id)
   }
 
+  // Drop into this right-side group. Cross-sidebar (2026-06-04): if
+  // the dropped tab currently lives in a left-side group, route
+  // through moveTabAcrossSidebars so it's evicted from the left side
+  // as part of the same operation.
   const onAddToThisGroup = (otherId: RightSidebarTabId) => {
-    moveTabToRightGroup(otherId, group.id)
+    const leftGroups = useSettingsStore.getState().sidebarGroups
+    const onLeft = leftGroups.some(g => g.tabs.includes(otherId))
+    if (onLeft) {
+      moveTabAcrossSidebars(otherId, 'right', group.id)
+    } else {
+      moveTabToRightGroup(otherId, group.id)
+    }
     setLastFocusedRightGroupId(group.id)
   }
 

--- a/src/components/sidebar/RightSidebarStack.tsx
+++ b/src/components/sidebar/RightSidebarStack.tsx
@@ -16,6 +16,7 @@ import {
   closeTabInRightGroup,
   moveTabToNewRightGroup,
 } from './rightSidebarGroupActions'
+import { moveTabAcrossSidebars } from './sidebarGroupActions'
 
 // Right-side stack — mirror of `SidebarStack`. Renders the right
 // sidebar's stacked groups plus inter-group drop zones (drag a panel
@@ -39,7 +40,10 @@ export const RightSidebarStack = () => {
       if (!g || !Array.isArray(g.tabs)) continue
       const cleanedTabs: RightSidebarTabId[] = []
       for (const id of g.tabs) {
-        if (RIGHT_KNOWN_IDS.has(id as RightSidebarTabId) && !seen.has(id)) {
+        // RIGHT_KNOWN_IDS now spans every left + right panel id so a
+        // cross-sidebar drag from the left activity bar (e.g. Plugins)
+        // lands cleanly on the right without being filtered out here.
+        if (RIGHT_KNOWN_IDS.has(id) && !seen.has(id)) {
           seen.add(id)
           cleanedTabs.push(id as RightSidebarTabId)
         }
@@ -144,7 +148,17 @@ export const RightSidebarStack = () => {
           <div key={g.id} ref={setGroupRef(g.id)} className={wrapperClass}>
             <RightInterGroupDropZone
               active={dragActive}
-              onDropId={(id) => createRightGroupWithTab(idx, id)}
+              onDropId={(id) => {
+                // Cross-sidebar: id may currently live in a left-side
+                // group. Route through moveTabAcrossSidebars so the
+                // left group loses the tab atomically.
+                const left = useSettingsStore.getState().sidebarGroups
+                if (left.some(g => g.tabs.includes(id))) {
+                  moveTabAcrossSidebars(id, 'right', null, idx)
+                } else {
+                  createRightGroupWithTab(idx, id)
+                }
+              }}
             />
             <RightSidebarGroup
               group={g}
@@ -184,7 +198,14 @@ export const RightSidebarStack = () => {
       {groups.length > 0 && (
         <RightInterGroupDropZone
           active={dragActive}
-          onDropId={(id) => createRightGroupWithTab(groups.length, id)}
+          onDropId={(id) => {
+            const left = useSettingsStore.getState().sidebarGroups
+            if (left.some(g => g.tabs.includes(id))) {
+              moveTabAcrossSidebars(id, 'right', null, groups.length)
+            } else {
+              createRightGroupWithTab(groups.length, id)
+            }
+          }}
         />
       )}
       {tabMenu && (
@@ -193,6 +214,16 @@ export const RightSidebarStack = () => {
           y={tabMenu.y}
           onClose={() => { closeTabInRightGroup(tabMenu.groupId, tabMenu.id); closeTabMenu() }}
           onMoveToNewGroup={() => { moveTabToNewRightGroup(tabMenu.id); closeTabMenu() }}
+          onMoveToOtherSidebar={() => {
+            // Right → left: moveTabAcrossSidebars removes from the
+            // right groups + creates a singleton left group in one
+            // setState pass. lastFocusedGroupId is updated to the
+            // new left group so the next activity-bar click lands
+            // there.
+            moveTabAcrossSidebars(tabMenu.id, 'left', null)
+            closeTabMenu()
+          }}
+          moveToOtherSidebarLabel="Move to left sidebar"
           // Right side has no hidden-tabs list yet — hide is wired
           // to a no-op + close so the menu still works without
           // surprising the user with a hidden panel they can't find.

--- a/src/components/sidebar/SidebarGroup.tsx
+++ b/src/components/sidebar/SidebarGroup.tsx
@@ -4,7 +4,7 @@ import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
 import { PinnedMiniStrip } from './PinnedMiniStrip'
 import { PANELS, PanelBody, type PanelRightClick } from './sidebarPanelRegistry'
 import { useSettingsStore, useUIStore, type SidebarTabId, type SidebarGroupState } from '@/stores'
-import { moveTabToGroup } from './sidebarGroupActions'
+import { moveTabToGroup, moveTabAcrossSidebars } from './sidebarGroupActions'
 
 // One leaf-model group: a horizontal tab strip + the active tab's
 // content. Every group renders its OWN strip even when it only holds
@@ -59,8 +59,18 @@ export const SidebarGroup = ({
   // Drop from another group's strip / activity bar → move into this
   // group. The settings store's addTabToGroup handles the move
   // semantics (remove from source, drop empty source group).
+  //
+  // Cross-sidebar (2026-06-04): if the dropped tab currently lives in
+  // a right-side group, route through moveTabAcrossSidebars so it's
+  // removed from the right side as part of the same operation.
   const onAddToThisGroup = (otherId: SidebarTabId) => {
-    moveTabToGroup(otherId, group.id)
+    const rightGroups = useSettingsStore.getState().rightSidebarGroups
+    const onRight = rightGroups.some(g => g.tabs.includes(otherId))
+    if (onRight) {
+      moveTabAcrossSidebars(otherId, 'left', group.id)
+    } else {
+      moveTabToGroup(otherId, group.id)
+    }
     setLastFocusedGroupId(group.id)
   }
 

--- a/src/components/sidebar/SidebarStack.tsx
+++ b/src/components/sidebar/SidebarStack.tsx
@@ -16,6 +16,7 @@ import {
   createGroupWithTab,
   closeTabInGroup,
   moveTabToNewGroup,
+  moveTabAcrossSidebars,
 } from './sidebarGroupActions'
 
 interface Props {
@@ -200,7 +201,17 @@ export const SidebarStack = ({ onRightClick }: Props) => {
           <div key={g.id} ref={setGroupRef(g.id)} className={wrapperClass}>
             <InterGroupDropZone
               active={dragActive}
-              onDropId={(id) => createGroupWithTab(idx, id)}
+              onDropId={(id) => {
+                // Cross-sidebar: if this id currently lives in a
+                // right-side group, route through moveTabAcrossSidebars
+                // so the right group loses the tab atomically.
+                const right = useSettingsStore.getState().rightSidebarGroups
+                if (right.some(g => g.tabs.includes(id))) {
+                  moveTabAcrossSidebars(id, 'left', null, idx)
+                } else {
+                  createGroupWithTab(idx, id)
+                }
+              }}
             />
             <SidebarGroup
               group={g}
@@ -243,11 +254,19 @@ export const SidebarStack = ({ onRightClick }: Props) => {
         )
       })}
       {/* Trailing zone — drop here to spawn a new group at the very
-          bottom of the stack. */}
+          bottom of the stack. Same cross-sidebar routing as the inner
+          zones. */}
       {groups.length > 0 && (
         <InterGroupDropZone
           active={dragActive}
-          onDropId={(id) => createGroupWithTab(groups.length, id)}
+          onDropId={(id) => {
+            const right = useSettingsStore.getState().rightSidebarGroups
+            if (right.some(g => g.tabs.includes(id))) {
+              moveTabAcrossSidebars(id, 'left', null, groups.length)
+            } else {
+              createGroupWithTab(groups.length, id)
+            }
+          }}
         />
       )}
       {tabMenu && (
@@ -256,6 +275,15 @@ export const SidebarStack = ({ onRightClick }: Props) => {
           y={tabMenu.y}
           onClose={() => { closeTabInGroup(tabMenu.groupId, tabMenu.id); closeTabMenu() }}
           onMoveToNewGroup={() => { moveTabToNewGroup(tabMenu.id); closeTabMenu() }}
+          onMoveToOtherSidebar={() => {
+            // Yank from the left side, drop as a new singleton group
+            // on the right. moveTabAcrossSidebars handles removing the
+            // tab from its left group + creating the right group in
+            // one setState pass.
+            moveTabAcrossSidebars(tabMenu.id, 'right', null)
+            closeTabMenu()
+          }}
+          moveToOtherSidebarLabel="Move to right sidebar"
           onHide={() => { hideSidebarTab(tabMenu.id); closeTabMenu() }}
           onDismiss={closeTabMenu}
         />

--- a/src/components/sidebar/TabContextMenu.tsx
+++ b/src/components/sidebar/TabContextMenu.tsx
@@ -5,6 +5,7 @@ import {
   XMarkIcon,
   ArrowsPointingOutIcon,
   EyeSlashIcon,
+  ArrowsRightLeftIcon,
 } from '@heroicons/react/24/outline'
 
 // Lightweight popup menu for right-clicking a sidebar tab icon (or a
@@ -27,6 +28,19 @@ export interface TabContextMenuProps {
   onClose: () => void
   onMoveToNewGroup: () => void
   onHide: () => void
+  // Optional "Move to other sidebar" action — when set, renders an
+  // extra row that yanks the tab from the current side and creates a
+  // singleton group on the OPPOSITE side. Wired by SidebarGroup (left
+  // → right) and RightSidebarGroup (right → left). When unset, the
+  // row is hidden, so call sites that don't care (e.g. activity-bar
+  // panel menus, where there's no source side to move FROM) stay
+  // visually unchanged.
+  onMoveToOtherSidebar?: () => void
+  // Label override for the "Move to other sidebar" row. Defaults to
+  // "Move to other sidebar"; callsites pass a side-aware label like
+  // "Move to right sidebar" / "Move to left sidebar" so the menu reads
+  // naturally regardless of which side fired it.
+  moveToOtherSidebarLabel?: string
   // Called when the menu should dismiss WITHOUT performing any action
   // (Escape, outside click, etc.). Separate from the per-item handlers
   // so the parent doesn't fire close-tab on a stray outside click.
@@ -34,7 +48,9 @@ export interface TabContextMenuProps {
 }
 
 export const TabContextMenu = ({
-  x, y, onClose, onMoveToNewGroup, onHide, onDismiss,
+  x, y, onClose, onMoveToNewGroup, onHide,
+  onMoveToOtherSidebar, moveToOtherSidebarLabel,
+  onDismiss,
 }: TabContextMenuProps) => {
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -98,6 +114,18 @@ export const TabContextMenu = ({
         <ArrowsPointingOutIcon className="w-4 h-4" />
         Move to new group
       </button>
+      {onMoveToOtherSidebar && (
+        <button
+          type="button"
+          role="menuitem"
+          onClick={onMoveToOtherSidebar}
+          className="w-full flex items-center gap-2 px-3 py-2 text-sm text-obsidianText hover:bg-obsidianHighlight"
+          data-testid="tab-context-menu-move-to-other-sidebar"
+        >
+          <ArrowsRightLeftIcon className="w-4 h-4" />
+          {moveToOtherSidebarLabel ?? 'Move to other sidebar'}
+        </button>
+      )}
       <div className="my-1 border-t border-obsidianBorder" />
       <button
         type="button"

--- a/src/components/sidebar/rightPanelRegistry.tsx
+++ b/src/components/sidebar/rightPanelRegistry.tsx
@@ -1,15 +1,25 @@
 'use client'
 
 // Right-sidebar panel registry — mirrors `sidebarPanelRegistry.tsx`
-// for the right edge. SEPARATE from the left registry on purpose: the
-// two sides hold different panels (Properties + Backlinks live only
-// on the right; Files / Outline / Search live only on the left), and
-// the drag/drop MIMEs are distinct so dragging a left-side tab over
-// the right ribbon does NOT silently spawn a Files group on the right.
+// for the right edge. The two registries hold different DEFAULT panels
+// (Properties + Backlinks default-live on the right; Files / Outline /
+// Search default-live on the left), but as of 2026-06-04 the model
+// allows ANY left panel to also live on the right (and vice versa)
+// via cross-sidebar drag.
+//
+// Cross-sidebar moves: user feedback (Telegram, 2026-06-04):
+//   "μπορώ να μπορώ να πάρω το px plugin και να το πάω στη δεξιά μπάρα;
+//    αυτή τη στιγμή δεν φαίνεται να γίνεται" — the previous MIME
+// isolation silently rejected the drag at the right-side drop targets.
+// We now share TAB_DRAG_MIME across both sides; the drop handlers
+// detect which side currently owns the tab to route across (see
+// moveTabAcrossSidebars in sidebarGroupActions).
 //
 // Default panels (v1): Properties + Backlinks. Future right-side
 // panels (Outline, Local Graph, …) plug in here without touching the
-// left side.
+// left side. RIGHT_DEFAULT_IDS = the panels the right activity bar
+// surfaces. RIGHT_KNOWN_IDS = every id the right side will accept in
+// a group (defaults + every left-side panel id).
 
 import {
   InformationCircleIcon,
@@ -17,40 +27,91 @@ import {
 } from '@heroicons/react/24/outline'
 import { PropertiesPanel } from './PropertiesPanel'
 import { BacklinksView } from './BacklinksView'
+import {
+  PANELS,
+  PanelBody,
+  TAB_DRAG_MIME,
+  type PanelRightClick,
+} from './sidebarPanelRegistry'
+import { type SidebarTabId } from '@/stores'
 
-// IDs of panels available in the RIGHT sidebar. Kept narrow on purpose
-// — the right side is for note-context views, not vault navigation.
-export type RightSidebarTabId = 'properties' | 'backlinks'
+// Right-side panel id union — narrow native ids PLUS any left-side
+// panel that may have been dragged across. The right STACK accepts
+// any SidebarTabId; the right ACTIVITY BAR only surfaces the native
+// defaults below.
+type RightNativeId = 'properties' | 'backlinks'
+export type RightSidebarTabId = RightNativeId | SidebarTabId
 
-interface RightPanelDef {
-  id: RightSidebarTabId
+// Generic icon component type — heroicons' actual component is a
+// ForwardRefExoticComponent, so we widen to "any component with an
+// optional className" here to keep the def array assignable across
+// the two source registries (right native + left PANELS).
+interface PanelLikeDef {
+  id: string
   Icon: typeof InformationCircleIcon
   title: string
 }
 
-export const RIGHT_PANELS: readonly RightPanelDef[] = [
+// Native right-side panels (the only ones the right activity bar
+// surfaces by default). When a left-side panel is dragged onto the
+// right stack it still renders, but its icon stays on the LEFT
+// activity bar — see RightRibbon for the rationale.
+export const RIGHT_DEFAULT_PANELS: readonly PanelLikeDef[] = [
   { id: 'properties', Icon: InformationCircleIcon, title: 'Properties' },
   { id: 'backlinks',  Icon: LinkIcon,              title: 'Backlinks' },
 ]
 
-export const RIGHT_KNOWN_IDS = new Set<RightSidebarTabId>(
-  RIGHT_PANELS.map(p => p.id),
-)
+// Legacy export name kept so callsites + tests that read RIGHT_PANELS
+// still compile. Identical to RIGHT_DEFAULT_PANELS.
+export const RIGHT_PANELS = RIGHT_DEFAULT_PANELS
 
-// MIME shared by every right-side strip + the right ribbon so cross-
-// zone drops work without coupling. DIFFERENT from the left's
-// TAB_DRAG_MIME so a left-side drag never accidentally lands on a
-// right-side drop target (the dataTransfer check filters on the
-// specific MIME).
-export const RIGHT_TAB_DRAG_MIME = 'application/x-noteser-right-sidebar-tab'
+// Combined registry — every panel that the right side knows how to
+// render. Native ids first (so RIGHT_PANELS lookups still find their
+// def at the front), followed by every left-side panel.
+const COMBINED_PANELS: readonly PanelLikeDef[] = [
+  ...RIGHT_DEFAULT_PANELS,
+  ...PANELS,
+]
 
-// Body renderer keyed by id. The actual content components are the
-// existing PropertiesPanel + BacklinksView — moving them into the
-// right registry doesn't change their behaviour, only how they're
-// looked up.
-export const RightPanelBody = ({ id }: { id: RightSidebarTabId }) => {
+// Look up the icon + title for any id the right side might render.
+// Used by RightMiniStrip so dragged-in left panels still get their
+// proper icon + title.
+export const rightPanelDef = (id: RightSidebarTabId): PanelLikeDef | undefined =>
+  COMBINED_PANELS.find(p => p.id === id)
+
+// Every id the right stack will accept in a group. Combines the
+// right-native defaults with every left-side panel id. The stack's
+// sanitiser filters out anything that isn't here.
+export const RIGHT_KNOWN_IDS = new Set<string>([
+  ...RIGHT_DEFAULT_PANELS.map(p => p.id),
+  ...PANELS.map(p => p.id),
+])
+
+// MIME shared by every right-side strip + the right ribbon. As of
+// 2026-06-04 this is the SAME string as the left side's TAB_DRAG_MIME
+// — left + right drops accept a unified payload and the drop handlers
+// (PinnedMiniStrip, RightMiniStrip, InterGroupDropZone,
+// RightInterGroupDropZone) detect which side currently owns the tab
+// to route across (see moveTabAcrossSidebars in sidebarGroupActions).
+// Re-exported as a separate alias for back-compat with any callsite
+// or test that still imports under the old name.
+export const RIGHT_TAB_DRAG_MIME = TAB_DRAG_MIME
+
+// Body renderer keyed by id. Native ids render their dedicated
+// components; everything else delegates to the left-side PanelBody so
+// a dragged-in panel (e.g. Plugins, Outline) keeps its behaviour on
+// the right side.
+export const RightPanelBody = ({
+  id, onRightClick,
+}: { id: RightSidebarTabId; onRightClick?: PanelRightClick }) => {
   switch (id) {
     case 'properties': return <PropertiesPanel />
     case 'backlinks':  return <BacklinksView />
+    default:
+      // Fall through to the left registry. onRightClick is only used
+      // by the Files panel; the right side rarely hosts Files, but if
+      // a user drags it across we still want context menus to work —
+      // pass a no-op default to keep the type happy.
+      return <PanelBody id={id} onRightClick={onRightClick ?? (() => {})} />
   }
 }

--- a/src/components/sidebar/sidebarGroupActions.ts
+++ b/src/components/sidebar/sidebarGroupActions.ts
@@ -12,6 +12,7 @@
 // and so the activity-bar 4-case click logic has one canonical home.
 
 import { useSettingsStore, useUIStore, type SidebarTabId, type SidebarGroupState, newSidebarGroupId } from '@/stores'
+import { applyAddTabToGroup, applyRemoveTabFromGroup, applyCreateGroupAt } from '@/stores/settingsStore'
 
 // Find which group (if any) currently contains `tabId`. Returns the
 // group object or null. Pure — does not touch the store.
@@ -124,6 +125,88 @@ export function moveTabToNewGroup(tabId: SidebarTabId): void {
   const sourceIdx = owner ? groups.findIndex(g => g.id === owner.id) : -1
   const insertAt = sourceIdx >= 0 ? sourceIdx + 1 : groups.length
   useSettingsStore.getState().createGroupAt(insertAt, tabId)
+}
+
+// Cross-sidebar move (2026-06-04). Yanks `tabId` out of whichever
+// side currently owns it (left `sidebarGroups` or right
+// `rightSidebarGroups`) and drops it onto the other side. The drop
+// destination is one of:
+//
+//   • `targetGroupId` non-null → add to that existing group on the
+//     `targetSide`. Uses applyAddTabToGroup so the activeTab flips
+//     to the moved tab automatically.
+//   • `targetGroupId` null + `insertAt` provided → spawn a brand-new
+//     group on the target side at that index. Uses applyCreateGroupAt
+//     which already de-dupes the same tab out of every other group on
+//     the target side.
+//
+// Both store writes happen in one set() pass — the helper reads the
+// current state, computes the next snapshot for each side, then commits
+// both in a single setState. Atomic from the React/Zustand perspective:
+// subscribers see either both writes or neither.
+//
+// No-op when the tab isn't on the OTHER side (use moveTabToGroup /
+// createGroupWithTab / the right-side equivalents for same-side moves).
+export function moveTabAcrossSidebars(
+  tabId: string,
+  targetSide: 'left' | 'right',
+  targetGroupId: string | null,
+  insertAt?: number,
+): void {
+  const state = useSettingsStore.getState()
+  const sourceSide = targetSide === 'left' ? 'right' : 'left'
+  const sourceGroups = sourceSide === 'left' ? state.sidebarGroups : state.rightSidebarGroups
+  const owner = sourceGroups.find(g => g.tabs.includes(tabId))
+  if (!owner) return // not on the other side — nothing to move
+
+  // Remove from source side first.
+  const nextSourceGroups = applyRemoveTabFromGroup(sourceGroups, owner.id, tabId)
+
+  // Add to target side.
+  const targetGroups = targetSide === 'left' ? state.sidebarGroups : state.rightSidebarGroups
+  let nextTargetGroups: SidebarGroupState[]
+  if (targetGroupId != null) {
+    // Drop into an existing target group. The target side may not have
+    // had this tab before, so applyAddTabToGroup handles the append +
+    // makes it active.
+    nextTargetGroups = applyAddTabToGroup(targetGroups, targetGroupId, tabId)
+  } else {
+    const idx = typeof insertAt === 'number' ? insertAt : targetGroups.length
+    nextTargetGroups = applyCreateGroupAt(targetGroups, idx, tabId)
+  }
+
+  // Commit both sides in a single setState so subscribers see the
+  // post-move world in one render pass.
+  if (targetSide === 'left') {
+    useSettingsStore.setState({
+      sidebarGroups: nextTargetGroups,
+      rightSidebarGroups: nextSourceGroups,
+    })
+    useUIStore.getState().setLastFocusedGroupId(
+      targetGroupId ?? (nextTargetGroups.find(g => g.tabs.includes(tabId))?.id ?? null),
+    )
+  } else {
+    useSettingsStore.setState({
+      sidebarGroups: nextSourceGroups,
+      rightSidebarGroups: nextTargetGroups,
+    })
+    useUIStore.getState().setLastFocusedRightGroupId(
+      targetGroupId ?? (nextTargetGroups.find(g => g.tabs.includes(tabId))?.id ?? null),
+    )
+  }
+}
+
+// Helper used by drop handlers: is `tabId` currently in any group on
+// the OTHER side? Pure — does not touch the store. The caller decides
+// the source by passing in the right-side groups array.
+export function findRightGroupWithTabFromLeft(
+  rightGroups: SidebarGroupState[],
+  tabId: string,
+): SidebarGroupState | null {
+  for (const g of rightGroups) {
+    if (g.tabs.includes(tabId)) return g
+  }
+  return null
 }
 
 // Re-export the id factory + state type so call sites can build groups

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -217,6 +217,9 @@ export interface SettingsState {
   // ID of the note (in `templatesFolder`) whose content seeds new daily
   // notes. null = no template; new daily notes start empty.
   dailyNoteTemplateId: string | null
+  // Same idea for new weekly notes (2026-06-04). Parallel to
+  // dailyNoteTemplateId; null = no template, new weekly notes empty.
+  weeklyNoteTemplateId: string | null
 
   // ── AI (BYO key) ──────────────────────────────────────────────────────
   // Which provider the aiClient targets. `'off'` (default) disables every
@@ -463,6 +466,7 @@ export interface SettingsState {
   setMonthlyNoteDateFormat: (format: string) => void
   setTemplatesFolder: (folder: string) => void
   setDailyNoteTemplateId: (id: string | null) => void
+  setWeeklyNoteTemplateId: (id: string | null) => void
   setAiProvider: (provider: AIProvider) => void
   setAiApiKey: (key: string) => void
   setAiModel: (model: string) => void
@@ -566,6 +570,7 @@ export const VAULT_SETTING_KEYS = [
   'monthlyNoteDateFormat',
   'templatesFolder',
   'dailyNoteTemplateId',
+  'weeklyNoteTemplateId',
   'trashMode',
   'confirmBulkDelete',
   'betaEnabled',
@@ -603,6 +608,7 @@ const DEFAULTS = {
   monthlyNoteDateFormat: 'YYYY-MM',
   templatesFolder: 'Templates',
   dailyNoteTemplateId: null as string | null,
+  weeklyNoteTemplateId: null as string | null,
   aiProvider: 'off' as AIProvider,
   aiApiKey: '',
   aiModel: DEFAULT_AI_MODEL.anthropic,
@@ -765,6 +771,7 @@ export const useSettingsStore = create<SettingsState>()(
         setMonthlyNoteDateFormat: (monthlyNoteDateFormat) => setVault({ monthlyNoteDateFormat }),
         setTemplatesFolder: (templatesFolder) => setVault({ templatesFolder }),
         setDailyNoteTemplateId: (dailyNoteTemplateId) => setVault({ dailyNoteTemplateId }),
+        setWeeklyNoteTemplateId: (weeklyNoteTemplateId) => setVault({ weeklyNoteTemplateId }),
         setAiProvider: (aiProvider) => set({ aiProvider }),
         setAiApiKey: (aiApiKey) => set({ aiApiKey }),
         setAiModel: (aiModel) => set({ aiModel }),

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -48,10 +48,12 @@
     font-family: var(--font-interface);
   }
 
-  /* Scrollbar styling */
+  /* Scrollbar styling. obsidianBorder thumb matches the soft palette
+     introduced 2026-06-04 — it blends into the near-black bg until
+     hover. */
   * {
     scrollbar-width: thin;
-    scrollbar-color: theme('colors.obsidianAccent') transparent;
+    scrollbar-color: theme('colors.obsidianBorder') transparent;
   }
 
   ::-webkit-scrollbar {
@@ -63,8 +65,13 @@
     background: transparent;
   }
 
+  /* Darker thumb (user feedback 2026-06-04, option 1α): the previous
+     obsidianAccent (#3a3a3a) read as a bright vertical line against the
+     near-black sidebar; obsidianBorder (#2e2e2e) is closer to bg so it
+     blends in until you actually need it. Hover keeps a more visible
+     highlight so the thumb is still findable. */
   ::-webkit-scrollbar-thumb {
-    background-color: theme('colors.obsidianAccent');
+    background-color: theme('colors.obsidianBorder');
     border-radius: 3px;
   }
 
@@ -186,8 +193,12 @@
     @apply bg-transparent p-0;
   }
 
+  /* Blockquote: bar removed per user feedback (2026-06-04, option 2γ).
+     The italic + secondary-text colour still differentiates quoted
+     content from regular prose; the previous 4px blue accent read as
+     visual noise. */
   .prose blockquote {
-    @apply border-l-4 border-obsidianAccentPurple pl-4 italic text-obsidianSecondaryText my-4;
+    @apply pl-4 italic text-obsidianSecondaryText my-4;
   }
 
   .prose ul,

--- a/src/utils/calendarGrid.ts
+++ b/src/utils/calendarGrid.ts
@@ -26,3 +26,46 @@ export const leadingBlankCount = (
   firstWeekday: number,
   startDay: CalendarWeekStartDay,
 ): number => (firstWeekday - startDay + 7) % 7
+
+// ISO 8601 week number for the given local date. Weeks start on
+// Monday and week 1 is the one that contains the first Thursday of
+// the year. The result is in [1, 53].
+//
+// Why duplicate the helper that already lives in dateFormat.ts?
+//   • The calendar W-column renders the number visually; it doesn't
+//     format an arbitrary moment-style token. Keeping the grid math
+//     in calendarGrid (alongside dayHeadersForWeekStart +
+//     leadingBlankCount) makes the unit tests sit next to each
+//     other, so an off-by-one in either is caught in the same file.
+//   • dateFormat.ts's isoWeek is private to that module — exposing it
+//     would tie the calendar to the formatter's lifecycle. The two
+//     functions are intentionally tiny and trivially proven by tests.
+//
+// Algorithm: shift to the Thursday of the current ISO week, find the
+// Thursday of Jan 4 (week 1 anchor), divide the day-delta by 7.
+export function isoWeekNumber(date: Date): number {
+  // Use a UTC copy to avoid DST jumps perturbing the day arithmetic.
+  // `Sun = 0` becomes `7` so the "Thursday of this week" offset is
+  // computed correctly regardless of the input weekday.
+  const d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
+  const dayNum = d.getUTCDay() || 7
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum)
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1))
+  return Math.ceil((((d.getTime() - yearStart.getTime()) / 86400000) + 1) / 7)
+}
+
+// Anchor Monday for the given date. Used by the W-column so the
+// per-row week-number cell clicks land on the correct ISO week even
+// when the calendar's week-start setting is Sunday (the leftmost cell
+// in the row is then a SUNDAY, but the ISO week is keyed on the
+// MONDAY that follows it).
+export function mondayOfIsoWeek(date: Date): Date {
+  // Build a fresh local-time date so callers can pass any Date.
+  const d = new Date(date.getFullYear(), date.getMonth(), date.getDate())
+  // JS getDay: 0=Sunday..6=Saturday. ISO Monday is the (day - 1 + 7) % 7
+  // step backward; Sunday (0) maps to 6 steps back.
+  const dayNum = d.getDay()
+  const offset = dayNum === 0 ? -6 : 1 - dayNum
+  d.setDate(d.getDate() + offset)
+  return d
+}

--- a/src/utils/periodicNotes.ts
+++ b/src/utils/periodicNotes.ts
@@ -17,10 +17,14 @@ import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { weeklyNotesFolder, monthlyNotesFolder } from './systemFolder'
 import { formatDate } from './dateFormat'
 
+// Open or create a periodic note for the given date in the given
+// folder. `templateContent` (when supplied) seeds the body on first
+// creation — used by the weekly-note template setting.
 function openPeriodicNote(
   now: Date,
   folderPath: string,
   format: string,
+  templateContent?: string,
 ): string {
   const title = formatDate(now, format)
   const segments = folderPath.split('/')
@@ -35,16 +39,69 @@ function openPeriodicNote(
     return existing.id
   }
 
-  const created = addNote({ title, folderId, content: '' })
+  const created = addNote({ title, folderId, content: templateContent ?? '' })
   useWorkspaceStore.getState().openNote(created.id, { preview: false })
   return created.id
+}
+
+// Resolve the configured weekly-note template's body (or undefined
+// when no template is selected / the template note is missing). Kept
+// private because the daily-note path uses the same dance inline.
+function weeklyTemplateContent(): string | undefined {
+  const settings = useSettingsStore.getState()
+  const id = settings.weeklyNoteTemplateId
+  if (!id) return undefined
+  const note = useNoteStore.getState().notes.find(
+    n => !n.isDeleted && n.id === id,
+  )
+  return note?.content
 }
 
 export function openThisWeekNote(now: Date = new Date()): string {
   const settings = useSettingsStore.getState()
   const folder = weeklyNotesFolder.get()
   const format = settings.weeklyNoteDateFormat || 'YYYY-WW'
-  return openPeriodicNote(now, folder, format)
+  return openPeriodicNote(now, folder, format, weeklyTemplateContent())
+}
+
+// Open or create the weekly note for a specific week (identified by
+// its Monday). Used by the sidebar Calendar's new W column — clicking
+// "23" jumps to whichever YYYY-WW week the Monday of that row lives
+// in. Same lookup/create dance as openThisWeekNote but with the date
+// driven by the caller (not "now").
+export function openWeekNote(weekStartDate: Date): string {
+  const settings = useSettingsStore.getState()
+  const folder = weeklyNotesFolder.get()
+  const format = settings.weeklyNoteDateFormat || 'YYYY-WW'
+  return openPeriodicNote(weekStartDate, folder, format, weeklyTemplateContent())
+}
+
+// Pure: look up the existing weekly note id (if any) for the given
+// Monday. Returns the title (always computed) + the note id (or null
+// when no note exists yet). Mirrors findDailyNoteId in CalendarView so
+// the right-click menu can branch on "has note" without an open call.
+export function findWeeklyNoteId(weekStartDate: Date): { id: string | null; title: string } {
+  const settings = useSettingsStore.getState()
+  const format = settings.weeklyNoteDateFormat || 'YYYY-WW'
+  const title = formatDate(weekStartDate, format)
+  const folder = weeklyNotesFolder.get()
+  const segments = folder.split('/')
+  // Find the folder WITHOUT creating it — purely a read. We mimic
+  // ensureFolderPath's traversal but bail on the first missing segment.
+  const folders = useFolderStore.getState().folders
+  let parentId: string | null = null
+  for (const seg of segments) {
+    const found = folders.find(
+      f => !f.isDeleted && f.parentId === parentId && f.name === seg,
+    )
+    if (!found) return { id: null, title }
+    parentId = found.id
+  }
+  const folderId = parentId
+  const note = useNoteStore.getState().notes.find(
+    n => !n.isDeleted && n.folderId === folderId && n.title === title,
+  )
+  return { id: note?.id ?? null, title }
 }
 
 export function openThisMonthNote(now: Date = new Date()): string {


### PR DESCRIPTION
## Summary
Two follow-ups on top of PR #38 (merged earlier today):

1. **Cross-sidebar drag** — unified `TAB_DRAG_MIME` so any panel icon can be dragged left ↔ right. Activity bars dedup across both sides. `TabContextMenu` gains a "Move to other sidebar" row.
2. **ISO week-number column + weekly notes** — calendar gains a "W" left column showing ISO week numbers. Click → opens or creates a weekly note. Right-click → same menu as daily notes (Open / Open in new pane / Copy wikilink / Add to bookmarks / Delete). Settings → Daily & weekly notes for folder + title format + template.

## Test plan
- [ ] Drag the Plugins icon from the LEFT activity bar onto a RIGHT group's mini-strip → Plugins appears as a tab on the right, disappears from left bar
- [ ] Right-click a tab → "Move to other sidebar" → creates a new group on the other side
- [ ] Calendar W column shows 23, 24, 25, 26, 27 for June 2026
- [ ] Click W cell → opens/creates `2026-W23` etc. in the configured weekly folder
- [ ] Right-click W cell → menu reads "Create weekly note" / "Delete weekly note"
- [ ] Settings → Daily & weekly notes shows the new "Weekly notes" section
- [ ] All existing tests stay green (2022 / 2022)