### PR TITLE
feat(plugins): manifest-preview modal with capability prose (#43)

### DIFF
--- a/src/__tests__/plugins/manifest.test.ts
+++ b/src/__tests__/plugins/manifest.test.ts
@@ -118,4 +118,48 @@ describe('validateManifest', () => {
     })
     expect(r.ok).toBe(false)
   })
+
+  test('accepts an optional description and surfaces it on the normalised manifest', () => {
+    const r = validateManifest({
+      ...goodManifest,
+      description: 'Counts words in the active note.',
+    })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.description).toBe('Counts words in the active note.')
+  })
+
+  test('rejects an oversize description', () => {
+    const r = validateManifest({
+      ...goodManifest,
+      description: 'x'.repeat(500),
+    })
+    expect(r.ok).toBe(false)
+    expect(r.errors.some((e) => e.toLowerCase().includes('description'))).toBe(true)
+  })
+
+  test('accepts an https homepage URL', () => {
+    const r = validateManifest({
+      ...goodManifest,
+      homepage: 'https://example.com/word-count',
+    })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.homepage).toBe('https://example.com/word-count')
+  })
+
+  test('rejects a non-https homepage', () => {
+    const r = validateManifest({
+      ...goodManifest,
+      homepage: 'javascript:alert(1)',
+    })
+    expect(r.ok).toBe(false)
+    expect(r.errors.some((e) => e.toLowerCase().includes('homepage'))).toBe(true)
+  })
+
+  test('accepts http://localhost as a homepage for dev', () => {
+    const r = validateManifest({
+      ...goodManifest,
+      homepage: 'http://localhost:3001/plugin',
+    })
+    expect(r.ok).toBe(true)
+  })
 })

