### PR TITLE
feat(plugins): scan vault for in-vault manifest.json (#43)

### DIFF
--- a/src/__tests__/plugins/pluginsSettingsPanelVaultScan.test.tsx
+++ b/src/__tests__/plugins/pluginsSettingsPanelVaultScan.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Settings → Plugins → Scan vault for plugins. The scanner reads
+ * the live note + folder stores and renders results inline. The
+ * Install button on each result hands the assembled record to the
+ * existing plugin-install-confirm modal (same path the URL flow
+ * uses), so the test asserts on uiStore.modal — not on the modal
+ * itself.
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('../../plugins/pluginHostSingleton', () => ({
+  fetchPluginForInstall: jest.fn(),
+  fetchPluginForInstallFromVault: jest.fn(),
+  uninstallPlugin: jest.fn(),
+}))
+
+import React from 'react'
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { PluginsSettingsPanel } from '../../components/modals/PluginsSettingsPanel'
+import { useNoteStore } from '../../stores/noteStore'
+import { useFolderStore } from '../../stores/folderStore'
+import { useUIStore } from '../../stores/uiStore'
+import { usePluginInstallStore } from '../../stores/pluginInstallStore'
+import type { Note, Folder } from '../../types'
+
+const mockedHost = jest.requireMock('../../plugins/pluginHostSingleton') as {
+  fetchPluginForInstall: jest.Mock
+  fetchPluginForInstallFromVault: jest.Mock
+  uninstallPlugin: jest.Mock
+}
+
+const validManifestBody = JSON.stringify({
+  id: 'word-count',
+  name: 'Word count',
+  version: '1.0.0',
+  main: 'https://example.com/word-count/main.js',
+  surfaces: { commands: [{ id: 'show', title: 'Word count: show' }] },
+})
+
+function makeNote(partial: Partial<Note> & { id: string; title: string }): Note {
+  return {
+    id: partial.id,
+    title: partial.title,
+    content: partial.content ?? '',
+    folderId: partial.folderId ?? null,
+    createdAt: 0,
+    updatedAt: 0,
+    isDeleted: false,
+    deletedAt: null,
+    isPinned: false,
+    templateId: null,
+  }
+}
+
+function makeFolder(partial: Partial<Folder> & { id: string; name: string }): Folder {
+  return {
+    id: partial.id,
+    name: partial.name,
+    parentId: partial.parentId ?? null,
+    createdAt: 0,
+    updatedAt: 0,
+    isDeleted: false,
+    deletedAt: null,
+    order: 0,
+  }
+}
+
+beforeEach(() => {
+  useNoteStore.setState({ notes: [], selectedNoteId: null })
+  useFolderStore.setState({ folders: [] })
+  usePluginInstallStore.setState({ records: {} })
+  useUIStore.setState({ modal: { type: null } })
+  mockedHost.fetchPluginForInstall.mockReset()
+  mockedHost.fetchPluginForInstallFromVault.mockReset()
+  mockedHost.uninstallPlugin.mockReset()
+})
+
+test('empty-state copy when nothing in the vault looks like a manifest', async () => {
+  render(<PluginsSettingsPanel />)
+  await userEvent.click(screen.getByTestId('settings-plugins-scan'))
+  expect(await screen.findByTestId('settings-plugins-scan-empty')).toHaveTextContent(
+    /No plugin manifests found in this vault/,
+  )
+})
+
+test('lists each valid manifest with name, version, and path', async () => {
+  useFolderStore.setState({ folders: [makeFolder({ id: 'f1', name: 'Plugins' })] })
+  useNoteStore.setState({
+    notes: [
+      makeNote({
+        id: 'n1',
+        title: 'manifest.json',
+        content: validManifestBody,
+        folderId: 'f1',
+      }),
+    ],
+    selectedNoteId: null,
+  })
+
+  render(<PluginsSettingsPanel />)
+  await userEvent.click(screen.getByTestId('settings-plugins-scan'))
+  const list = await screen.findByTestId('settings-plugins-scan-results')
+  expect(list).toHaveTextContent('Word count')
+  expect(list).toHaveTextContent('v1.0.0')
+  expect(list).toHaveTextContent('Plugins/manifest.json')
+  expect(list).toHaveTextContent('word-count')
+})
+
+test('skips notes titled manifest.json that fail validation, with a skip count', async () => {
+  useNoteStore.setState({
+    notes: [
+      makeNote({ id: 'bad1', title: 'manifest.json', content: 'not json' }),
+      makeNote({ id: 'bad2', title: 'manifest.json', content: '{}' }),
+    ],
+    selectedNoteId: null,
+  })
+  render(<PluginsSettingsPanel />)
+  await userEvent.click(screen.getByTestId('settings-plugins-scan'))
+  const empty = await screen.findByTestId('settings-plugins-scan-empty')
+  expect(empty).toHaveTextContent(/Skipped 2 note\(s\)/)
+})
+
+test('clicking Install on a candidate opens the existing confirm modal with a record', async () => {
+  useNoteStore.setState({
+    notes: [
+      makeNote({ id: 'n1', title: 'manifest.json', content: validManifestBody }),
+    ],
+    selectedNoteId: null,
+  })
+  const fakeRecord = {
+    manifest: JSON.parse(validManifestBody),
+    mainSource: 'export default {}',
+    hash: 'abc',
+    sourceUrl: 'vault: manifest.json',
+    addedAt: 0,
+    enabled: true,
+  }
+  mockedHost.fetchPluginForInstallFromVault.mockResolvedValueOnce(fakeRecord)
+
+  render(<PluginsSettingsPanel />)
+  await userEvent.click(screen.getByTestId('settings-plugins-scan'))
+  await userEvent.click(await screen.findByTestId('settings-plugins-scan-install-word-count'))
+
+  await waitFor(() => {
+    expect(useUIStore.getState().modal.type).toBe('plugin-install-confirm')
+  })
+  expect(mockedHost.fetchPluginForInstallFromVault).toHaveBeenCalledTimes(1)
+  expect(useUIStore.getState().modal.data).toEqual({ record: fakeRecord })
+})
+
+test('renders the error state when fetching the bundle for a candidate fails', async () => {
+  useNoteStore.setState({
+    notes: [
+      makeNote({ id: 'n1', title: 'manifest.json', content: validManifestBody }),
+    ],
+    selectedNoteId: null,
+  })
+  mockedHost.fetchPluginForInstallFromVault.mockRejectedValueOnce(new Error('HTTP 500 fetching main.js'))
+
+  render(<PluginsSettingsPanel />)
+  await userEvent.click(screen.getByTestId('settings-plugins-scan'))
+  await userEvent.click(await screen.findByTestId('settings-plugins-scan-install-word-count'))
+
+  const err = await screen.findByTestId('settings-plugins-scan-error')
+  expect(err).toHaveTextContent('Could not read vault: HTTP 500 fetching main.js')
+})
+
+test('surface-level error state covers a thrown scan (defensive path)', async () => {
+  // Force noteStore.getState() to throw on the next call by monkey-patching
+  // its getState. This exercises the catch in handleScan().
+  const original = useNoteStore.getState
+  useNoteStore.getState = (() => {
+    throw new Error('store unavailable')
+  }) as typeof useNoteStore.getState
+
+  try {
+    render(<PluginsSettingsPanel />)
+    await act(async () => {
+      await userEvent.click(screen.getByTestId('settings-plugins-scan'))
+    })
+    const err = await screen.findByTestId('settings-plugins-scan-error')
+    expect(err).toHaveTextContent('Could not read vault: store unavailable')
+  } finally {
+    useNoteStore.getState = original
+  }
+})

--- a/src/__tests__/plugins/vaultScan.test.ts
+++ b/src/__tests__/plugins/vaultScan.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @jest-environment node
+ *
+ * Vault-folder scan contract tests. The scanner walks an in-memory
+ * notes + folders list (the live store passes its current arrays
+ * straight in) and returns validated manifest candidates plus a
+ * skipped count for notes whose title matched but body did not.
+ */
+
+import { scanVaultForManifests } from '@/plugins/vaultScan'
+import type { Note, Folder } from '@/types'
+
+const validManifestBody = JSON.stringify({
+  id: 'word-count',
+  name: 'Word count',
+  version: '1.0.0',
+  main: 'https://example.com/word-count/main.js',
+  surfaces: { commands: [{ id: 'show', title: 'Word count: show' }] },
+})
+
+function makeNote(partial: Partial<Note> & { id: string; title: string }): Note {
+  return {
+    id: partial.id,
+    title: partial.title,
+    content: partial.content ?? '',
+    folderId: partial.folderId ?? null,
+    createdAt: 0,
+    updatedAt: 0,
+    isDeleted: partial.isDeleted ?? false,
+    deletedAt: partial.isDeleted ? 0 : null,
+    isPinned: false,
+    templateId: null,
+  }
+}
+
+function makeFolder(partial: Partial<Folder> & { id: string; name: string }): Folder {
+  return {
+    id: partial.id,
+    name: partial.name,
+    parentId: partial.parentId ?? null,
+    createdAt: 0,
+    updatedAt: 0,
+    isDeleted: partial.isDeleted ?? false,
+    deletedAt: partial.isDeleted ? 0 : null,
+    order: partial.order ?? 0,
+  }
+}
+
+describe('scanVaultForManifests', () => {
+  test('finds a known manifest by title + valid body', () => {
+    const folder = makeFolder({ id: 'f1', name: 'Plugins' })
+    const note = makeNote({
+      id: 'n1',
+      title: 'manifest.json',
+      content: validManifestBody,
+      folderId: 'f1',
+    })
+    const result = scanVaultForManifests([note], [folder])
+    expect(result.candidates).toHaveLength(1)
+    expect(result.skipped).toBe(0)
+    const c = result.candidates[0]
+    expect(c.manifest.id).toBe('word-count')
+    expect(c.manifest.name).toBe('Word count')
+    expect(c.manifest.version).toBe('1.0.0')
+    expect(c.mainUrl).toBe('https://example.com/word-count/main.js')
+    expect(c.noteId).toBe('n1')
+    expect(c.pathInVault).toBe('Plugins/manifest.json')
+  })
+
+  test('skips deleted notes', () => {
+    const note = makeNote({
+      id: 'n1',
+      title: 'manifest.json',
+      content: validManifestBody,
+      isDeleted: true,
+    })
+    const result = scanVaultForManifests([note], [])
+    expect(result.candidates).toHaveLength(0)
+    expect(result.skipped).toBe(0)
+  })
+
+  test('ignores notes whose title is not manifest.json', () => {
+    const note = makeNote({ id: 'n1', title: 'README.md', content: validManifestBody })
+    const result = scanVaultForManifests([note], [])
+    expect(result.candidates).toHaveLength(0)
+    expect(result.skipped).toBe(0)
+  })
+
+  test('skips non-manifest JSON notes (matched title, garbage body)', () => {
+    const notJson = makeNote({ id: 'n1', title: 'manifest.json', content: 'not json' })
+    const wrongShape = makeNote({
+      id: 'n2',
+      title: 'manifest.json',
+      content: JSON.stringify({ foo: 'bar' }),
+    })
+    const noMain = makeNote({
+      id: 'n3',
+      title: 'manifest.json',
+      content: JSON.stringify({
+        id: 'p',
+        name: 'P',
+        version: '1.0.0',
+        surfaces: { commands: [{ id: 'a', title: 'A' }] },
+      }),
+    })
+    const failsValidation = makeNote({
+      id: 'n4',
+      title: 'manifest.json',
+      content: JSON.stringify({
+        id: 'BadID',
+        name: 'P',
+        version: '1.0.0',
+        main: 'https://example.com/main.js',
+        surfaces: { commands: [{ id: 'a', title: 'A' }] },
+      }),
+    })
+    const result = scanVaultForManifests([notJson, wrongShape, noMain, failsValidation], [])
+    expect(result.candidates).toHaveLength(0)
+    expect(result.skipped).toBe(4)
+  })
+
+  test('matches manifest.json title case-insensitively', () => {
+    const note = makeNote({ id: 'n1', title: 'Manifest.JSON', content: validManifestBody })
+    const result = scanVaultForManifests([note], [])
+    expect(result.candidates).toHaveLength(1)
+  })
+
+  test('empty vault returns no candidates and no skips', () => {
+    const result = scanVaultForManifests([], [])
+    expect(result.candidates).toHaveLength(0)
+    expect(result.skipped).toBe(0)
+  })
+
+  test('builds nested folder path for display', () => {
+    const root = makeFolder({ id: 'root', name: 'Tools' })
+    const child = makeFolder({ id: 'child', name: 'word-count', parentId: 'root' })
+    const note = makeNote({
+      id: 'n1',
+      title: 'manifest.json',
+      content: validManifestBody,
+      folderId: 'child',
+    })
+    const result = scanVaultForManifests([note], [root, child])
+    expect(result.candidates[0].pathInVault).toBe('Tools/word-count/manifest.json')
+  })
+
+  test('falls back to title when the note is at vault root', () => {
+    const note = makeNote({ id: 'n1', title: 'manifest.json', content: validManifestBody })
+    const result = scanVaultForManifests([note], [])
+    expect(result.candidates[0].pathInVault).toBe('manifest.json')
+  })
+
+  test('sorts candidates by display path', () => {
+    const a = makeFolder({ id: 'a', name: 'A' })
+    const b = makeFolder({ id: 'b', name: 'B' })
+    const m1 = JSON.stringify({
+      id: 'one',
+      name: 'One',
+      version: '1.0.0',
+      main: 'https://e.com/1.js',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+    })
+    const m2 = JSON.stringify({
+      id: 'two',
+      name: 'Two',
+      version: '1.0.0',
+      main: 'https://e.com/2.js',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+    })
+    const notes = [
+      makeNote({ id: 'n1', title: 'manifest.json', content: m2, folderId: 'b' }),
+      makeNote({ id: 'n2', title: 'manifest.json', content: m1, folderId: 'a' }),
+    ]
+    const result = scanVaultForManifests(notes, [a, b])
+    expect(result.candidates.map((c) => c.manifest.id)).toEqual(['one', 'two'])
+  })
+
+  test('mixes valid and invalid: counts skips, returns only valid', () => {
+    const good = makeNote({
+      id: 'good',
+      title: 'manifest.json',
+      content: validManifestBody,
+    })
+    const bad = makeNote({ id: 'bad', title: 'manifest.json', content: 'oops' })
+    const ignored = makeNote({ id: 'ignored', title: 'notes.md', content: validManifestBody })
+    const result = scanVaultForManifests([good, bad, ignored], [])
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0].noteId).toBe('good')
+    expect(result.skipped).toBe(1)
+  })
+})

