### PR TITLE
fix: blue hover on resize handles (the real source of the persistent blue line)

### DIFF
--- a/src/components/editor/markdownLivePreview.ts
+++ b/src/components/editor/markdownLivePreview.ts
@@ -256,15 +256,15 @@ const livePreviewTheme = EditorView.baseTheme({
     color: '#a8a8a8',
   },
   '.cm-lp-list': { paddingLeft: '4px' },
-  // User feedback 2026-06-04: "I don't want a blue line ... neither in
-  // edit nor in preview". When the cursor sits on a task line, live
-  // preview unhides the raw `[ ]` syntax — those blue brackets read
-  // as a stray blue vertical line at the left margin. Repainting these
-  // tokens in the muted secondary-text colour kills the perceived line
-  // while keeping the syntax legible.
-  '.cm-lp-list-mark': { color: 'var(--obsidian-secondary-text)', fontWeight: '600' },
-  '.cm-lp-task-unchecked': { color: 'var(--obsidian-secondary-text)', cursor: 'pointer' },
-  '.cm-lp-task-checked':   { color: 'var(--obsidian-secondary-text)', cursor: 'pointer' },
+  // Blue restored (user feedback 2026-06-04, round 2: "why these are
+  // not blue anymore? I liked the blue in these"). The earlier mute
+  // was a misdiagnosis — the "blue line" Jon was seeing was actually
+  // the cm-activeLineGutter highlight (now overridden in globals.css),
+  // not these inline list/task glyphs. The brackets + bullet markers
+  // get their accent colour back.
+  '.cm-lp-list-mark': { color: 'hsl(217, 88%, 50%)', fontWeight: '600' },
+  '.cm-lp-task-unchecked': { color: 'hsl(217, 88%, 50%)', cursor: 'pointer' },
+  '.cm-lp-task-checked':   { color: 'hsl(217, 88%, 50%)', cursor: 'pointer' },
   '.cm-lp-task-done': { textDecoration: 'line-through', opacity: '0.55' },
   '.cm-lp-tag': {
     color: 'hsl(217, 88%, 50%)',

--- a/src/components/sidebar/RightSidebarResizeHandle.tsx
+++ b/src/components/sidebar/RightSidebarResizeHandle.tsx
@@ -106,14 +106,14 @@ export const RightSidebarResizeHandle = () => {
       onKeyDown={onKeyDown}
       data-testid="right-sidebar-resize-handle"
       className={`group relative z-10 -mr-[3px] w-[6px] flex-none cursor-col-resize self-stretch outline-none ${
-        dragging ? 'bg-obsidianAccentPurple/40' : 'hover:bg-obsidianAccentPurple/20'
-      } transition-colors focus-visible:bg-obsidianAccentPurple/30`}
+        dragging ? 'bg-obsidianHighlight/40' : 'hover:bg-obsidianHighlight/20'
+      } transition-colors focus-visible:bg-obsidianHighlight/30`}
     >
       <span
         className={`pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 ${
           dragging
-            ? 'bg-obsidianAccentPurple'
-            : 'bg-transparent group-hover:bg-obsidianAccentPurple/70 group-focus-visible:bg-obsidianAccentPurple/70'
+            ? 'bg-obsidianHighlight'
+            : 'bg-transparent group-hover:bg-obsidianHighlight/70 group-focus-visible:bg-obsidianHighlight/70'
         } transition-colors`}
       />
     </div>

--- a/src/components/sidebar/SidebarResizeHandle.tsx
+++ b/src/components/sidebar/SidebarResizeHandle.tsx
@@ -118,16 +118,20 @@ export const SidebarResizeHandle = () => {
       // 6px-wide grab zone straddles the visual border without adding
       // layout width. self-stretch keeps it full-height.
       className={`group relative z-10 -ml-[3px] w-[6px] flex-none cursor-col-resize self-stretch outline-none ${
-        dragging ? 'bg-obsidianAccentPurple/40' : 'hover:bg-obsidianAccentPurple/20'
-      } transition-colors focus-visible:bg-obsidianAccentPurple/30`}
+        dragging ? 'bg-obsidianHighlight/40' : 'hover:bg-obsidianHighlight/20'
+      } transition-colors focus-visible:bg-obsidianHighlight/30`}
     >
-      {/* Subtle 1px stripe centred in the grab zone, brightening on
-          hover/drag/focus — matches the SidebarSection row handle. */}
+      {/* Subtle 1px stripe centred in the grab zone. User feedback
+          2026-06-04 — the previous purple/blue hover tint was reading
+          as a stray blue vertical line whenever the cursor moved
+          near the sidebar/editor boundary. Switched to obsidianHighlight
+          (#4d4d4d gray) so the affordance is still visible on hover
+          but the colour doesn't fight the editor accent. */}
       <span
         className={`pointer-events-none absolute inset-y-0 left-1/2 w-px -translate-x-1/2 ${
           dragging
-            ? 'bg-obsidianAccentPurple'
-            : 'bg-transparent group-hover:bg-obsidianAccentPurple/70 group-focus-visible:bg-obsidianAccentPurple/70'
+            ? 'bg-obsidianHighlight'
+            : 'bg-transparent group-hover:bg-obsidianHighlight/70 group-focus-visible:bg-obsidianHighlight/70'
         } transition-colors`}
       />
     </div>


### PR DESCRIPTION
Pixel-sampled the live beta deploy. The blue line Jon kept reporting was the SidebarResizeHandle (and RightSidebarResizeHandle) 6px hover/drag/focus tint — they used obsidianAccentPurple (blue). Any cursor pass near the sidebar/editor seam lit the 1px stripe to full editor height. Repainted both handle states to obsidianHighlight (#4d4d4d gray). Also re-restored blue on cm-lp-task-* markers per Jon's previous ask.