### PR TITLE
fix(editor): kill cm-activeLineGutter light-blue highlight on cursor line

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -330,7 +330,9 @@
 .cm-editor .cm-scroller,
 .cm-editor .cm-content,
 .cm-editor .cm-line,
-.cm-editor .cm-gutters {
+.cm-editor .cm-gutters,
+.cm-editor .cm-gutterElement,
+.cm-editor .cm-activeLineGutter {
   background-color: transparent !important;
   color: inherit;
   border-right: none !important;


### PR DESCRIPTION
Found via DOM scan: the blue line that returns the moment Jon starts editing is CodeMirror's default `.cm-activeLineGutter` rule painting the active line's 3px gutter cell with rgb(226, 242, 255). Added it to the existing !important override block.