--- a/src/components/modals/PluginsSettingsPanel.tsx
+++ b/src/components/modals/PluginsSettingsPanel.tsx
@@ -3,21 +3,23 @@
 // Settings → Plugins.
 //
 // Lists every installed plugin (toggle / uninstall), and accepts a
-// new plugin via URL paste. The paste flow:
-//   1. User types/pastes a manifest.json URL
-//   2. We click "Add" — calls installPluginFromUrl which fetches,
-//      validates, stores, and boots the plugin
-//   3. Errors surface as inline text + the existing toast system
-//
-// This is the v1 install surface. Vault-folder scan
-// (.noteser/plugins/) lands in a follow-up.
+// new plugin via URL paste or by scanning the vault for in-vault
+// manifest.json notes. Both paths hand the assembled
+// InstalledPluginRecord to the existing plugin-install-confirm modal
+// so the user sees the same preview + permissions screen.
 
 import { useState } from 'react'
 import { ArrowPathIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { usePluginInstallStore } from '@/stores/pluginInstallStore'
 import { usePluginStore } from '@/stores/pluginStore'
+import { useNoteStore } from '@/stores/noteStore'
+import { useFolderStore } from '@/stores/folderStore'
 import { useUIStore } from '@/stores'
-import { uninstallPlugin } from '@/plugins/pluginHostSingleton'
+import {
+  fetchPluginForInstallFromVault,
+  uninstallPlugin,
+} from '@/plugins/pluginHostSingleton'
+import { scanVaultForManifests, type VaultManifestCandidate } from '@/plugins/vaultScan'
 
 export const PluginsSettingsPanel = () => {
   const records = usePluginInstallStore((s) => s.records)
@@ -28,7 +30,15 @@ export const PluginsSettingsPanel = () => {
   const [url, setUrl] = useState('')
   const [error, setError] = useState<string | null>(null)
 
-  const handleAdd = () => {
+  const [scanState, setScanState] = useState<
+    | { kind: 'idle' }
+    | { kind: 'scanning' }
+    | { kind: 'done'; candidates: VaultManifestCandidate[]; skipped: number }
+    | { kind: 'error'; message: string }
+  >({ kind: 'idle' })
+  const [installingNoteId, setInstallingNoteId] = useState<string | null>(null)
+
+  const handleAdd = async () => {
     setError(null)
     const trimmed = url.trim()
     if (!trimmed) {
@@ -37,6 +47,36 @@ export const PluginsSettingsPanel = () => {
     }
     openModal({ type: 'plugin-install-confirm', data: { manifestUrl: trimmed } })
     setUrl('')
+  }
+
+  const handleScan = () => {
+    setScanState({ kind: 'scanning' })
+    try {
+      const notes = useNoteStore.getState().notes
+      const folders = useFolderStore.getState().folders
+      const result = scanVaultForManifests(notes, folders)
+      setScanState({ kind: 'done', candidates: result.candidates, skipped: result.skipped })
+    } catch (err) {
+      setScanState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  const handleInstallFromVault = async (candidate: VaultManifestCandidate) => {
+    setInstallingNoteId(candidate.noteId)
+    try {
+      const record = await fetchPluginForInstallFromVault(candidate)
+      openModal({ type: 'plugin-install-confirm', data: { record } })
+    } catch (err) {
+      setScanState({
+        kind: 'error',
+        message: err instanceof Error ? err.message : String(err),
+      })
+    } finally {
+      setInstallingNoteId(null)
+    }
   }
 
   const handleUninstall = (pluginId: string) => {
@@ -85,6 +125,71 @@ export const PluginsSettingsPanel = () => {
           </button>
         </div>
         {error && <p className="text-xs text-red-300 mt-2">{error}</p>}
+      </section>
+
+      <section>
+        <div className="text-sm text-obsidianText mb-1">Scan vault for plugins</div>
+        <p className="text-xs text-obsidianSecondaryText mb-2">
+          Look through your vault for notes titled <code className="text-[11px] bg-obsidianHighlight/40 px-1 rounded">manifest.json</code> that declare a plugin. Each match shows up below with an Install button.
+        </p>
+        <button
+          type="button"
+          onClick={handleScan}
+          disabled={scanState.kind === 'scanning'}
+          className="px-3 py-1.5 rounded-md border border-obsidianBorder bg-obsidianBlack/40 hover:bg-obsidianHighlight/40 text-sm text-obsidianText disabled:opacity-60"
+          data-testid="settings-plugins-scan"
+        >
+          {scanState.kind === 'scanning' ? 'Scanning…' : 'Scan vault for plugins'}
+        </button>
+
+        {scanState.kind === 'error' && (
+          <p className="text-xs text-red-300 mt-2" data-testid="settings-plugins-scan-error">
+            Could not read vault: {scanState.message}
+          </p>
+        )}
+
+        {scanState.kind === 'done' && scanState.candidates.length === 0 && (
+          <p className="text-xs text-obsidianSecondaryText mt-2" data-testid="settings-plugins-scan-empty">
+            No plugin manifests found in this vault.
+            {scanState.skipped > 0 && ` Skipped ${scanState.skipped} note(s) titled manifest.json that did not match the plugin schema.`}
+          </p>
+        )}
+
+        {scanState.kind === 'done' && scanState.candidates.length > 0 && (
+          <ul
+            className="mt-2 divide-y divide-obsidianBorder rounded-lg border border-obsidianBorder"
+            data-testid="settings-plugins-scan-results"
+          >
+            {scanState.candidates.map((c) => (
+              <li key={c.noteId} className="p-3 flex items-start justify-between gap-3">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-sm font-medium text-obsidianText">{c.manifest.name}</span>
+                    <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
+                      v{c.manifest.version}
+                    </span>
+                  </div>
+                  <div className="text-xs text-obsidianSecondaryText mt-0.5">
+                    <code className="text-[11px] bg-obsidianHighlight/40 px-1 rounded">{c.manifest.id}</code>
+                    {c.manifest.author && <span> · by {c.manifest.author}</span>}
+                  </div>
+                  <div className="text-[11px] text-obsidianSecondaryText/80 mt-1 truncate">
+                    {c.pathInVault}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleInstallFromVault(c)}
+                  disabled={installingNoteId !== null}
+                  className="px-3 py-1.5 rounded-md bg-obsidianAccentPurple/80 hover:bg-obsidianAccentPurple text-white text-xs font-medium disabled:opacity-60"
+                  data-testid={`settings-plugins-scan-install-${c.manifest.id}`}
+                >
+                  {installingNoteId === c.noteId ? 'Preparing…' : 'Install'}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
       </section>
 
       <section>

--- a/src/plugins/installer.ts
+++ b/src/plugins/installer.ts
@@ -30,6 +30,17 @@ export interface FetchedPlugin {
   sourceUrl: string
 }
 
+export interface FetchPluginFromManifestArgs {
+  /** Already-validated manifest object (vault-scan provides this). */
+  manifest: PluginManifest
+  /** The raw `main` URL from the manifest. */
+  mainUrl: string
+  /** Display label for the install record's sourceUrl field. The
+   *  vault scanner passes the in-vault path so the Plugins list shows
+   *  where the manifest came from. */
+  sourceLabel: string
+}
+
 export interface FetchOptions {
   /** Per-request timeout in milliseconds. Total fetch budget for an
    *  install is `2 * timeoutMs` (manifest + main). */
@@ -97,6 +108,32 @@ export async function fetchPluginFromUrl(
     mainSource,
     hash,
     sourceUrl: manifestUrl,
+  }
+}
+
+/**
+ * Build a FetchedPlugin from a manifest that came from somewhere
+ * other than an HTTPS manifest URL — currently only the vault scan.
+ * The bundle still lives on the network, so we fetch + hash it here;
+ * the manifest itself is taken as-is (the caller validated it).
+ */
+export async function fetchPluginFromManifest(
+  args: FetchPluginFromManifestArgs,
+  opts: FetchOptions = {},
+): Promise<FetchedPlugin> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  if (!isHttpsOrLocalhost(args.mainUrl)) {
+    throw new Error(
+      'Plugin main.js URL must use HTTPS. Plain HTTP is only accepted from localhost (dev mode).',
+    )
+  }
+  const mainSource = await fetchText(args.mainUrl, timeoutMs)
+  const hash = await sha256Hex(mainSource)
+  return {
+    manifest: args.manifest,
+    mainSource,
+    hash,
+    sourceUrl: args.sourceLabel,
   }
 }
 

--- a/src/plugins/pluginHostSingleton.ts
+++ b/src/plugins/pluginHostSingleton.ts
@@ -23,7 +23,8 @@ import { useToastStore } from '@/stores/toastStore'
 import { useNoteStore } from '@/stores/noteStore'
 import { useFolderStore } from '@/stores/folderStore'
 import { useWorkspaceStore } from '@/stores/workspaceStore'
-import { fetchPluginFromUrl, sha256Hex } from './installer'
+import { fetchPluginFromUrl, fetchPluginFromManifest, sha256Hex } from './installer'
+import type { VaultManifestCandidate } from './vaultScan'
 
 let instance: PluginHost | null = null
 
@@ -79,6 +80,30 @@ export async function fetchPluginForInstall(
   manifestUrl: string,
 ): Promise<InstalledPluginRecord> {
   const fetched = await fetchPluginFromUrl(manifestUrl)
+  return {
+    manifest: fetched.manifest,
+    mainSource: fetched.mainSource,
+    hash: fetched.hash,
+    sourceUrl: fetched.sourceUrl,
+    addedAt: Date.now(),
+    enabled: true,
+  }
+}
+
+/**
+ * Vault-scan equivalent of fetchPluginForInstall. Takes a candidate
+ * from scanVaultForManifests (manifest already parsed + validated)
+ * and fetches the bundle, returning a record the existing confirm
+ * modal accepts unchanged.
+ */
+export async function fetchPluginForInstallFromVault(
+  candidate: VaultManifestCandidate,
+): Promise<InstalledPluginRecord> {
+  const fetched = await fetchPluginFromManifest({
+    manifest: candidate.manifest,
+    mainUrl: candidate.mainUrl,
+    sourceLabel: `vault: ${candidate.pathInVault}`,
+  })
   return {
     manifest: fetched.manifest,
     mainSource: fetched.mainSource,

--- a/src/plugins/vaultScan.ts
+++ b/src/plugins/vaultScan.ts
@@ -1,0 +1,101 @@
+// Vault-folder scan: walk the user's notes for in-vault plugin
+// manifests. A vault manifest is a note whose title is "manifest.json"
+// (case-insensitive) and whose body parses as a JSON object with the
+// minimum fields the URL installer requires: a "main" string + the
+// fields validateManifest() accepts.
+//
+// The scan is pure — it reads from arrays the caller passed in, never
+// from a fresh store snapshot, so it tests cleanly. The PluginsSettingsPanel
+// is responsible for handing it the live notes + folders list.
+
+import { validateManifest, type PluginManifest } from './manifest'
+import type { Note, Folder } from '@/types'
+
+export interface VaultManifestCandidate {
+  /** Validated + normalised manifest. */
+  manifest: PluginManifest
+  /** The `main` URL from the raw manifest JSON. The installer fetches
+   *  this verbatim when the user confirms install. */
+  mainUrl: string
+  /** Note id whose body contained the manifest. */
+  noteId: string
+  /** Folder-prefixed display path, e.g. "Plugins/word-count/manifest.json".
+   *  Plain string for display only. */
+  pathInVault: string
+}
+
+export interface VaultScanResult {
+  candidates: VaultManifestCandidate[]
+  /** Notes whose title matched but whose body failed to parse or
+   *  validate. Surfaced as a count so the user knows the scan saw
+   *  something but skipped it. */
+  skipped: number
+}
+
+const MANIFEST_TITLE_RE = /^manifest\.json$/i
+
+export function scanVaultForManifests(
+  notes: ReadonlyArray<Note>,
+  folders: ReadonlyArray<Folder>,
+): VaultScanResult {
+  const byId = new Map(folders.map((f) => [f.id, f] as const))
+  const candidates: VaultManifestCandidate[] = []
+  let skipped = 0
+
+  for (const note of notes) {
+    if (note.isDeleted) continue
+    if (!MANIFEST_TITLE_RE.test(note.title ?? '')) continue
+
+    const candidate = tryParseManifestNote(note, byId)
+    if (candidate === null) {
+      skipped += 1
+      continue
+    }
+    candidates.push(candidate)
+  }
+
+  candidates.sort((a, b) => a.pathInVault.localeCompare(b.pathInVault))
+  return { candidates, skipped }
+}
+
+function tryParseManifestNote(
+  note: Note,
+  byId: ReadonlyMap<string, Folder>,
+): VaultManifestCandidate | null {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(note.content ?? '')
+  } catch {
+    return null
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+
+  const raw = parsed as Record<string, unknown>
+  const mainField = raw.main
+  if (typeof mainField !== 'string' || mainField.length === 0) return null
+
+  // Strip `main` before validating — the schema treats it as unknown.
+  const { main: _omit, ...rest } = raw
+  void _omit
+  const result = validateManifest(rest)
+  if (!result.ok || !result.manifest) return null
+
+  return {
+    manifest: result.manifest,
+    mainUrl: mainField,
+    noteId: note.id,
+    pathInVault: buildPath(note, byId),
+  }
+}
+
+function buildPath(note: Note, byId: ReadonlyMap<string, Folder>): string {
+  const segs: string[] = []
+  let cur = note.folderId ? byId.get(note.folderId) : undefined
+  for (let i = 0; cur && i < 32; i++) {
+    if (cur.isDeleted) break
+    segs.unshift(cur.name)
+    cur = cur.parentId ? byId.get(cur.parentId) : undefined
+  }
+  segs.push(note.title ?? 'manifest.json')
+  return segs.join('/')
+}


### PR DESCRIPTION
## Summary

- Adds a "Scan vault for plugins" button to Settings → Plugins. The scan walks the live note store for notes titled `manifest.json` whose body parses as a valid plugin manifest, then renders each candidate inline with name, version, and folder-prefixed path.
- New installer helper `fetchPluginFromManifest` accepts an already-validated manifest object and fetches just the bundle. The vault path uses it via `fetchPluginForInstallFromVault`.
- Each candidate's Install button hands the assembled `InstalledPluginRecord` to the existing `plugin-install-confirm` modal, so the user sees the same permissions / surfaces preview the URL flow already triggers.

## Design decision: composing with the install flow

The existing modal accepts `modal.data.record` (a pre-fetched `InstalledPluginRecord`). The cleanest fit for the vault path was to keep that contract unchanged: parse + validate the manifest from the note body in-memory, fetch the bundle, build a record, hand it off. No new modal data field, no in-vault bundle storage, no duplication of the permissions UI. The vault-scan record's `sourceUrl` is set to `vault: <path>` so the installed list shows where the manifest came from.

Note: the prompt referenced PR #50 (the manifest-preview modal with capability prose, `modal.data.manifestUrl`). That work has not landed on `dev` yet — it lives on `feat/plugin-manifest-preview-modal`. This branch bases on the current `dev` (manifest_url modal not present). If the preview modal merges next, the vault path keeps working: it still hands a fully-fetched record over. If that PR rewires the modal to take a URL instead, this branch's `handleInstallFromVault` is one tiny call swap away from feeding it a `data: { record }` vs. a `data: { manifest, mainUrl }` shape.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — full suite passes (2047 passing, 17 skipped). 16 new tests across:
  - `src/__tests__/plugins/vaultScan.test.ts` — finds known manifests, skips non-manifest JSON, skips deleted, ignores non-`manifest.json` titles, case-insensitive title match, nested folder path, sort order, empty vault, mixed valid + invalid skip-count
  - `src/__tests__/plugins/pluginsSettingsPanelVaultScan.test.tsx` — empty state, results list rendering, skip count, Install opens confirm modal with record, fetch-failure error state, scan-failure error state

Closes #43.