### PR TITLE
feat(settings): in-modal search for finding settings by keyword

### DIFF
--- a/src/__tests__/settingsSearch.test.tsx
+++ b/src/__tests__/settingsSearch.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * settingsSearch.test.tsx
+ *
+ * Unit tests for the in-modal Settings search:
+ *   - filterSettingsCatalog matches label, description, category, and
+ *     keywords case-insensitively and returns an empty list on no match.
+ *   - The Settings modal search input clears on Escape while the modal
+ *     stays open.
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+  keys: jest.fn().mockResolvedValue([]),
+}))
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+import {
+  filterSettingsCatalog,
+} from '../components/modals/settings/filterSettingsCatalog'
+import {
+  SETTINGS_CATALOG,
+  type SettingsCatalogEntry,
+} from '../components/modals/settings/settingsCatalog'
+import { SettingsModal } from '../components/modals/SettingsModal'
+import { useUIStore } from '../stores/uiStore'
+
+describe('filterSettingsCatalog', () => {
+  const sample: readonly SettingsCatalogEntry[] = [
+    {
+      id: 'a.one',
+      categoryId: 'editor',
+      categoryLabel: 'Editor',
+      label: 'Open notes in preview mode',
+      description: 'Clicking a note opens the rendered markdown.',
+      keywords: ['preview', 'render'],
+    },
+    {
+      id: 'a.two',
+      categoryId: 'github',
+      categoryLabel: 'GitHub sync',
+      label: 'Auto-sync on startup',
+      description: 'Pull and push once at boot.',
+      keywords: ['github', 'sync'],
+    },
+    {
+      id: 'a.three',
+      categoryId: 'appearance',
+      categoryLabel: 'Appearance',
+      label: 'Text font',
+      description: 'Font used for note bodies.',
+      keywords: ['typography'],
+    },
+  ]
+
+  test('returns empty list for empty query', () => {
+    expect(filterSettingsCatalog(sample, '')).toEqual([])
+    expect(filterSettingsCatalog(sample, '   ')).toEqual([])
+  })
+
+  test('matches against label, case-insensitive', () => {
+    const out = filterSettingsCatalog(sample, 'PREVIEW')
+    expect(out).toHaveLength(1)
+    expect(out[0].id).toBe('a.one')
+  })
+
+  test('matches against description', () => {
+    const out = filterSettingsCatalog(sample, 'boot')
+    expect(out).toHaveLength(1)
+    expect(out[0].id).toBe('a.two')
+  })
+
+  test('matches against category label', () => {
+    const out = filterSettingsCatalog(sample, 'github')
+    expect(out).toHaveLength(1)
+    expect(out[0].id).toBe('a.two')
+  })
+
+  test('matches against keywords', () => {
+    const out = filterSettingsCatalog(sample, 'typography')
+    expect(out).toHaveLength(1)
+    expect(out[0].id).toBe('a.three')
+  })
+
+  test('returns empty list when no entry matches', () => {
+    expect(filterSettingsCatalog(sample, 'xyznevermatches')).toEqual([])
+  })
+
+  test('catalog itself has entries and matches realistic queries', () => {
+    expect(SETTINGS_CATALOG.length).toBeGreaterThan(0)
+    expect(filterSettingsCatalog(SETTINGS_CATALOG, 'font').length).toBeGreaterThan(0)
+    expect(filterSettingsCatalog(SETTINGS_CATALOG, 'shortcut').length).toBeGreaterThan(0)
+  })
+})
+
+describe('SettingsModal search input', () => {
+  beforeEach(() => {
+    useUIStore.setState({
+      sidebarCollapsed: false,
+      sidebarWidth: 256,
+      isSearchOpen: false,
+      searchQuery: '',
+      isPreviewMode: false,
+      contextMenu: null,
+      modal: { type: 'settings' },
+      currentView: 'notes',
+      renameRequest: null,
+    })
+  })
+
+  test('renders the search input with the documented placeholder', () => {
+    render(<SettingsModal />)
+    const input = screen.getByTestId('settings-search-input') as HTMLInputElement
+    expect(input).toBeInTheDocument()
+    expect(input.placeholder).toBe('Search settings')
+  })
+
+  test('typing a query swaps the category panel for the results list', () => {
+    render(<SettingsModal />)
+    const input = screen.getByTestId('settings-search-input')
+    fireEvent.change(input, { target: { value: 'font' } })
+    expect(screen.getByTestId('settings-search-results')).toBeInTheDocument()
+    expect(screen.queryByTestId('settings-panel-general')).not.toBeInTheDocument()
+  })
+
+  test('no-match query renders the documented empty state', () => {
+    render(<SettingsModal />)
+    const input = screen.getByTestId('settings-search-input')
+    fireEvent.change(input, { target: { value: 'zzznotathing' } })
+    const empty = screen.getByTestId('settings-search-empty')
+    expect(empty.textContent).toBe('No settings match “zzznotathing”.')
+  })
+
+  test('Escape on the search input clears the query and leaves the modal open', () => {
+    render(<SettingsModal />)
+    const input = screen.getByTestId('settings-search-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'font' } })
+    expect(input.value).toBe('font')
+
+    // Focus then dispatch Escape via the document so the capture-phase
+    // listener (which beats the Modal close handler) fires.
+    act(() => {
+      input.focus()
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    })
+
+    expect((screen.getByTestId('settings-search-input') as HTMLInputElement).value).toBe('')
+    // Modal stayed open — category panel is back in the DOM.
+    expect(screen.getByTestId('settings-panel-general')).toBeInTheDocument()
+  })
+
+  test('clear button empties the query', () => {
+    render(<SettingsModal />)
+    const input = screen.getByTestId('settings-search-input') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'font' } })
+    fireEvent.click(screen.getByTestId('settings-search-clear'))
+    expect((screen.getByTestId('settings-search-input') as HTMLInputElement).value).toBe('')
+  })
+})

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -19,6 +19,8 @@ import {
   ViewColumnsIcon,
   EyeIcon,
   FolderOpenIcon,
+  MagnifyingGlassIcon,
+  XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { PANELS } from '@/components/sidebar/sidebarPanelRegistry'
 import { THEME_TOKENS, THEME_PRESETS } from '@/utils/theme'
@@ -44,6 +46,8 @@ import {
 import { EmailSignup } from '@/components/marketing/EmailSignup'
 import { PluginsSettingsPanel } from './PluginsSettingsPanel'
 import { isIosSafari, isStandalone } from '@/components/pwa/PwaProvider'
+import { SETTINGS_CATALOG, type SettingsCatalogEntry } from './settings/settingsCatalog'
+import { filterSettingsCatalog, groupByCategory } from './settings/filterSettingsCatalog'
 
 // One row in the left-side category navigator. Order here drives the
 // rendering order of the list AND the keyboard up/down nav (later).
@@ -97,6 +101,81 @@ export const SettingsModal = () => {
   // when the modal re-opens via `key={modal.type}` on the inner panel —
   // not strictly necessary but it keeps the default predictable.
   const [active, setActive] = useState<CategoryId>('general')
+  const [query, setQuery] = useState('')
+  const searchInputRef = useRef<HTMLInputElement | null>(null)
+
+  // Reset state every time the modal opens fresh.
+  useEffect(() => {
+    if (isOpen) {
+      setQuery('')
+      setActive('general')
+    }
+  }, [isOpen])
+
+  // Auto-focus the search input when the modal opens, and listen for `/`
+  // to refocus from elsewhere in the modal. Esc while the search has a
+  // query clears it; Modal's own Esc handler then closes the modal on
+  // the next press (because we stop propagation only when there is a
+  // query to clear).
+  useEffect(() => {
+    if (!isOpen) return
+    // Defer focus one frame so the input is mounted.
+    const id = window.requestAnimationFrame(() => {
+      searchInputRef.current?.focus()
+    })
+    return () => window.cancelAnimationFrame(id)
+  }, [isOpen])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const handler = (e: KeyboardEvent) => {
+      // `/` from anywhere in the modal refocuses the search input, as
+      // long as the user is not already typing into another text field
+      // where `/` is a real character.
+      if (e.key === '/' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const target = e.target as HTMLElement | null
+        const tag = target?.tagName
+        const editable = tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable
+        if (!editable || target === searchInputRef.current) {
+          e.preventDefault()
+          searchInputRef.current?.focus()
+          searchInputRef.current?.select()
+        }
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [isOpen])
+
+  // Capture-phase Escape interceptor: if the search has a query, swallow
+  // the first Escape so Modal's own listener does not close the modal.
+  useEffect(() => {
+    if (!isOpen) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      if (query.length === 0) return
+      const focused = document.activeElement
+      if (focused !== searchInputRef.current) return
+      e.preventDefault()
+      e.stopImmediatePropagation()
+      setQuery('')
+    }
+    document.addEventListener('keydown', handler, true)
+    return () => document.removeEventListener('keydown', handler, true)
+  }, [isOpen, query])
+
+  const trimmedQuery = query.trim()
+  const isSearching = trimmedQuery.length > 0
+  const searchResults = useMemo(
+    () => (isSearching ? filterSettingsCatalog(SETTINGS_CATALOG, trimmedQuery) : []),
+    [isSearching, trimmedQuery],
+  )
+
+  const handleJumpToCategory = (categoryId: CategoryId) => {
+    setActive(categoryId)
+    setQuery('')
+    searchInputRef.current?.blur()
+  }
 
   return (
     <Modal
@@ -106,53 +185,153 @@ export const SettingsModal = () => {
       size="3xl"
       bodyless
     >
-      <div className="flex flex-col md:flex-row h-[80dvh] md:h-[70dvh] min-h-[480px]">
-        {/* ── Mobile (≤md): horizontal scroll strip of category chips
-                across the top. Desktop: vertical left rail.
-            Same buttons, different container; only the wrapper class
-            changes by breakpoint. */}
-        <nav
-          aria-label="Settings categories"
-          className="md:w-52 md:flex-none md:border-r border-b md:border-b-0 border-obsidianBorder bg-obsidianBlack/40 overflow-x-auto md:overflow-x-visible md:overflow-y-auto py-1 md:py-2 flex md:block flex-row gap-1 md:gap-0 px-2 md:px-0 flex-none"
-          data-testid="settings-categories"
-        >
-          {CATEGORIES.map(cat => {
-            const isActive = cat.id === active
-            return (
+      <div className="flex flex-col h-[80dvh] md:h-[70dvh] min-h-[480px]">
+        {/* Sticky search row spanning sidebar + main column. */}
+        <div className="flex-none border-b border-obsidianBorder px-3 py-2 bg-obsidianBlack/40">
+          <div className="relative">
+            <MagnifyingGlassIcon className="w-4 h-4 absolute left-2 top-1/2 -translate-y-1/2 text-obsidianSecondaryText pointer-events-none" />
+            <input
+              ref={searchInputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search settings"
+              aria-label="Search settings"
+              data-testid="settings-search-input"
+              className="w-full pl-8 pr-8 py-1.5 text-sm bg-obsidianDarkGray border border-obsidianBorder rounded text-obsidianText placeholder-obsidianSecondaryText focus:outline-none focus:border-obsidianAccentPurple"
+            />
+            {query.length > 0 && (
               <button
-                key={cat.id}
                 type="button"
-                onClick={() => setActive(cat.id)}
-                aria-current={isActive ? 'page' : undefined}
-                data-testid={`settings-cat-${cat.id}`}
-                className={[
-                  // Mobile: rounded chip; desktop: full-width row.
-                  'flex items-center gap-2 text-sm text-left transition-colors flex-none',
-                  'px-3 py-1.5 rounded md:rounded-none md:w-full md:px-3 md:py-1.5',
-                  isActive
-                    ? 'bg-obsidianAccentPurple/15 text-obsidianText md:border-l-2 md:border-obsidianAccentPurple md:pl-[10px]'
-                    : 'text-obsidianSecondaryText hover:bg-obsidianHighlight hover:text-obsidianText md:border-l-2 md:border-transparent md:pl-[10px]',
-                ].join(' ')}
+                onClick={() => {
+                  setQuery('')
+                  searchInputRef.current?.focus()
+                }}
+                aria-label="Clear search"
+                data-testid="settings-search-clear"
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-obsidianSecondaryText hover:text-obsidianText hover:bg-obsidianHighlight"
               >
-                <cat.Icon className="w-4 h-4 flex-none" />
-                <span className="truncate">{cat.label}</span>
+                <XMarkIcon className="w-3.5 h-3.5" />
               </button>
-            )
-          })}
-        </nav>
-
-        {/* ── Right pane: selected category content ─────────────────── */}
-        <div className="flex-1 min-w-0 flex flex-col">
-          <div
-            className="flex-1 min-h-0 overflow-y-auto p-4 md:p-5"
-            data-testid={`settings-panel-${active}`}
-          >
-            <CategoryPanel id={active} />
+            )}
           </div>
-          <SettingsFooterBar />
+        </div>
+
+        <div className="flex flex-col md:flex-row flex-1 min-h-0">
+          {/* ── Mobile (≤md): horizontal scroll strip of category chips
+                  across the top. Desktop: vertical left rail.
+              Hidden while a search query is active — the results list
+              owns the whole right pane and category context is shown
+              per-result. */}
+          {!isSearching && (
+            <nav
+              aria-label="Settings categories"
+              className="md:w-52 md:flex-none md:border-r border-b md:border-b-0 border-obsidianBorder bg-obsidianBlack/40 overflow-x-auto md:overflow-x-visible md:overflow-y-auto py-1 md:py-2 flex md:block flex-row gap-1 md:gap-0 px-2 md:px-0 flex-none"
+              data-testid="settings-categories"
+            >
+              {CATEGORIES.map(cat => {
+                const isActive = cat.id === active
+                return (
+                  <button
+                    key={cat.id}
+                    type="button"
+                    onClick={() => setActive(cat.id)}
+                    aria-current={isActive ? 'page' : undefined}
+                    data-testid={`settings-cat-${cat.id}`}
+                    className={[
+                      // Mobile: rounded chip; desktop: full-width row.
+                      'flex items-center gap-2 text-sm text-left transition-colors flex-none',
+                      'px-3 py-1.5 rounded md:rounded-none md:w-full md:px-3 md:py-1.5',
+                      isActive
+                        ? 'bg-obsidianAccentPurple/15 text-obsidianText md:border-l-2 md:border-obsidianAccentPurple md:pl-[10px]'
+                        : 'text-obsidianSecondaryText hover:bg-obsidianHighlight hover:text-obsidianText md:border-l-2 md:border-transparent md:pl-[10px]',
+                    ].join(' ')}
+                  >
+                    <cat.Icon className="w-4 h-4 flex-none" />
+                    <span className="truncate">{cat.label}</span>
+                  </button>
+                )
+              })}
+            </nav>
+          )}
+
+          {/* ── Right pane: selected category content OR search results ── */}
+          <div className="flex-1 min-w-0 flex flex-col">
+            <div
+              className="flex-1 min-h-0 overflow-y-auto p-4 md:p-5"
+              data-testid={isSearching ? 'settings-search-results' : `settings-panel-${active}`}
+            >
+              {isSearching ? (
+                <SettingsSearchResults
+                  query={trimmedQuery}
+                  results={searchResults}
+                  onJump={handleJumpToCategory}
+                />
+              ) : (
+                <CategoryPanel id={active} />
+              )}
+            </div>
+            <SettingsFooterBar />
+          </div>
         </div>
       </div>
     </Modal>
+  )
+}
+
+// Renders the filtered settings list grouped by category. The Go to setting
+// button jumps to that setting's category and clears the query so the user
+// lands on the live control.
+function SettingsSearchResults({
+  query,
+  results,
+  onJump,
+}: {
+  query: string
+  results: SettingsCatalogEntry[]
+  onJump: (categoryId: CategoryId) => void
+}) {
+  if (results.length === 0) {
+    return (
+      <div className="text-sm text-obsidianSecondaryText" data-testid="settings-search-empty">
+        No settings match &ldquo;{query}&rdquo;.
+      </div>
+    )
+  }
+  const groups = groupByCategory(results)
+  return (
+    <div className="space-y-5" data-testid="settings-search-list">
+      {groups.map(group => (
+        <div key={group.categoryId} className="space-y-2">
+          <div className="text-xs uppercase tracking-wide text-obsidianSecondaryText">
+            {group.categoryLabel}
+          </div>
+          <ul className="divide-y divide-obsidianBorder border border-obsidianBorder rounded">
+            {group.items.map(item => (
+              <li
+                key={item.id}
+                className="p-3 flex items-start justify-between gap-3"
+                data-testid={`settings-search-result-${item.id}`}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-sm text-obsidianText">{item.label}</div>
+                  <div className="text-xs text-obsidianSecondaryText mt-0.5">
+                    {item.description}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onJump(item.categoryId as CategoryId)}
+                  className="flex-none px-2 py-1 text-xs rounded border border-obsidianBorder text-obsidianText hover:border-obsidianAccentPurple hover:bg-obsidianHighlight/40 transition-colors"
+                >
+                  Go to setting
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
   )
 }
 

--- a/src/components/modals/settings/filterSettingsCatalog.ts
+++ b/src/components/modals/settings/filterSettingsCatalog.ts
@@ -1,0 +1,35 @@
+import type { SettingsCatalogEntry } from './settingsCatalog'
+
+export function filterSettingsCatalog(
+  entries: readonly SettingsCatalogEntry[],
+  query: string,
+): SettingsCatalogEntry[] {
+  const q = query.trim().toLowerCase()
+  if (!q) return []
+  return entries.filter(entry => {
+    if (entry.label.toLowerCase().includes(q)) return true
+    if (entry.description.toLowerCase().includes(q)) return true
+    if (entry.categoryLabel.toLowerCase().includes(q)) return true
+    if (entry.keywords && entry.keywords.some(k => k.toLowerCase().includes(q))) return true
+    return false
+  })
+}
+
+export function groupByCategory(
+  entries: readonly SettingsCatalogEntry[],
+): { categoryId: SettingsCatalogEntry['categoryId']; categoryLabel: string; items: SettingsCatalogEntry[] }[] {
+  const buckets = new Map<string, { categoryId: SettingsCatalogEntry['categoryId']; categoryLabel: string; items: SettingsCatalogEntry[] }>()
+  for (const entry of entries) {
+    const bucket = buckets.get(entry.categoryId)
+    if (bucket) {
+      bucket.items.push(entry)
+    } else {
+      buckets.set(entry.categoryId, {
+        categoryId: entry.categoryId,
+        categoryLabel: entry.categoryLabel,
+        items: [entry],
+      })
+    }
+  }
+  return Array.from(buckets.values())
+}

--- a/src/components/modals/settings/settingsCatalog.ts
+++ b/src/components/modals/settings/settingsCatalog.ts
@@ -1,0 +1,521 @@
+// Static catalog of every user-visible setting surfaced by SettingsModal.
+//
+// The catalog is consumed by the in-modal search UI to filter across
+// label, description, category, and keywords without each panel having
+// to declare its own searchable metadata. Adding a new setting means
+// adding one entry here AND the actual UI in the panel — the search
+// will not pick up controls that are not catalogued.
+
+export type SettingsCategoryId =
+  | 'general'
+  | 'appearance'
+  | 'editor'
+  | 'sidebar'
+  | 'attachments'
+  | 'daily-notes'
+  | 'templates'
+  | 'github'
+  | 'local-folder'
+  | 'ai'
+  | 'shortcuts'
+  | 'export'
+  | 'plugins'
+  | 'beta'
+  | 'about'
+
+export interface SettingsCatalogEntry {
+  id: string
+  label: string
+  description: string
+  categoryId: SettingsCategoryId
+  categoryLabel: string
+  keywords?: readonly string[]
+}
+
+export const SETTINGS_CATALOG: readonly SettingsCatalogEntry[] = [
+  // ── General ─────────────────────────────────────────────────────────
+  {
+    id: 'general.startupNote',
+    categoryId: 'general',
+    categoryLabel: 'General',
+    label: 'Open on launch',
+    description: 'Which note opens automatically when Noteser starts. Leave on Welcome view to keep the current behaviour.',
+    keywords: ['startup', 'boot', 'launch', 'welcome', 'home'],
+  },
+  {
+    id: 'general.folderSortMode',
+    categoryId: 'general',
+    categoryLabel: 'General',
+    label: 'Sort notes within folders',
+    description: 'How notes are ordered in the sidebar. Manual = insertion order.',
+    keywords: ['sort', 'order', 'alphabetical', 'modified', 'created'],
+  },
+  {
+    id: 'general.showHiddenFolders',
+    categoryId: 'general',
+    categoryLabel: 'General',
+    label: 'Show hidden folders',
+    description: 'Folders whose name starts with a dot (.obsidian, .github, …). Turn off to suppress them from the sidebar.',
+    keywords: ['hidden', 'dotfile', 'dot folder'],
+  },
+  {
+    id: 'general.trashMode',
+    categoryId: 'general',
+    categoryLabel: 'General',
+    label: 'Delete behaviour',
+    description: 'What happens when you delete a note. Trash keeps it recoverable via the Trash view. No trash deletes immediately.',
+    keywords: ['delete', 'trash', 'remove'],
+  },
+  {
+    id: 'general.confirmBeforeTrash',
+    categoryId: 'general',
+    categoryLabel: 'General',
+    label: 'Confirm before moving notes to trash',
+    description: 'When off, deleting a note skips the confirmation and moves it straight to trash.',
+    keywords: ['confirm', 'delete', 'trash', 'prompt'],
+  },
+  {
+    id: 'general.confirmBulkDelete',
+    categoryId: 'general',
+    categoryLabel: 'General',
+    label: 'Confirm before bulk delete',
+    description: 'Show a confirm dialog when deleting multiple notes via the sidebar multi-select.',
+    keywords: ['confirm', 'delete', 'multi-select', 'bulk'],
+  },
+  {
+    id: 'general.shareDefaultExpiryDays',
+    categoryId: 'general',
+    categoryLabel: 'General',
+    label: 'Default expiry',
+    description: 'Days until newly-generated /share links stop rendering. 0 = no expiry.',
+    keywords: ['share', 'expiry', 'link', 'url'],
+  },
+  {
+    id: 'general.shareDefaultBurn',
+    categoryId: 'general',
+    categoryLabel: 'General',
+    label: 'Burn after first view',
+    description: 'Mark /share links so the recipient browser refuses to re-render after the first successful view.',
+    keywords: ['share', 'burn', 'link', 'one-time'],
+  },
+  {
+    id: 'general.showWelcomeTab',
+    categoryId: 'general',
+    categoryLabel: 'General',
+    label: 'Show welcome tab',
+    description: 'Reopens the Welcome tab with the feature tour link, starter vaults, and getting-started shortcuts.',
+    keywords: ['welcome', 'onboarding', 'tour'],
+  },
+
+  // ── Appearance ──────────────────────────────────────────────────────
+  {
+    id: 'appearance.themePresets',
+    categoryId: 'appearance',
+    categoryLabel: 'Appearance',
+    label: 'Theme presets',
+    description: 'Pick a preset palette. Changes apply instantly and sync across devices via your vault settings file.',
+    keywords: ['theme', 'preset', 'palette', 'colors', 'dark', 'light'],
+  },
+  {
+    id: 'appearance.themeTokens',
+    categoryId: 'appearance',
+    categoryLabel: 'Appearance',
+    label: 'Individual tokens',
+    description: 'Per-token color overrides for fine-grained tweaks on top of the active preset.',
+    keywords: ['theme', 'color', 'token', 'override', 'css variable'],
+  },
+  {
+    id: 'appearance.fontText',
+    categoryId: 'appearance',
+    categoryLabel: 'Appearance',
+    label: 'Text font',
+    description: 'Font used for note bodies. Choose a curated family or type a font installed on this device.',
+    keywords: ['font', 'typography', 'text', 'body'],
+  },
+  {
+    id: 'appearance.fontMono',
+    categoryId: 'appearance',
+    categoryLabel: 'Appearance',
+    label: 'Monospace font',
+    description: 'Font used for code blocks and inline code.',
+    keywords: ['font', 'monospace', 'code', 'mono'],
+  },
+  {
+    id: 'appearance.fontInterface',
+    categoryId: 'appearance',
+    categoryLabel: 'Appearance',
+    label: 'Interface font',
+    description: 'Font used for the sidebar, toolbars, and modals.',
+    keywords: ['font', 'interface', 'ui', 'chrome'],
+  },
+
+  // ── Editor ──────────────────────────────────────────────────────────
+  {
+    id: 'editor.notesOpenInPreviewMode',
+    categoryId: 'editor',
+    categoryLabel: 'Editor',
+    label: 'Open notes in preview mode',
+    description: 'When ON (default), clicking a note opens the rendered markdown. Toggle to edit mode any time with the pencil icon.',
+    keywords: ['preview', 'edit mode', 'render', 'markdown'],
+  },
+  {
+    id: 'editor.autocorrect',
+    categoryId: 'editor',
+    categoryLabel: 'Editor',
+    label: 'Autocorrect and word suggestions',
+    description: 'Lets your keyboard autocorrect, auto-capitalisation, and predictive text suggestions work while you type.',
+    keywords: ['autocorrect', 'spell', 'suggestion', 'keyboard', 'mobile'],
+  },
+  {
+    id: 'editor.reopenTabsOnStartup',
+    categoryId: 'editor',
+    categoryLabel: 'Editor',
+    label: 'Reopen tabs on startup',
+    description: 'When ON (default), the notes you had open are reopened when you reload or return to noteser.',
+    keywords: ['tabs', 'startup', 'restore', 'session'],
+  },
+  {
+    id: 'editor.taskListDensity',
+    categoryId: 'editor',
+    categoryLabel: 'Editor',
+    label: 'Task list density',
+    description: 'Spacing inside tasks query blocks. Comfortable matches Obsidian; Compact is the legacy noteser default.',
+    keywords: ['task', 'density', 'spacing', 'compact', 'comfortable'],
+  },
+  {
+    id: 'editor.taskQueryLenientDoneToday',
+    categoryId: 'editor',
+    categoryLabel: 'Editor',
+    label: 'Match completed tasks without a date stamp as done today',
+    description: 'When ON, done today also matches completed tasks without a completion date if their note was updated today.',
+    keywords: ['task', 'done today', 'completion', 'query'],
+  },
+
+  // ── Sidebar ─────────────────────────────────────────────────────────
+  {
+    id: 'sidebar.hiddenTabs',
+    categoryId: 'sidebar',
+    categoryLabel: 'Sidebar',
+    label: 'Hidden sidebar tabs',
+    description: 'Tabs you have hidden from the sidebar strip. Show them again to restore.',
+    keywords: ['sidebar', 'tabs', 'hidden', 'restore'],
+  },
+
+  // ── Attachments ─────────────────────────────────────────────────────
+  {
+    id: 'attachments.folder',
+    categoryId: 'attachments',
+    categoryLabel: 'Attachments',
+    label: 'Attachments folder',
+    description: 'Folder where new attachments are stored. Existing files keep their original path.',
+    keywords: ['attachment', 'folder', 'images', 'files'],
+  },
+  {
+    id: 'attachments.cleanupOrphans',
+    categoryId: 'attachments',
+    categoryLabel: 'Attachments',
+    label: 'Clean up orphans',
+    description: 'Delete attachments that are not referenced by any note.',
+    keywords: ['orphan', 'cleanup', 'attachment', 'unused'],
+  },
+
+  // ── Daily and weekly notes ──────────────────────────────────────────
+  {
+    id: 'dailyNotes.folder',
+    categoryId: 'daily-notes',
+    categoryLabel: 'Daily and weekly notes',
+    label: 'Daily notes folder',
+    description: 'Where new daily notes are created.',
+    keywords: ['daily', 'folder', 'journal'],
+  },
+  {
+    id: 'dailyNotes.dateFormat',
+    categoryId: 'daily-notes',
+    categoryLabel: 'Daily and weekly notes',
+    label: 'Daily note date format',
+    description: 'Title format. Tokens: YYYY YY MMMM MMM MM M DD D dddd ddd.',
+    keywords: ['daily', 'date', 'format', 'title'],
+  },
+  {
+    id: 'dailyNotes.weekStartDay',
+    categoryId: 'daily-notes',
+    categoryLabel: 'Daily and weekly notes',
+    label: 'Calendar starts on',
+    description: 'First day of the week in the sidebar Calendar grid. Per-device display preference, not synced.',
+    keywords: ['calendar', 'week', 'sunday', 'monday'],
+  },
+  {
+    id: 'weeklyNotes.folder',
+    categoryId: 'daily-notes',
+    categoryLabel: 'Daily and weekly notes',
+    label: 'Weekly notes folder',
+    description: 'Where new weekly notes are created.',
+    keywords: ['weekly', 'folder', 'journal'],
+  },
+  {
+    id: 'weeklyNotes.dateFormat',
+    categoryId: 'daily-notes',
+    categoryLabel: 'Daily and weekly notes',
+    label: 'Weekly note title format',
+    description: 'Title format for weekly notes. Tokens include WW / W (ISO week number).',
+    keywords: ['weekly', 'date', 'format', 'iso week'],
+  },
+
+  // ── Templates ───────────────────────────────────────────────────────
+  {
+    id: 'templates.folder',
+    categoryId: 'templates',
+    categoryLabel: 'Templates',
+    label: 'Templates folder',
+    description: 'Where template notes live. Notes inside this folder appear in the template pickers.',
+    keywords: ['template', 'folder'],
+  },
+  {
+    id: 'templates.dailyTemplate',
+    categoryId: 'templates',
+    categoryLabel: 'Templates',
+    label: 'Daily note template',
+    description: 'When a daily note is created (Alt+D / calendar click), its content is seeded from this note.',
+    keywords: ['template', 'daily', 'seed'],
+  },
+  {
+    id: 'templates.weeklyTemplate',
+    categoryId: 'templates',
+    categoryLabel: 'Templates',
+    label: 'Weekly note template',
+    description: 'When a weekly note is created (calendar W-column click), its content is seeded from this note.',
+    keywords: ['template', 'weekly', 'seed'],
+  },
+
+  // ── GitHub sync ─────────────────────────────────────────────────────
+  {
+    id: 'github.autoSyncOnStart',
+    categoryId: 'github',
+    categoryLabel: 'GitHub sync',
+    label: 'Auto-sync on startup',
+    description: 'When the app boots and a repo is connected, pull and push once automatically.',
+    keywords: ['github', 'sync', 'startup', 'auto'],
+  },
+  {
+    id: 'github.pullOnlyOnStartup',
+    categoryId: 'github',
+    categoryLabel: 'GitHub sync',
+    label: 'Pull-only on startup',
+    description: 'When auto-sync runs on boot, only PULL. Local edits stay local until you click Commit and Sync.',
+    keywords: ['github', 'sync', 'pull', 'startup'],
+  },
+  {
+    id: 'github.autoSyncIntervalMinutes',
+    categoryId: 'github',
+    categoryLabel: 'GitHub sync',
+    label: 'Auto-sync every',
+    description: 'Minutes between auto-syncs. 0 disables periodic syncing.',
+    keywords: ['github', 'sync', 'interval', 'period', 'auto'],
+  },
+  {
+    id: 'github.defaultCommitMessage',
+    categoryId: 'github',
+    categoryLabel: 'GitHub sync',
+    label: 'Default commit message',
+    description: 'Pre-fills the Source Control commit textarea. Supports {{date}} substitution.',
+    keywords: ['commit', 'message', 'template', 'github'],
+  },
+  {
+    id: 'github.settingsFolderPath',
+    categoryId: 'github',
+    categoryLabel: 'GitHub sync',
+    label: 'Settings folder',
+    description: 'Repo path that holds settings.json. Empty disables settings sync.',
+    keywords: ['settings', 'folder', 'path', 'github', 'sync'],
+  },
+  {
+    id: 'github.vaultGitignore',
+    categoryId: 'github',
+    categoryLabel: 'GitHub sync',
+    label: 'Vault .gitignore',
+    description: 'The shared ignore file at the repo root. Fetch, edit, and the next sync pushes your changes.',
+    keywords: ['gitignore', 'ignore', 'github', 'vault'],
+  },
+  {
+    id: 'github.localGitignoreOverlay',
+    categoryId: 'github',
+    categoryLabel: 'GitHub sync',
+    label: 'Local ignore patterns',
+    description: 'Per-device additions to the vault .gitignore. One pattern per line.',
+    keywords: ['gitignore', 'ignore', 'local', 'overlay'],
+  },
+  {
+    id: 'github.vaultEncryption',
+    categoryId: 'github',
+    categoryLabel: 'GitHub sync',
+    label: 'Vault encryption',
+    description: 'AES-GCM-encrypt note bodies before pushing to GitHub. Passphrase is never persisted.',
+    keywords: ['encryption', 'aes', 'passphrase', 'security', 'github'],
+  },
+  {
+    id: 'github.resetToRemote',
+    categoryId: 'github',
+    categoryLabel: 'GitHub sync',
+    label: 'Reset to remote',
+    description: 'Discard local edits to pushed notes and pull a fresh copy from the repo.',
+    keywords: ['reset', 'remote', 'discard', 'github'],
+  },
+
+  // ── Local folder ────────────────────────────────────────────────────
+  {
+    id: 'localFolder.connect',
+    categoryId: 'local-folder',
+    categoryLabel: 'Local folder',
+    label: 'Local folder sync',
+    description: 'Mirror your vault to a folder on disk (Obsidian-style local vault). Push out for backup or re-import after editing elsewhere.',
+    keywords: ['local', 'folder', 'sync', 'disk', 'obsidian', 'filesystem'],
+  },
+  {
+    id: 'localFolder.inFolderGit',
+    categoryId: 'local-folder',
+    categoryLabel: 'Local folder',
+    label: 'In-folder git',
+    description: 'Initialise, set remote, commit, and push the connected local folder directly from noteser when it is a git repo.',
+    keywords: ['git', 'commit', 'push', 'remote', 'local folder'],
+  },
+
+  // ── AI ──────────────────────────────────────────────────────────────
+  {
+    id: 'ai.provider',
+    categoryId: 'ai',
+    categoryLabel: 'AI',
+    label: 'AI provider',
+    description: 'Which AI service to call. Off disables every AI feature.',
+    keywords: ['ai', 'provider', 'anthropic', 'openai', 'claude'],
+  },
+  {
+    id: 'ai.apiKey',
+    categoryId: 'ai',
+    categoryLabel: 'AI',
+    label: 'AI API key',
+    description: 'Paste your provider key. Masked in this field; stored in localStorage.',
+    keywords: ['ai', 'key', 'token', 'api'],
+  },
+  {
+    id: 'ai.model',
+    categoryId: 'ai',
+    categoryLabel: 'AI',
+    label: 'AI model',
+    description: 'Free-form model id. Leave the suggested default unless you need a specific snapshot.',
+    keywords: ['ai', 'model', 'gpt', 'claude'],
+  },
+  {
+    id: 'ai.embeddingsEnabled',
+    categoryId: 'ai',
+    categoryLabel: 'AI',
+    label: 'Enable AI embeddings',
+    description: 'Index notes via OpenAI text-embedding-3-small to power the Related notes panel.',
+    keywords: ['embeddings', 'related', 'openai', 'index', 'vector'],
+  },
+  {
+    id: 'ai.commitMessages',
+    categoryId: 'ai',
+    categoryLabel: 'AI',
+    label: 'AI-drafted commit messages',
+    description: 'When syncing, ask the model to draft a one-line commit message from the pending diff.',
+    keywords: ['commit', 'message', 'ai', 'sync', 'github'],
+  },
+
+  // ── Shortcuts ───────────────────────────────────────────────────────
+  {
+    id: 'shortcuts.all',
+    categoryId: 'shortcuts',
+    categoryLabel: 'Shortcuts',
+    label: 'Keyboard shortcuts',
+    description: 'Rebind any of the application keyboard shortcuts. Click a combo to capture a new one.',
+    keywords: ['keyboard', 'shortcut', 'hotkey', 'rebind', 'keybinding'],
+  },
+
+  // ── Export ──────────────────────────────────────────────────────────
+  {
+    id: 'export.action',
+    categoryId: 'export',
+    categoryLabel: 'Export',
+    label: 'Export notes',
+    description: 'Download all notes as markdown, JSON, or HTML.',
+    keywords: ['export', 'download', 'backup', 'markdown', 'json', 'html'],
+  },
+
+  // ── Plugins ─────────────────────────────────────────────────────────
+  {
+    id: 'plugins.add',
+    categoryId: 'plugins',
+    categoryLabel: 'Plugins',
+    label: 'Add a plugin',
+    description: 'Load a plugin from any HTTPS URL that serves a manifest.json. The plugin code runs in a Web Worker sandbox.',
+    keywords: ['plugin', 'install', 'manifest', 'extension', 'add'],
+  },
+  {
+    id: 'plugins.scanVault',
+    categoryId: 'plugins',
+    categoryLabel: 'Plugins',
+    label: 'Scan vault for plugins',
+    description: 'Look through your vault for notes titled manifest.json that declare a plugin.',
+    keywords: ['plugin', 'vault', 'scan', 'manifest'],
+  },
+  {
+    id: 'plugins.installed',
+    categoryId: 'plugins',
+    categoryLabel: 'Plugins',
+    label: 'Installed plugins',
+    description: 'Toggle, reload, or uninstall plugins you have installed.',
+    keywords: ['plugin', 'installed', 'uninstall', 'enable', 'disable'],
+  },
+
+  // ── Beta ────────────────────────────────────────────────────────────
+  {
+    id: 'beta.enabled',
+    categoryId: 'beta',
+    categoryLabel: 'Beta',
+    label: 'Enable beta features',
+    description: 'Master switch. Individual flags have no effect when this is off.',
+    keywords: ['beta', 'experimental', 'preview', 'flag'],
+  },
+  {
+    id: 'beta.flags',
+    categoryId: 'beta',
+    categoryLabel: 'Beta',
+    label: 'Beta feature flags',
+    description: 'Opt into work-in-progress features. They may be buggy or removed.',
+    keywords: ['beta', 'experimental', 'flag', 'feature'],
+  },
+
+  // ── About ───────────────────────────────────────────────────────────
+  {
+    id: 'about.version',
+    categoryId: 'about',
+    categoryLabel: 'About',
+    label: 'Version and build',
+    description: 'Current noteser version and build id.',
+    keywords: ['version', 'build', 'release'],
+  },
+  {
+    id: 'about.help',
+    categoryId: 'about',
+    categoryLabel: 'About',
+    label: 'Help and docs',
+    description: 'In-app help: getting started, GitHub sync, local folder, shortcuts, FAQ.',
+    keywords: ['help', 'docs', 'faq', 'getting started'],
+  },
+  {
+    id: 'about.reportBug',
+    categoryId: 'about',
+    categoryLabel: 'About',
+    label: 'Report a bug',
+    description: 'Open the bug report form with diagnostics attached.',
+    keywords: ['bug', 'report', 'issue', 'feedback'],
+  },
+  {
+    id: 'about.launchUpdates',
+    categoryId: 'about',
+    categoryLabel: 'About',
+    label: 'Get launch updates',
+    description: 'A short email when sync, mobile, and the next features land. No spam.',
+    keywords: ['email', 'updates', 'newsletter', 'launch'],
+  },
+]


### PR DESCRIPTION
## Summary

Adds a sticky search input at the top of the Settings modal so users can find a specific setting by typing a keyword instead of clicking through every category panel.

- Sticky search row spanning sidebar + main column with placeholder `Search settings`.
- Real-time case-insensitive substring filter across label, description, panel name, and per-entry keywords. Matches render grouped by their original panel.
- No-match state reads exactly `No settings match \"<query>\".`
- Keyboard: input is auto-focused when the modal opens. `/` from elsewhere in the modal refocuses (skipped if the user is typing into a different text field). `Esc` clears a non-empty query without closing the modal (capture-phase interceptor beats the Modal close handler). The clear-X button in the input mirrors this.
- Picking a result jumps the modal to that setting's category and clears the query so the user lands on the live control.

## Design decision

Approach B (lower-touch metadata). Each setting's searchable info lives in a new `settingsCatalog.ts` data module; panels keep their existing per-store render code. The catalog is consumed only by the search UI, so adding a new setting needs one extra entry but does not require refactoring the panel to a render-from-data shape. 54 entries catalogued across the existing 15 categories.

## Files touched

- `src/components/modals/SettingsModal.tsx` — search input, keyboard wiring, results renderer.
- `src/components/modals/settings/settingsCatalog.ts` — new.
- `src/components/modals/settings/filterSettingsCatalog.ts` — new (pure filter + group helpers).
- `src/__tests__/settingsSearch.test.tsx` — new (filter unit tests + modal smoke test for Esc-clears-input).

## Test plan

- [ ] `npm run typecheck` clean (verified).
- [ ] `npm run lint` clean (verified).
- [ ] `npm test` all green (174 suites, 2105 tests passing locally).
- [ ] Open Settings, type `font` — see Appearance grouping with the three font rows. Click Go to setting on Text font, land on the Appearance panel.
- [ ] Type `zzznotathing` — see `No settings match \"zzznotathing\".`
- [ ] With a non-empty query press Esc — input clears, modal stays open. Press Esc again with the input empty — modal closes.
- [ ] Focus a category button, press `/` — search input is refocused and its content is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)