--- a/src/__tests__/plugins/pluginInstallConfirmModal.test.tsx
+++ b/src/__tests__/plugins/pluginInstallConfirmModal.test.tsx
@@ -1,0 +1,264 @@
+/**
+ * pluginInstallConfirmModal.test.tsx
+ *
+ * Verifies the manifest-preview modal:
+ *   - Loading state while the manifest is fetched
+ *   - Preview state shows name/version/author/description/homepage +
+ *     the capability list (surfaces + permissions) with prose
+ *   - Install button calls confirmAndInstallPlugin and closes the modal
+ *   - Cancel button closes without installing
+ *   - Fetch / validation errors render inside the modal shell
+ *   - Pre-fetched record path (legacy entry shape) renders directly
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+  keys: jest.fn().mockResolvedValue([]),
+}))
+
+const mockFetchPluginForInstall = jest.fn()
+const mockConfirmAndInstallPlugin = jest.fn()
+jest.mock('../../plugins/pluginHostSingleton', () => ({
+  fetchPluginForInstall: (...args: unknown[]) => mockFetchPluginForInstall(...args),
+  confirmAndInstallPlugin: (...args: unknown[]) => mockConfirmAndInstallPlugin(...args),
+}))
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { PluginInstallConfirmModal } from '../../components/modals/PluginInstallConfirmModal'
+import { useUIStore } from '../../stores/uiStore'
+import type { InstalledPluginRecord } from '../../stores/pluginInstallStore'
+import {
+  PERMISSION_DESCRIPTIONS,
+  SURFACE_DESCRIPTIONS,
+} from '../../plugins/manifest'
+
+const baseManifest = {
+  id: 'word-count',
+  name: 'Word count',
+  version: '1.2.3',
+  author: 'jane@example.com',
+  description: 'Counts words in the active note and shows the total in a sidebar panel.',
+  homepage: 'https://example.com/word-count',
+  surfaces: {
+    commands: [{ id: 'show', title: 'Word count: show' }],
+    sidebarPanels: [{ id: 'panel', title: 'Word count' }],
+  },
+}
+
+function makeRecord(overrides: Partial<InstalledPluginRecord> = {}): InstalledPluginRecord {
+  return {
+    manifest: baseManifest,
+    mainSource: 'export default {}',
+    hash: 'abc',
+    sourceUrl: 'https://example.com/word-count/manifest.json',
+    addedAt: 1000,
+    enabled: true,
+    ...overrides,
+  }
+}
+
+function openWithUrl(manifestUrl = 'https://example.com/p/manifest.json') {
+  useUIStore.setState({
+    modal: { type: 'plugin-install-confirm', data: { manifestUrl } },
+  })
+}
+
+function openWithRecord(record: InstalledPluginRecord) {
+  useUIStore.setState({
+    modal: { type: 'plugin-install-confirm', data: { record } },
+  })
+}
+
+beforeEach(() => {
+  mockFetchPluginForInstall.mockReset()
+  mockConfirmAndInstallPlugin.mockReset()
+  useUIStore.setState({ modal: { type: null } })
+})
+
+describe('PluginInstallConfirmModal — closed', () => {
+  test('renders nothing when modal type is not plugin-install-confirm', () => {
+    useUIStore.setState({ modal: { type: null } })
+    const { container } = render(<PluginInstallConfirmModal />)
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('PluginInstallConfirmModal — URL flow', () => {
+  test('shows the loading state while the manifest is being fetched', async () => {
+    let resolveFetch: (record: InstalledPluginRecord) => void = () => {}
+    mockFetchPluginForInstall.mockImplementation(
+      () => new Promise<InstalledPluginRecord>((resolve) => { resolveFetch = resolve }),
+    )
+    openWithUrl()
+    render(<PluginInstallConfirmModal />)
+    expect(screen.getByTestId('plugin-preview-loading')).toBeInTheDocument()
+
+    // Resolve so the test's outer promise queue drains cleanly.
+    resolveFetch(makeRecord())
+    await waitFor(() => expect(screen.getByTestId('plugin-preview-body')).toBeInTheDocument())
+  })
+
+  test('renders the preview body with name, version, author, description and homepage link', async () => {
+    mockFetchPluginForInstall.mockResolvedValueOnce(makeRecord())
+    openWithUrl()
+    render(<PluginInstallConfirmModal />)
+
+    const body = await screen.findByTestId('plugin-preview-body')
+    expect(body).toBeInTheDocument()
+    expect(screen.getByText('Word count')).toBeInTheDocument()
+    expect(screen.getByText('v1.2.3')).toBeInTheDocument()
+    expect(screen.getByText(/jane@example.com/)).toBeInTheDocument()
+    expect(screen.getByTestId('plugin-preview-description')).toHaveTextContent(
+      /Counts words in the active note/,
+    )
+    const link = screen.getByTestId('plugin-preview-homepage') as HTMLAnchorElement
+    expect(link.href).toBe('https://example.com/word-count')
+    expect(link.target).toBe('_blank')
+    expect(link.rel).toContain('noopener')
+  })
+
+  test('lists each declared capability with a human-readable description', async () => {
+    mockFetchPluginForInstall.mockResolvedValueOnce(
+      makeRecord({
+        manifest: {
+          ...baseManifest,
+          surfaces: {
+            commands: [{ id: 'a', title: 'A' }, { id: 'b', title: 'B' }],
+            sidebarPanels: [{ id: 'p', title: 'P' }],
+            codeBlockRenderers: [{ language: 'mermaid' }],
+          },
+          permissions: ['file-save', 'file-open'],
+        },
+      }),
+    )
+    openWithUrl()
+    render(<PluginInstallConfirmModal />)
+    await screen.findByTestId('plugin-preview-body')
+
+    // Surface rows
+    expect(screen.getByTestId('plugin-preview-capability-commands')).toHaveTextContent('2 commands')
+    expect(screen.getByTestId('plugin-preview-capability-commands')).toHaveTextContent(
+      SURFACE_DESCRIPTIONS.commands,
+    )
+    expect(screen.getByTestId('plugin-preview-capability-sidebarPanels')).toHaveTextContent('1 sidebar panel')
+    expect(screen.getByTestId('plugin-preview-capability-sidebarPanels')).toHaveTextContent(
+      SURFACE_DESCRIPTIONS.sidebarPanels,
+    )
+    expect(screen.getByTestId('plugin-preview-capability-codeBlockRenderers')).toHaveTextContent('mermaid')
+    expect(screen.getByTestId('plugin-preview-capability-codeBlockRenderers')).toHaveTextContent(
+      SURFACE_DESCRIPTIONS.codeBlockRenderers,
+    )
+
+    // Permission rows
+    expect(screen.getByTestId('plugin-preview-capability-file-save')).toHaveTextContent('file-save')
+    expect(screen.getByTestId('plugin-preview-capability-file-save')).toHaveTextContent(
+      PERMISSION_DESCRIPTIONS['file-save'],
+    )
+    expect(screen.getByTestId('plugin-preview-capability-file-open')).toHaveTextContent('file-open')
+    expect(screen.getByTestId('plugin-preview-capability-file-open')).toHaveTextContent(
+      PERMISSION_DESCRIPTIONS['file-open'],
+    )
+  })
+
+  test('shows the empty-capabilities reassurance when there are no surfaces beyond a single command and no permissions', async () => {
+    mockFetchPluginForInstall.mockResolvedValueOnce(
+      makeRecord({
+        manifest: {
+          id: 'minimal',
+          name: 'Minimal',
+          version: '1.0.0',
+          surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+        },
+      }),
+    )
+    openWithUrl()
+    render(<PluginInstallConfirmModal />)
+    await screen.findByTestId('plugin-preview-body')
+
+    // One command → capability row present.
+    expect(screen.getByTestId('plugin-preview-capability-commands')).toBeInTheDocument()
+    // No permission rows.
+    expect(screen.queryByTestId('plugin-preview-capability-file-save')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('plugin-preview-capability-file-open')).not.toBeInTheDocument()
+  })
+
+  test('renders an error state inline when fetch / validation fails', async () => {
+    mockFetchPluginForInstall.mockRejectedValueOnce(
+      new Error('Plugin manifest failed validation:\n  - bad id'),
+    )
+    openWithUrl()
+    render(<PluginInstallConfirmModal />)
+
+    const err = await screen.findByTestId('plugin-preview-error')
+    expect(err).toHaveTextContent(/Could not load this plugin/i)
+    expect(err).toHaveTextContent(/bad id/)
+    // No install button on the error state.
+    expect(screen.queryByTestId('plugin-install-confirm')).not.toBeInTheDocument()
+    // Close button is available — the inline footer "Close" inside the
+    // error pane. (The header X also has an aria-label "Close modal",
+    // so we anchor on visible text inside the error footer.)
+    const closeBtn = Array.from(err.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'Close',
+    )
+    expect(closeBtn).toBeTruthy()
+  })
+
+  test('Install button calls confirmAndInstallPlugin then closes the modal', async () => {
+    const record = makeRecord()
+    mockFetchPluginForInstall.mockResolvedValueOnce(record)
+    mockConfirmAndInstallPlugin.mockResolvedValueOnce(undefined)
+    openWithUrl()
+    const user = userEvent.setup()
+    render(<PluginInstallConfirmModal />)
+
+    await screen.findByTestId('plugin-preview-body')
+    await user.click(screen.getByTestId('plugin-install-confirm'))
+
+    await waitFor(() => expect(mockConfirmAndInstallPlugin).toHaveBeenCalledTimes(1))
+    expect(mockConfirmAndInstallPlugin.mock.calls[0][0]).toBe(record)
+    await waitFor(() => expect(useUIStore.getState().modal.type).toBeNull())
+  })
+
+  test('install failure stays on the preview and surfaces the error inline', async () => {
+    mockFetchPluginForInstall.mockResolvedValueOnce(makeRecord())
+    mockConfirmAndInstallPlugin.mockRejectedValueOnce(new Error('worker boot failed'))
+    openWithUrl()
+    const user = userEvent.setup()
+    render(<PluginInstallConfirmModal />)
+
+    await screen.findByTestId('plugin-preview-body')
+    await user.click(screen.getByTestId('plugin-install-confirm'))
+
+    await waitFor(() => expect(screen.getByText('worker boot failed')).toBeInTheDocument())
+    // Modal still open.
+    expect(useUIStore.getState().modal.type).toBe('plugin-install-confirm')
+  })
+
+  test('Cancel button closes the modal without calling install', async () => {
+    mockFetchPluginForInstall.mockResolvedValueOnce(makeRecord())
+    openWithUrl()
+    const user = userEvent.setup()
+    render(<PluginInstallConfirmModal />)
+
+    await screen.findByTestId('plugin-preview-body')
+    await user.click(screen.getByTestId('plugin-install-cancel'))
+
+    expect(mockConfirmAndInstallPlugin).not.toHaveBeenCalled()
+    await waitFor(() => expect(useUIStore.getState().modal.type).toBeNull())
+  })
+})
+
+describe('PluginInstallConfirmModal — pre-fetched record path', () => {
+  test('renders the preview body directly without calling fetchPluginForInstall', async () => {
+    openWithRecord(makeRecord())
+    render(<PluginInstallConfirmModal />)
+    expect(screen.getByTestId('plugin-preview-body')).toBeInTheDocument()
+    expect(mockFetchPluginForInstall).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/modals/PluginInstallConfirmModal.tsx
+++ b/src/components/modals/PluginInstallConfirmModal.tsx
@@ -1,136 +1,310 @@
 'use client'
 
-// Confirmation modal for installing a plugin from a manifest URL.
-// Shown after the manifest + bundle have been fetched and validated,
-// before they are persisted or the worker is booted.
+// Manifest-preview modal for the plugin install flow.
 //
-// Surfaces:
-//   - Plugin id, name, version, author
-//   - Source URL the bundle was fetched from
-//   - Surfaces declared (commands, panels, code-block renderers)
-//   - Capability PERMISSIONS the plugin asks for, with the
-//     human-readable description from PERMISSION_DESCRIPTIONS
-//   - Install / Cancel buttons
+// Two entry shapes via modal.data:
+//   { manifestUrl: string }           — modal fetches + validates inline
+//   { record: InstalledPluginRecord } — modal renders a pre-fetched record
 //
-// The user grants ALL declared permissions or none — v1.1 keeps this
-// coarse-grained to match Apple/Android app-install ergonomics. v2
-// may add per-permission toggles if the use case warrants.
+// Three render states share the same modal shell so a failed fetch /
+// invalid manifest surfaces inline instead of silently bouncing back to
+// the Plugins panel:
+//   - loading: spinner while fetching/validating
+//   - error:   the error message, Close button only
+//   - preview: name, version, author, description, homepage,
+//              capabilities (surfaces + permissions) with prose,
+//              Install / Cancel buttons
+//
+// Capability prose comes from SURFACE_DESCRIPTIONS / PERMISSION_DESCRIPTIONS
+// in src/plugins/manifest.ts — do not invent new strings here.
 
-import { useState } from 'react'
-import { CheckCircleIcon, ShieldCheckIcon } from '@heroicons/react/24/outline'
+import { useEffect, useRef, useState } from 'react'
+import { CheckCircleIcon, ShieldCheckIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { Modal, Button } from '@/components/ui'
 import { useUIStore } from '@/stores'
-import { confirmAndInstallPlugin } from '@/plugins/pluginHostSingleton'
-import { PERMISSION_DESCRIPTIONS, type PluginPermission } from '@/plugins/manifest'
+import {
+  confirmAndInstallPlugin,
+  fetchPluginForInstall,
+} from '@/plugins/pluginHostSingleton'
+import {
+  PERMISSION_DESCRIPTIONS,
+  SURFACE_DESCRIPTIONS,
+  type PluginPermission,
+  type PluginSurfaceKind,
+} from '@/plugins/manifest'
 import type { InstalledPluginRecord } from '@/stores/pluginInstallStore'
+
+type PreviewState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'preview'; record: InstalledPluginRecord }
+
+interface CapabilityRow {
+  key: string
+  label: string
+  description: string
+}
 
 export const PluginInstallConfirmModal = () => {
   const { modal, closeModal } = useUIStore()
   const isOpen = modal.type === 'plugin-install-confirm'
-  const record = (modal.data?.record as InstalledPluginRecord | undefined) ?? null
+  const data = modal.data ?? {}
+  const initialRecord = (data.record as InstalledPluginRecord | undefined) ?? null
+  const manifestUrl = typeof data.manifestUrl === 'string' ? data.manifestUrl : null
 
+  const [state, setState] = useState<PreviewState>(() =>
+    initialRecord
+      ? { status: 'preview', record: initialRecord }
+      : manifestUrl
+        ? { status: 'loading' }
+        : { status: 'error', message: 'No plugin URL or manifest provided.' },
+  )
   const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [installError, setInstallError] = useState<string | null>(null)
+  const fetchKeyRef = useRef<string | null>(null)
 
-  if (!isOpen || !record) return null
+  useEffect(() => {
+    if (!isOpen) {
+      fetchKeyRef.current = null
+      setBusy(false)
+      setInstallError(null)
+      return
+    }
+    if (initialRecord) {
+      setState({ status: 'preview', record: initialRecord })
+      return
+    }
+    if (!manifestUrl) {
+      setState({ status: 'error', message: 'No plugin URL or manifest provided.' })
+      return
+    }
+    if (fetchKeyRef.current === manifestUrl) return
+    fetchKeyRef.current = manifestUrl
+    setState({ status: 'loading' })
+    let cancelled = false
+    void (async () => {
+      try {
+        const record = await fetchPluginForInstall(manifestUrl)
+        if (cancelled) return
+        setState({ status: 'preview', record })
+      } catch (err) {
+        if (cancelled) return
+        setState({
+          status: 'error',
+          message: err instanceof Error ? err.message : String(err),
+        })
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, manifestUrl, initialRecord])
 
-  const { manifest } = record
-  const surfaces = manifest.surfaces
-  const surfaceLines: string[] = []
-  if (surfaces.commands && surfaces.commands.length > 0) {
-    surfaceLines.push(`${surfaces.commands.length} command(s) in the palette`)
-  }
-  if (surfaces.sidebarPanels && surfaces.sidebarPanels.length > 0) {
-    surfaceLines.push(`${surfaces.sidebarPanels.length} sidebar panel(s)`)
-  }
-  if (surfaces.codeBlockRenderers && surfaces.codeBlockRenderers.length > 0) {
-    const langs = surfaces.codeBlockRenderers.map((r) => `\`\`\`${r.language}`).join(', ')
-    surfaceLines.push(`code-block renderer(s) for ${langs}`)
-  }
+  if (!isOpen) return null
 
-  const permissions: PluginPermission[] = manifest.permissions ?? []
+  const handleClose = () => {
+    if (busy) return
+    closeModal()
+  }
 
   const handleConfirm = async () => {
+    if (state.status !== 'preview') return
     setBusy(true)
-    setError(null)
+    setInstallError(null)
     try {
-      await confirmAndInstallPlugin(record)
+      await confirmAndInstallPlugin(state.record)
       closeModal()
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
+      setInstallError(err instanceof Error ? err.message : String(err))
     } finally {
       setBusy(false)
     }
   }
 
   return (
-    <Modal isOpen={isOpen} onClose={() => (busy ? undefined : closeModal())} title="Install plugin?">
-      <div className="space-y-4">
-        <div>
-          <div className="flex items-baseline gap-2">
-            <span className="text-base font-semibold text-obsidianText">{manifest.name}</span>
-            <span className="text-xs text-obsidianSecondaryText">v{manifest.version}</span>
-          </div>
-          <div className="text-xs text-obsidianSecondaryText mt-0.5">
-            <code className="text-[11px] bg-obsidianHighlight/40 px-1 rounded">{manifest.id}</code>
-            {manifest.author && <span> · by {manifest.author}</span>}
-          </div>
-          <div className="text-[11px] text-obsidianSecondaryText/80 mt-1 break-all">
-            from {record.sourceUrl}
-          </div>
+    <Modal isOpen={isOpen} onClose={handleClose} title="Install plugin?">
+      {state.status === 'loading' && (
+        <div className="py-8 flex flex-col items-center justify-center gap-2" data-testid="plugin-preview-loading">
+          <svg
+            className="animate-spin h-5 w-5 text-obsidianAccentPurple"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+            <path
+              className="opacity-75"
+              fill="currentColor"
+              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+            />
+          </svg>
+          <p className="text-xs text-obsidianSecondaryText">Fetching plugin manifest…</p>
         </div>
+      )}
 
-        {surfaceLines.length > 0 && (
-          <section>
-            <div className="text-xs uppercase tracking-wide text-obsidianSecondaryText mb-1">
-              Adds to Noteser
+      {state.status === 'error' && (
+        <div className="space-y-4" data-testid="plugin-preview-error">
+          <div className="flex items-start gap-2 text-sm text-red-300">
+            <ExclamationTriangleIcon className="w-5 h-5 mt-0.5 flex-shrink-0" />
+            <div>
+              <div className="font-medium">Could not load this plugin.</div>
+              <div className="text-xs text-red-300/80 mt-1 whitespace-pre-wrap break-words">
+                {state.message}
+              </div>
             </div>
-            <ul className="text-sm text-obsidianText space-y-1 list-disc list-inside">
-              {surfaceLines.map((line, i) => (
-                <li key={i}>{line}</li>
-              ))}
-            </ul>
-          </section>
-        )}
-
-        <section>
-          <div className="text-xs uppercase tracking-wide text-obsidianSecondaryText mb-1 flex items-center gap-1">
-            <ShieldCheckIcon className="w-3 h-3" />
-            Permissions
           </div>
-          {permissions.length === 0 ? (
-            <p className="text-sm text-obsidianText">
-              None. This plugin runs in a sandboxed Web Worker with no DOM, no GitHub token, and no
-              access to other notes&apos; bodies.
-            </p>
-          ) : (
-            <ul className="space-y-2">
-              {permissions.map((perm) => (
-                <li key={perm} className="flex items-start gap-2 text-sm">
-                  <CheckCircleIcon className="w-4 h-4 mt-0.5 text-amber-400 flex-shrink-0" />
-                  <div>
-                    <span className="font-medium text-obsidianText">{perm}</span>
-                    <div className="text-xs text-obsidianSecondaryText mt-0.5">
-                      {PERMISSION_DESCRIPTIONS[perm]}
-                    </div>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-
-        {error && <div className="text-xs text-red-300">{error}</div>}
-
-        <div className="flex justify-end gap-2 pt-2 border-t border-obsidianBorder">
-          <Button variant="ghost" onClick={() => closeModal()} disabled={busy}>
-            Cancel
-          </Button>
-          <Button onClick={handleConfirm} disabled={busy} data-testid="plugin-install-confirm">
-            {busy ? 'Installing…' : 'Install'}
-          </Button>
+          <div className="flex justify-end pt-2 border-t border-obsidianBorder">
+            <Button variant="ghost" onClick={handleClose}>
+              Close
+            </Button>
+          </div>
         </div>
-      </div>
+      )}
+
+      {state.status === 'preview' && (
+        <PreviewBody
+          record={state.record}
+          busy={busy}
+          installError={installError}
+          onCancel={handleClose}
+          onInstall={handleConfirm}
+        />
+      )}
     </Modal>
   )
+}
+
+interface PreviewBodyProps {
+  record: InstalledPluginRecord
+  busy: boolean
+  installError: string | null
+  onCancel: () => void
+  onInstall: () => void
+}
+
+const PreviewBody = ({ record, busy, installError, onCancel, onInstall }: PreviewBodyProps) => {
+  const { manifest } = record
+  const surfaceRows = buildSurfaceRows(manifest.surfaces)
+  const permissions: PluginPermission[] = manifest.permissions ?? []
+
+  return (
+    <div className="space-y-4" data-testid="plugin-preview-body">
+      <div>
+        <div className="flex items-baseline gap-2">
+          <span className="text-base font-semibold text-obsidianText">{manifest.name}</span>
+          <span className="text-xs text-obsidianSecondaryText">v{manifest.version}</span>
+        </div>
+        <div className="text-xs text-obsidianSecondaryText mt-0.5">
+          <code className="text-[11px] bg-obsidianHighlight/40 px-1 rounded">{manifest.id}</code>
+          {manifest.author && <span> · by {manifest.author}</span>}
+        </div>
+        {manifest.homepage && (
+          <div className="text-[11px] mt-1 break-all">
+            <a
+              href={manifest.homepage}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-obsidianAccentPurple hover:underline"
+              data-testid="plugin-preview-homepage"
+            >
+              {manifest.homepage}
+            </a>
+          </div>
+        )}
+        <div className="text-[11px] text-obsidianSecondaryText/80 mt-1 break-all">
+          from {record.sourceUrl}
+        </div>
+        {manifest.description && (
+          <p
+            className="text-sm text-obsidianText mt-3 whitespace-pre-wrap"
+            data-testid="plugin-preview-description"
+          >
+            {manifest.description}
+          </p>
+        )}
+      </div>
+
+      <section>
+        <div className="text-xs uppercase tracking-wide text-obsidianSecondaryText mb-1 flex items-center gap-1">
+          <ShieldCheckIcon className="w-3 h-3" />
+          Capabilities
+        </div>
+        {surfaceRows.length === 0 && permissions.length === 0 ? (
+          <p className="text-sm text-obsidianText">
+            None. This plugin runs in a sandboxed Web Worker with no DOM, no GitHub token, and no
+            access to other notes&apos; bodies.
+          </p>
+        ) : (
+          <ul className="space-y-2" data-testid="plugin-preview-capabilities">
+            {surfaceRows.map((row) => (
+              <li
+                key={row.key}
+                className="flex items-start gap-2 text-sm"
+                data-testid={`plugin-preview-capability-${row.key}`}
+              >
+                <CheckCircleIcon className="w-4 h-4 mt-0.5 text-emerald-400 flex-shrink-0" />
+                <div>
+                  <span className="font-medium text-obsidianText">{row.label}</span>
+                  <div className="text-xs text-obsidianSecondaryText mt-0.5">{row.description}</div>
+                </div>
+              </li>
+            ))}
+            {permissions.map((perm) => (
+              <li
+                key={perm}
+                className="flex items-start gap-2 text-sm"
+                data-testid={`plugin-preview-capability-${perm}`}
+              >
+                <CheckCircleIcon className="w-4 h-4 mt-0.5 text-amber-400 flex-shrink-0" />
+                <div>
+                  <span className="font-medium text-obsidianText">{perm}</span>
+                  <div className="text-xs text-obsidianSecondaryText mt-0.5">
+                    {PERMISSION_DESCRIPTIONS[perm]}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {installError && <div className="text-xs text-red-300">{installError}</div>}
+
+      <div className="flex justify-end gap-2 pt-2 border-t border-obsidianBorder">
+        <Button variant="ghost" onClick={onCancel} disabled={busy} data-testid="plugin-install-cancel">
+          Cancel
+        </Button>
+        <Button onClick={onInstall} disabled={busy} data-testid="plugin-install-confirm">
+          {busy ? 'Installing…' : 'Install'}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function buildSurfaceRows(surfaces: InstalledPluginRecord['manifest']['surfaces']): CapabilityRow[] {
+  const rows: CapabilityRow[] = []
+  if (surfaces.commands && surfaces.commands.length > 0) {
+    rows.push({
+      key: 'commands' satisfies PluginSurfaceKind,
+      label: `${surfaces.commands.length} command${surfaces.commands.length === 1 ? '' : 's'}`,
+      description: SURFACE_DESCRIPTIONS.commands,
+    })
+  }
+  if (surfaces.sidebarPanels && surfaces.sidebarPanels.length > 0) {
+    rows.push({
+      key: 'sidebarPanels' satisfies PluginSurfaceKind,
+      label: `${surfaces.sidebarPanels.length} sidebar panel${surfaces.sidebarPanels.length === 1 ? '' : 's'}`,
+      description: SURFACE_DESCRIPTIONS.sidebarPanels,
+    })
+  }
+  if (surfaces.codeBlockRenderers && surfaces.codeBlockRenderers.length > 0) {
+    const langs = surfaces.codeBlockRenderers.map((r) => r.language).join(', ')
+    rows.push({
+      key: 'codeBlockRenderers' satisfies PluginSurfaceKind,
+      label: `code-block renderer${surfaces.codeBlockRenderers.length === 1 ? '' : 's'} (${langs})`,
+      description: SURFACE_DESCRIPTIONS.codeBlockRenderers,
+    })
+  }
+  return rows
 }

--- a/src/components/modals/PluginsSettingsPanel.tsx
+++ b/src/components/modals/PluginsSettingsPanel.tsx
@@ -17,10 +17,7 @@ import { ArrowPathIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { usePluginInstallStore } from '@/stores/pluginInstallStore'
 import { usePluginStore } from '@/stores/pluginStore'
 import { useUIStore } from '@/stores'
-import {
-  fetchPluginForInstall,
-  uninstallPlugin,
-} from '@/plugins/pluginHostSingleton'
+import { uninstallPlugin } from '@/plugins/pluginHostSingleton'
 
 export const PluginsSettingsPanel = () => {
   const records = usePluginInstallStore((s) => s.records)
@@ -29,25 +26,17 @@ export const PluginsSettingsPanel = () => {
   const openModal = useUIStore((s) => s.openModal)
 
   const [url, setUrl] = useState('')
-  const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const handleAdd = async () => {
+  const handleAdd = () => {
     setError(null)
-    if (!url.trim()) {
+    const trimmed = url.trim()
+    if (!trimmed) {
       setError('Paste a manifest.json URL.')
       return
     }
-    setBusy(true)
-    try {
-      const record = await fetchPluginForInstall(url.trim())
-      openModal({ type: 'plugin-install-confirm', data: { record } })
-      setUrl('')
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setBusy(false)
-    }
+    openModal({ type: 'plugin-install-confirm', data: { manifestUrl: trimmed } })
+    setUrl('')
   }
 
   const handleUninstall = (pluginId: string) => {
@@ -83,18 +72,16 @@ export const PluginsSettingsPanel = () => {
             type="url"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
-            disabled={busy}
             placeholder="https://…/manifest.json"
-            className="flex-1 appearance-none px-3 py-2 rounded-md border border-obsidianBorder bg-obsidianBlack/40 text-sm text-obsidianText placeholder:text-obsidianSecondaryText focus:outline-none focus:border-obsidianAccentPurple disabled:opacity-60"
+            className="flex-1 appearance-none px-3 py-2 rounded-md border border-obsidianBorder bg-obsidianBlack/40 text-sm text-obsidianText placeholder:text-obsidianSecondaryText focus:outline-none focus:border-obsidianAccentPurple"
           />
           <button
             type="button"
             onClick={handleAdd}
-            disabled={busy}
-            className="px-4 py-2 rounded-md bg-obsidianAccentPurple/80 hover:bg-obsidianAccentPurple text-white text-sm font-medium disabled:opacity-60"
+            className="px-4 py-2 rounded-md bg-obsidianAccentPurple/80 hover:bg-obsidianAccentPurple text-white text-sm font-medium"
             data-testid="settings-plugins-add"
           >
-            {busy ? 'Adding…' : 'Add'}
+            Add
           </button>
         </div>
         {error && <p className="text-xs text-red-300 mt-2">{error}</p>}

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -12,6 +12,13 @@ export interface PluginManifest {
   name: string
   version: string
   author?: string
+  /** Short one-to-two sentence summary of what the plugin does.
+   *  Shown verbatim in the install-preview modal. Capped at 280
+   *  chars so a verbose paragraph cannot blow up the layout. */
+  description?: string
+  /** Optional homepage / repo URL. Must be https (or http://localhost
+   *  for dev). Rendered as a link in the install-preview modal. */
+  homepage?: string
   surfaces: PluginSurfaces
   /** Capabilities the plugin asks for at install time. v1.0 plugins
    *  omit this; v1.1+ plugins may request `file-save` / `file-open`
@@ -32,6 +39,17 @@ export type PluginPermission = (typeof PERMISSIONS)[number]
 export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
   'file-save': 'Save a file to your computer (opens the native save dialog when the plugin needs to write a file).',
   'file-open': 'Read a file you pick (opens the native file picker; the plugin sees the bytes of the file you choose, nothing else).',
+}
+
+/** Surface kinds the manifest can declare. Used by the install-preview
+ *  modal to render a one-line explanation per kind alongside the count.
+ *  Keep the prose short — these appear as bullets next to a count. */
+export type PluginSurfaceKind = 'commands' | 'sidebarPanels' | 'codeBlockRenderers'
+
+export const SURFACE_DESCRIPTIONS: Record<PluginSurfaceKind, string> = {
+  commands: 'Adds entries to the command palette you can run with the keyboard.',
+  sidebarPanels: 'Adds a panel to the sidebar showing plugin-rendered content.',
+  codeBlockRenderers: 'Renders fenced code blocks of a given language inside notes.',
 }
 
 export interface PluginSurfaces {
@@ -112,6 +130,18 @@ export function validateManifest(input: unknown): ManifestValidationResult {
     errors.push('Manifest "author" must be a string when present.')
   }
 
+  if (m.description !== undefined) {
+    if (typeof m.description !== 'string' || m.description.length === 0 || m.description.length > 280) {
+      errors.push('Manifest "description" must be a non-empty string up to 280 chars when present.')
+    }
+  }
+
+  if (m.homepage !== undefined) {
+    if (typeof m.homepage !== 'string' || !isSafeUrl(m.homepage)) {
+      errors.push('Manifest "homepage" must be an https URL (or http://localhost for dev) when present.')
+    }
+  }
+
   if (!isPlainObject(m.surfaces)) {
     errors.push('Manifest "surfaces" must be an object.')
   }
@@ -145,6 +175,8 @@ export function validateManifest(input: unknown): ManifestValidationResult {
     name: m.name as string,
     version: m.version as string,
     author: m.author as string | undefined,
+    ...(typeof m.description === 'string' ? { description: m.description } : {}),
+    ...(typeof m.homepage === 'string' ? { homepage: m.homepage } : {}),
     surfaces: {
       ...(commands && commands.length > 0 ? { commands } : {}),
       ...(sidebarPanels && sidebarPanels.length > 0 ? { sidebarPanels } : {}),
@@ -272,4 +304,15 @@ function validatePermissions(
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+function isSafeUrl(s: string): boolean {
+  try {
+    const u = new URL(s)
+    if (u.protocol === 'https:') return true
+    if (u.protocol === 'http:' && (u.hostname === 'localhost' || u.hostname === '127.0.0.1')) return true
+    return false
+  } catch {
+    return false
+  }
 }


### PR DESCRIPTION
## Summary

Closes the first half of #43: a manifest-preview modal that shows the user **what** they are about to install before they hit Install.

### Flow

Settings → Plugins → paste a `manifest.json` URL → click **Add**. Previously the panel ran `fetchPluginForInstall(url)` itself and only showed a modal on success — any fetch or validation failure surfaced as a tiny line of red text under the input.

Now the panel opens the modal immediately with `{ manifestUrl }` in `modal.data`, and the modal owns three render states sharing one shell:

- **loading** — spinner while the manifest + bundle download.
- **preview** — name, version, author, description, homepage link, capabilities, Install / Cancel buttons.
- **error** — the underlying error message (network 404, JSON parse, schema validation) inline, with a single Close button.

The legacy `{ record }` entry shape still works — `confirmAndInstallPlugin` callers that already have a fetched record can keep passing it.

### Capability-to-prose mapping

Lives in `src/plugins/manifest.ts` next to the schema, so the modal cannot drift from the contract:

| Capability | One-line prose |
|---|---|
| `commands` | Adds entries to the command palette you can run with the keyboard. |
| `sidebarPanels` | Adds a panel to the sidebar showing plugin-rendered content. |
| `codeBlockRenderers` | Renders fenced code blocks of a given language inside notes. |
| `file-save` | (existing) Save a file to your computer (opens the native save dialog…). |
| `file-open` | (existing) Read a file you pick (opens the native file picker…). |

Surface counts (`2 commands`, `1 sidebar panel`, `code-block renderers (mermaid)`) are computed at render time from the validated manifest — no hardcoded plurals to drift.

### Schema additions

`PluginManifest` gains two optional fields with strict validation:

- `description` — non-empty string up to 280 chars.
- `homepage` — https URL (or http://localhost for dev). Rejects `javascript:` / `data:` / non-URL strings.

### Files touched

- `src/plugins/manifest.ts` — `description` / `homepage` fields + `SURFACE_DESCRIPTIONS` map.
- `src/components/modals/PluginInstallConfirmModal.tsx` — three-state modal, owns the fetch.
- `src/components/modals/PluginsSettingsPanel.tsx` — passes URL straight to the modal.
- `src/__tests__/plugins/manifest.test.ts` — +5 schema tests for the new fields.
- `src/__tests__/plugins/pluginInstallConfirmModal.test.tsx` — new, 10 tests covering all three render states + Install/Cancel handlers + the pre-fetched-record path.

### Scope

This PR is **only** the manifest-preview modal half of #43. The "vault-folder scan" half is intentionally left for a follow-up.

## Test plan

- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm test` — 2046 passing (added 15 new tests across modal + manifest), no regressions.
- [ ] Manual: open Settings → Plugins, paste a known-good manifest URL, confirm the preview shows description / homepage / capability list, click Install and confirm the plugin boots.
- [ ] Manual: paste a 404 URL, confirm the error renders inline inside the modal shell.
- [ ] Manual: paste a malformed JSON URL, confirm the validation error message renders inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)