### PR TITLE
style: drop blue task brackets + preview cursor accents

### DIFF
--- a/src/components/editor/markdownLivePreview.ts
+++ b/src/components/editor/markdownLivePreview.ts
@@ -256,9 +256,15 @@ const livePreviewTheme = EditorView.baseTheme({
     color: '#a8a8a8',
   },
   '.cm-lp-list': { paddingLeft: '4px' },
-  '.cm-lp-list-mark': { color: 'hsl(217, 88%, 50%)', fontWeight: '600' },
-  '.cm-lp-task-unchecked': { color: 'hsl(217, 88%, 50%)', cursor: 'pointer' },
-  '.cm-lp-task-checked':   { color: 'hsl(217, 88%, 50%)', cursor: 'pointer' },
+  // User feedback 2026-06-04: "I don't want a blue line ... neither in
+  // edit nor in preview". When the cursor sits on a task line, live
+  // preview unhides the raw `[ ]` syntax — those blue brackets read
+  // as a stray blue vertical line at the left margin. Repainting these
+  // tokens in the muted secondary-text colour kills the perceived line
+  // while keeping the syntax legible.
+  '.cm-lp-list-mark': { color: 'var(--obsidian-secondary-text)', fontWeight: '600' },
+  '.cm-lp-task-unchecked': { color: 'var(--obsidian-secondary-text)', cursor: 'pointer' },
+  '.cm-lp-task-checked':   { color: 'var(--obsidian-secondary-text)', cursor: 'pointer' },
   '.cm-lp-task-done': { textDecoration: 'line-through', opacity: '0.55' },
   '.cm-lp-tag': {
     color: 'hsl(217, 88%, 50%)',

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -245,9 +245,14 @@
   }
 }
 
-/* Preview mode: cursor indicator + completed-task strikethrough */
+/* Preview mode: cursor indicator + completed-task strikethrough.
+   User feedback 2026-06-04: "I don't want a blue line ... in edit
+   nor in preview". Repainted the cursor block + marker in the muted
+   secondary-text colour so the cursor stays visible in preview mode
+   but the persistent vertical blue bar that was reading as a "line"
+   alongside the active line is gone. */
 .preview-cursor-block {
-  border-left: 3px solid theme('colors.obsidianAccentPurple');
+  border-left: 3px solid theme('colors.obsidianSecondaryText');
   padding-left: 0.75rem;
   margin-left: -0.95rem;
 }
@@ -256,7 +261,7 @@
   display: inline-block;
   width: 2px;
   height: 1.1em;
-  background: theme('colors.obsidianAccentPurple');
+  background: theme('colors.obsidianSecondaryText');
   vertical-align: text-bottom;
   margin: 0 -1px;
   border-radius: 1px;


### PR DESCRIPTION
Jon's screenshot showed the cursor was on a task line. Live preview unhides the raw `[ ]` syntax on the active line, and those brackets were painted in the blue accent (cm-lp-task-unchecked / cm-lp-list-mark). Plus the preview-mode cursor block + marker carried the same accent. Repainted in obsidianSecondaryText.