### PR TITLE
fix: nested checkbox strikethrough + explicit CodeMirror drawSelection

### DIFF
--- a/src/__tests__/codeMirrorDrawSelection.test.ts
+++ b/src/__tests__/codeMirrorDrawSelection.test.ts
@@ -1,0 +1,44 @@
+/**
+ * codeMirrorDrawSelection.test.ts
+ *
+ * Static-source regression check: `drawSelection()` MUST be imported and
+ * applied inside CodeMirrorEditor.tsx.
+ *
+ * Background: the editor's selection background is painted by CodeMirror's
+ * `drawSelection()` plugin into a `.cm-selectionBackground` layer; our
+ * obsidianTheme (`backgroundColor: var(--obsidian-highlight)`) styles that
+ * layer. Without the plugin, the editor falls back to the native `::selection`
+ * pseudo-element on contenteditable. On past builds this combination produced
+ * a near-invisible selection — same near-white text on the default light
+ * background that CodeMirror's built-in theme paints.
+ *
+ * The fix made `drawSelection()` explicit in the extensions array (no longer
+ * relying on @uiw/react-codemirror's basicSetup defaults). This test pins the
+ * arrangement so a future contributor refactoring the extensions list cannot
+ * silently drop it again. We test at the source-text level rather than mount
+ * a CodeMirror view because jsdom does not faithfully render the
+ * `.cm-selectionLayer` (no useful runtime assertion is possible without a
+ * real browser).
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const FILE = join(__dirname, '..', 'components', 'editor', 'CodeMirrorEditor.tsx')
+const SRC = readFileSync(FILE, 'utf8')
+
+describe('CodeMirrorEditor drawSelection wiring', () => {
+  test('imports drawSelection from @codemirror/view', () => {
+    // Match any named-import list from @codemirror/view that contains drawSelection.
+    const importMatch = SRC.match(
+      /import\s*\{[^}]*\bdrawSelection\b[^}]*\}\s*from\s*['"]@codemirror\/view['"]/,
+    )
+    expect(importMatch).not.toBeNull()
+  })
+
+  test('applies drawSelection() inside the extensions array', () => {
+    // Call form — drawSelection() must be invoked (not just imported) so its
+    // Extension lands in the array. Allow whitespace inside the parens.
+    expect(SRC).toMatch(/drawSelection\s*\(\s*\)/)
+  })
+})

--- a/src/__tests__/previewTaskDone.test.tsx
+++ b/src/__tests__/previewTaskDone.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * previewTaskDone.test.tsx
+ *
+ * Reading-mode nested-task strikethrough regression.
+ *
+ * Earlier behaviour put `text-decoration: line-through` on the outer `<li>`,
+ * which painted the strike line across every descendant text — including a
+ * nested UNDONE sub-task — even when the descendant set
+ * `text-decoration: none` (modern browsers still draw the ancestor's strike
+ * across the descendant's box). The fix splits the done item's React children
+ * into its OWN content and any nested <ul>/<ol> sublists, wrapping only the
+ * own content in a `.preview-task-done-line` span sibling of the nested list.
+ * `splitTaskDoneChildren` is the pure helper that does the split — testing it
+ * directly avoids pulling react-markdown (ESM) into Jest.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+import { splitTaskDoneChildren } from '../utils/previewTaskDoneSplit'
+
+describe('splitTaskDoneChildren', () => {
+  test('text-only children land in ownContent; no nested lists', () => {
+    const { ownContent, nestedLists } = splitTaskDoneChildren(['hello world'])
+    expect(ownContent).toHaveLength(1)
+    expect(nestedLists).toHaveLength(0)
+  })
+
+  test('separates a nested <ul> from text content', () => {
+    const children = [
+      'parent text',
+      <ul key="ul"><li key="li">child</li></ul>,
+    ]
+    const { ownContent, nestedLists } = splitTaskDoneChildren(children)
+    expect(ownContent).toHaveLength(1)
+    expect(nestedLists).toHaveLength(1)
+  })
+
+  test('separates a nested <ol> from inline elements', () => {
+    const children = [
+      <input key="cb" type="checkbox" />,
+      ' done thing ',
+      <ol key="ol"><li key="li">step 1</li></ol>,
+    ]
+    const { ownContent, nestedLists } = splitTaskDoneChildren(children)
+    expect(ownContent).toHaveLength(2)
+    expect(nestedLists).toHaveLength(1)
+  })
+
+  test('keeps non-list elements (<p>, <a>, <span>) in ownContent', () => {
+    const children = [
+      <p key="p">para</p>,
+      <a key="a" href="#">link</a>,
+      <span key="s">span</span>,
+    ]
+    const { ownContent, nestedLists } = splitTaskDoneChildren(children)
+    expect(ownContent).toHaveLength(3)
+    expect(nestedLists).toHaveLength(0)
+  })
+})
+
+describe('reading-mode nested-task strikethrough — rendered structure', () => {
+  // End-to-end DOM check: rebuild the EXACT JSX the EditorContent ListItem
+  // emits for a done item, then assert the structural invariant the fix
+  // relies on — `.preview-task-done-line` is a SIBLING of the nested <ul>,
+  // never an ancestor of it. That sibling boundary is what stops the
+  // strike line from being painted across the nested rows.
+
+  const renderDoneLi = (children: React.ReactNode) => {
+    const { ownContent, nestedLists } = splitTaskDoneChildren(children)
+    return render(
+      <ul>
+        <li className="task-list-item preview-task-done">
+          <span className="preview-task-done-line">{ownContent}</span>
+          {nestedLists}
+        </li>
+      </ul>,
+    )
+  }
+
+  test('done item with no children has an empty .preview-task-done-line span', () => {
+    const { container } = renderDoneLi([])
+    const span = container.querySelector('.preview-task-done-line')
+    expect(span).not.toBeNull()
+    expect(span!.textContent).toBe('')
+  })
+
+  test('nested <ul> renders OUTSIDE the .preview-task-done-line span', () => {
+    const children = [
+      <input key="cb" type="checkbox" defaultChecked readOnly />,
+      ' Parent done',
+      <ul key="ul">
+        <li key="c1" className="task-list-item">
+          <input type="checkbox" readOnly /> Child todo
+        </li>
+      </ul>,
+    ]
+    const { container } = renderDoneLi(children)
+    const outerLi = container.querySelector('li.preview-task-done')!
+    const span = outerLi.querySelector(':scope > .preview-task-done-line')!
+    const nestedUl = outerLi.querySelector(':scope > ul')!
+    expect(span).not.toBeNull()
+    expect(nestedUl).not.toBeNull()
+    // The structural invariant: <ul> is a sibling of the span, NOT a descendant.
+    expect(span.querySelector('ul')).toBeNull()
+    // And the span carries the strike class.
+    expect(span.classList.contains('preview-task-done-line')).toBe(true)
+  })
+
+  test('nested <ol> also lands outside the strike span (numbered sub-lists)', () => {
+    const children = [
+      'Done ',
+      <ol key="ol"><li key="i">step</li></ol>,
+    ]
+    const { container } = renderDoneLi(children)
+    const span = container.querySelector('.preview-task-done-line')!
+    expect(span.querySelector('ol')).toBeNull()
+    const sibling = span.nextElementSibling
+    expect(sibling?.tagName).toBe('OL')
+  })
+})

--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror'
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown'
-import { EditorView, keymap, type Command } from '@codemirror/view'
+import { EditorView, keymap, drawSelection, type Command } from '@codemirror/view'
 import { Prec, Compartment } from '@codemirror/state'
 import { moveLineUp, moveLineDown, deleteLine } from '@codemirror/commands'
 import { search, searchKeymap, openSearchPanel } from '@codemirror/search'
@@ -639,6 +639,13 @@ export function CodeMirrorEditor({
     ])),
     obsidianTheme,
     EditorView.lineWrapping,
+    // Explicit drawSelection() so the .cm-selectionBackground layer is
+    // guaranteed to render regardless of basicSetup defaults. We already paint
+    // that layer with var(--obsidian-highlight) (see obsidianTheme above), and
+    // globals.css carries a `::selection` fallback for the native path —
+    // belt-and-suspenders so a future @uiw basicSetup change that drops
+    // drawSelection() from defaults can't leave the selection invisible again.
+    drawSelection(),
     renumberOnEdit,
     // Prec.highest ensures our bindings win over any conflicting default keymap.
     Prec.highest(keymap.of([

--- a/src/components/editor/EditorContent.tsx
+++ b/src/components/editor/EditorContent.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef, useCallback, createElement } from 'react'
+import React, { useState, useEffect, useRef, useCallback, createElement } from 'react'
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import dynamic from 'next/dynamic'
@@ -24,6 +24,7 @@ import { resolveAttachmentPath } from '@/utils/attachments'
 import { findNoteByTitleOrAlias } from '@/utils/aliases'
 import { toggleTaskLineText, removeTaskPrefixFromLine } from '@/utils/tasks'
 import { isTaskItemDone, type HastNode } from '@/utils/taskListItem'
+import { splitTaskDoneChildren } from '@/utils/previewTaskDoneSplit'
 import { SCROLL_TO_LINE_EVENT } from '@/utils/events'
 import { CodeMirrorEditor } from './CodeMirrorEditor'
 import { FrontmatterPanel } from './FrontmatterPanel'
@@ -517,6 +518,24 @@ export const EditorContent = ({ note, isPreviewMode, onContentChange }: EditorCo
       isCursorBlock(node) ? 'preview-cursor-block' : '',
       isChecked ? 'preview-task-done' : '',
     ].filter(Boolean).join(' ')
+    // For a DONE task we split children into (a) the item's own content and
+    // (b) any nested <ul>/<ol> sub-lists. The own content is wrapped in a
+    // `.preview-task-done-line` span that carries the line-through; the
+    // nested sub-list sits OUTSIDE the span so the strike line does not get
+    // painted through its descendant text — even when a descendant <li> sets
+    // text-decoration: none, modern browsers still paint the ancestor's
+    // strike line across the descendant's box (the bug the older
+    // descendant-reset CSS rules could not fix). Sibling-relationship is the
+    // only reliable separator.
+    if (isChecked) {
+      const { ownContent, nestedLists } = splitTaskDoneChildren(children)
+      return (
+        <li className={cls || undefined} {...rest}>
+          <span className="preview-task-done-line">{ownContent}</span>
+          {nestedLists}
+        </li>
+      )
+    }
     return <li className={cls || undefined} {...rest}>{children}</li>
   }
   ListItem.displayName = 'MdListItem'

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -275,37 +275,21 @@
 
 /* Completed task (`- [x]`) — strike through the item's own content (links,
    bold, text inside a wrapping <p>) at any nesting depth, WITHOUT bleeding the
-   strike onto its nested sub-tasks. A blanket `.preview-task-done *` would also
-   strike every descendant list item, so an UN-done subtask under a done parent
-   would wrongly look complete. Instead we:
-     1. strike the item's own non-list children (and their inline content), but
-        never descend into a nested <ul>/<ol>;
-     2. reset decoration inside any nested list at any depth, so each child
-        decides for itself;
-     3. re-apply the strike to nested items that carry the done class.
-   The checkbox input is always kept readable. */
-.preview-task-done {
+   strike onto its nested sub-tasks.
+   ListItem in EditorContent.tsx wraps the done item's own (non-list) children
+   in a `.preview-task-done-line` span and keeps any nested <ul>/<ol> as a
+   sibling of that span. We therefore decorate the SPAN only — never the outer
+   <li> — so the line-through never paints across nested rows. Older versions
+   put text-decoration on `.preview-task-done` itself, but browsers still draw
+   the ancestor's strike across descendant text even when the descendant sets
+   `text-decoration: none`, so an UN-done child under a done parent looked
+   completed. The span sibling boundary is the only reliable fix. The checkbox
+   input is kept readable. */
+.preview-task-done-line {
   text-decoration: line-through;
   opacity: 0.55;
 }
-.preview-task-done > :not(ul):not(ol),
-.preview-task-done > :not(ul):not(ol) * {
-  text-decoration: line-through;
-  opacity: 0.55;
-}
-.preview-task-done ul,
-.preview-task-done ol,
-.preview-task-done :is(ul, ol) * {
-  text-decoration: none;
-  opacity: 1;
-}
-.preview-task-done .preview-task-done,
-.preview-task-done .preview-task-done > :not(ul):not(ol),
-.preview-task-done .preview-task-done > :not(ul):not(ol) * {
-  text-decoration: line-through;
-  opacity: 0.55;
-}
-.preview-task-done input[type='checkbox'] {
+.preview-task-done-line input[type='checkbox'] {
   text-decoration: none;
   opacity: 1;
 }

--- a/src/utils/previewTaskDoneSplit.tsx
+++ b/src/utils/previewTaskDoneSplit.tsx
@@ -1,0 +1,45 @@
+/**
+ * previewTaskDoneSplit.tsx
+ *
+ * Helper for the reading-mode ListItem renderer (see
+ * `src/components/editor/EditorContent.tsx`). When a task item is DONE we want
+ * a line-through on its OWN content but never on its nested sub-lists. Older
+ * CSS tried to "reset" text-decoration on descendants — modern browsers still
+ * paint the ancestor's strike across the descendant's box, so an UN-done
+ * subtask under a done parent wrongly LOOKED struck.
+ *
+ * The fix is structural: split the React children into (a) own content and
+ * (b) nested <ul>/<ol>, then render only (a) inside a
+ * `.preview-task-done-line` span sibling. The strike line cannot cross into
+ * a sibling element's box. This module exports the splitter so tests can
+ * assert the split (rather than going through react-markdown, which is ESM
+ * and not transformed by our Jest setup).
+ */
+
+import React, { Children, isValidElement } from 'react'
+
+export interface TaskDoneSplit {
+  ownContent: React.ReactNode[]
+  nestedLists: React.ReactNode[]
+}
+
+/**
+ * Walk React children once, fanning out into two arrays:
+ *   - `nestedLists`: child elements whose `type === 'ul' || 'ol'`
+ *   - `ownContent`: everything else (text, <input>, <p>, <a>, …)
+ *
+ * Both arrays preserve order; React Fragments are inserted with stable keys so
+ * downstream renders don't re-mount the children.
+ */
+export function splitTaskDoneChildren(children: React.ReactNode): TaskDoneSplit {
+  const ownContent: React.ReactNode[] = []
+  const nestedLists: React.ReactNode[] = []
+  Children.forEach(children, (child, idx) => {
+    if (isValidElement(child) && (child.type === 'ul' || child.type === 'ol')) {
+      nestedLists.push(<React.Fragment key={`nl-${idx}`}>{child}</React.Fragment>)
+    } else {
+      ownContent.push(<React.Fragment key={`oc-${idx}`}>{child}</React.Fragment>)
+    }
+  })
+  return { ownContent, nestedLists }
+}


### PR DESCRIPTION
## Summary

Two small UX fixes off the latest dev:

- **Reading-mode strikethrough no longer bleeds onto nested undone tasks.** Older CSS put text-decoration: line-through on the outer done <li>; even when nested descendants set text-decoration: none, modern browsers still painted the ancestor's strike line across the descendant's box, so an undone child under a done parent looked completed. The ListItem renderer now splits a done item's React children into its own content and any nested <ul>/<ol> sub-lists, wrapping only the own content in a `.preview-task-done-line` span sibling of the nested list. Sibling boundary stops the strike at the span's box edge.
- **drawSelection() is now an explicit extension** in CodeMirrorEditor (not just inherited from @uiw basicSetup defaults), so the `.cm-selectionBackground` layer obsidianTheme paints with var(--obsidian-highlight) is guaranteed to render. The current `::selection` fallback in globals.css stays as a safety net for the native path.

## Files changed

- `src/components/editor/EditorContent.tsx` — split done item's children; wrap own content in `.preview-task-done-line` span
- `src/utils/previewTaskDoneSplit.tsx` — pure helper for the children split (so it is testable without pulling react-markdown into Jest)
- `src/styles/globals.css` — replace ancestor-decorate + descendant-reset hack with single `.preview-task-done-line { text-decoration: line-through }`
- `src/components/editor/CodeMirrorEditor.tsx` — import + call `drawSelection()` explicitly
- `src/__tests__/previewTaskDone.test.tsx` — 7 new tests asserting the split + sibling structure
- `src/__tests__/codeMirrorDrawSelection.test.ts` — 2 source-text regression checks for the import and call site

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (zero warnings)
- [x] `npm test` — 2031 passing (was 2022; +9 new tests)
- [x] `npm run build`
- [x] Playwright sanity sweep at 1280x800 — captured screenshots for live-preview, reading mode, and selection visibility

## Screenshots

- `/tmp/sidebar-preview/v16-nested-strikethrough.png` — reading mode: every done line struck through, undone children clean
- `/tmp/sidebar-preview/v16-nested-strikethrough-livepreview.png` — live preview: same pattern in the editor
- `/tmp/sidebar-preview/v16-selection-visible.png` — programmatic selection in the editor renders with `obsidianHighlight` background, white text on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)