### PR TITLE
style: remove sidebar→editor border + tighten calendar W column

### DIFF
--- a/src/components/sidebar/CalendarView.tsx
+++ b/src/components/sidebar/CalendarView.tsx
@@ -272,9 +272,13 @@ export const CalendarView = () => {
           headers. `[auto_repeat(7,_1fr)]` keeps the W column tight to
           its content while the 7 day columns share the remaining
           width equally — same per-row layout as the day grid below. */}
-      <div className="grid grid-cols-[auto_repeat(7,_1fr)] mb-1">
+      {/* Headers row. The W column gets an explicit 18px width so the
+          7 day columns keep their breathing room. (User feedback
+          2026-06-04: the previous auto-sized W column squeezed the
+          day cells.) */}
+      <div className="grid grid-cols-[18px_repeat(7,_1fr)] mb-1">
         <div
-          className="text-center text-[10px] text-obsidianSecondaryText/60 py-1 pr-1"
+          className="text-center text-[9px] text-obsidianSecondaryText/60 py-1"
           aria-label="ISO week number"
         >
           W
@@ -294,7 +298,7 @@ export const CalendarView = () => {
           start with a leading blank still anchor on the row's first
           REAL day (the Monday derived from that day is always the
           row's ISO-week Monday). */}
-      <div className="grid grid-cols-[auto_repeat(7,_1fr)] gap-y-0.5">
+      <div className="grid grid-cols-[18px_repeat(7,_1fr)] gap-y-0.5">
         {Array.from({ length: Math.ceil(cells.length / 7) }, (_, rowIdx) => {
           const rowStart = rowIdx * 7
           const rowCells = cells.slice(rowStart, rowStart + 7)
@@ -319,7 +323,7 @@ export const CalendarView = () => {
                 <button
                   onClick={() => openWeek(weekMonday)}
                   onContextMenu={(e) => onWeekContextMenu(e, weekMonday)}
-                  className="flex items-center justify-center rounded py-1 pr-1 text-[10px] text-obsidianSecondaryText/70 hover:bg-obsidianHighlight hover:text-obsidianText transition-colors"
+                  className="flex items-center justify-center rounded py-1 text-[9px] text-obsidianSecondaryText/70 hover:bg-obsidianHighlight hover:text-obsidianText transition-colors"
                   data-testid={`calendar-week-${weekMonday.getFullYear()}-W${String(weekNumber).padStart(2, '0')}`}
                   title={`Week ${weekNumber} — open or create weekly note`}
                   aria-label={`Open weekly note for week ${weekNumber}`}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -89,11 +89,11 @@
 /* Components */
 @layer components {
   .obsidian-sidebar {
-    /* Same bg as the Ribbon (obsidianBlack) so the activity bar and
-       the sidebar form one seamless dark surface — no visible "gap"
-       between them. The right border stays as the boundary against
-       the editor. */
-    @apply bg-obsidianBlack border-r border-obsidianBorder h-full overflow-y-auto;
+    /* User feedback 2026-06-04: remove the right border entirely so
+       the sidebar → editor seam is invisible. The SidebarResizeHandle
+       still occupies the 6px gap as the draggable boundary; it stays
+       transparent at rest and tints purple on hover/drag. */
+    @apply bg-obsidianBlack h-full overflow-y-auto;
   }
 
   .obsidian-button {


### PR DESCRIPTION
User feedback 2026-06-04. Two CSS fixes:

- Removed the right border on `.obsidian-sidebar` so there is no visible vertical line between the sidebar and the editor.
- W column in the calendar pinned to 18px (was auto-sized) and font dropped to text-[9px] so the 7 day cells get the horizontal space back.