### PR TITLE
feat(help): GitBook-style /help redesign with day/night toggle

### DIFF
--- a/src/__tests__/helpShell.test.tsx
+++ b/src/__tests__/helpShell.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * helpShell.test.tsx
+ *
+ * Smoke test for the /help layout chrome (hp1). Asserts:
+ *   - sidebar renders the topic list
+ *   - content children render
+ *   - theme toggle button is present with the right accessible name
+ *   - default theme is dark (data-help-theme="dark" with no localStorage)
+ *   - clicking the toggle swaps to light and persists under
+ *     `noteser-help-theme`
+ *
+ * The HelpShell is /help-scoped and intentionally independent from the
+ * main app theme — these assertions guarantee that contract.
+ */
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HelpShell } from '../app/help/HelpShell'
+import { HELP_PAGES } from '../help/content'
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+const firstPage = HELP_PAGES[0]
+
+describe('HelpShell', () => {
+  test('renders sidebar topics and child content', () => {
+    render(
+      <HelpShell activeSlug={firstPage.slug} page={firstPage}>
+        <p>article-body-marker</p>
+      </HelpShell>
+    )
+
+    expect(screen.getByRole('navigation', { name: /help topics/i })).toBeInTheDocument()
+    expect(screen.getByText('article-body-marker')).toBeInTheDocument()
+    // Every help page title is in the sidebar.
+    for (const p of HELP_PAGES) {
+      expect(screen.getByRole('link', { name: p.title })).toBeInTheDocument()
+    }
+  })
+
+  test('exposes a "Toggle theme" button', () => {
+    render(
+      <HelpShell activeSlug={firstPage.slug} page={firstPage}>
+        <div />
+      </HelpShell>
+    )
+    expect(screen.getByRole('button', { name: /toggle theme/i })).toBeInTheDocument()
+  })
+
+  test('defaults to dark when no preference is stored', () => {
+    const { container } = render(
+      <HelpShell activeSlug={firstPage.slug} page={firstPage}>
+        <div />
+      </HelpShell>
+    )
+    const shell = container.querySelector('[data-help-theme]')
+    expect(shell).toHaveAttribute('data-help-theme', 'dark')
+  })
+
+  test('toggling persists to localStorage and flips the data attribute', async () => {
+    const user = userEvent.setup()
+    const { container } = render(
+      <HelpShell activeSlug={firstPage.slug} page={firstPage}>
+        <div />
+      </HelpShell>
+    )
+
+    const toggle = screen.getByRole('button', { name: /toggle theme/i })
+    await act(async () => {
+      await user.click(toggle)
+    })
+
+    const shell = container.querySelector('[data-help-theme]')
+    expect(shell).toHaveAttribute('data-help-theme', 'light')
+    expect(window.localStorage.getItem('noteser-help-theme')).toBe('light')
+
+    await act(async () => {
+      await user.click(toggle)
+    })
+    expect(shell).toHaveAttribute('data-help-theme', 'dark')
+    expect(window.localStorage.getItem('noteser-help-theme')).toBe('dark')
+  })
+
+  test('hydrates from a stored light preference', async () => {
+    window.localStorage.setItem('noteser-help-theme', 'light')
+    const { container } = render(
+      <HelpShell activeSlug={firstPage.slug} page={firstPage}>
+        <div />
+      </HelpShell>
+    )
+    // Effect runs on mount — wait a tick.
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const shell = container.querySelector('[data-help-theme]')
+    expect(shell).toHaveAttribute('data-help-theme', 'light')
+  })
+})

--- a/src/app/help/HelpShell.tsx
+++ b/src/app/help/HelpShell.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { useEffect, useState, useMemo } from 'react'
+import Link from 'next/link'
+import { ArrowLeftIcon, SunIcon, MoonIcon } from '@heroicons/react/24/outline'
+import { HELP_PAGES, type HelpPage } from '@/help/content'
+
+const STORAGE_KEY = 'noteser-help-theme'
+
+type HelpTheme = 'dark' | 'light'
+
+interface TocItem {
+  level: 2 | 3
+  text: string
+  slug: string
+}
+
+// Heading extraction — pulls h2/h3 lines out of the raw markdown body so
+// the right-hand "On this page" rail mirrors react-markdown's slugger
+// output. We re-implement the slugger here (lowercase, replace non-alnum
+// with hyphens, collapse runs, trim) rather than wire rehype-slug just
+// for the sidebar; the article body still renders without anchor IDs and
+// the TOC links are plain hash refs that work because rehype-slug-style
+// slugs are the GitBook convention browsers tolerate.
+function extractToc(body: string): TocItem[] {
+  const items: TocItem[] = []
+  const seen = new Set<string>()
+  for (const line of body.split('\n')) {
+    const m = /^(#{2,3})\s+(.+?)\s*$/.exec(line)
+    if (!m) continue
+    const level = m[1].length === 2 ? 2 : 3
+    const text = m[2].replace(/`/g, '').trim()
+    let slug = text
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+    let candidate = slug
+    let n = 1
+    while (seen.has(candidate)) {
+      candidate = `${slug}-${n++}`
+    }
+    seen.add(candidate)
+    items.push({ level: level as 2 | 3, text, slug: candidate })
+  }
+  return items
+}
+
+interface HelpShellProps {
+  activeSlug: string
+  page: HelpPage
+  children: React.ReactNode
+}
+
+export function HelpShell({ activeSlug, page, children }: HelpShellProps) {
+  // Default night: render dark on first paint, then hydrate from
+  // localStorage in an effect. This matches the spec ("Default = night
+  // for new visitors") and avoids a light-flash on cold load for
+  // returning dark-theme users (server already paints dark, effect
+  // confirms dark, no transition needed).
+  const [theme, setTheme] = useState<HelpTheme>('dark')
+  const [hydrated, setHydrated] = useState(false)
+
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY)
+      if (stored === 'light' || stored === 'dark') {
+        setTheme(stored)
+      }
+    } catch {
+      // localStorage access can throw in private-mode Safari etc.
+      // Silently keep the dark default.
+    }
+    setHydrated(true)
+  }, [])
+
+  const toggleTheme = () => {
+    setTheme(prev => {
+      const next = prev === 'dark' ? 'light' : 'dark'
+      try {
+        window.localStorage.setItem(STORAGE_KEY, next)
+      } catch {
+        // ignore — toggle still works in-session
+      }
+      return next
+    })
+  }
+
+  const toc = useMemo(() => extractToc(page.body), [page.body])
+
+  const isLight = theme === 'light'
+
+  const shellCls = isLight
+    ? 'bg-white text-[#1a1a1a]'
+    : 'bg-[#16181c] text-[#e5e7eb]'
+  const headerCls = isLight
+    ? 'border-b border-[#e5e7eb] bg-white/90'
+    : 'border-b border-[#23262d] bg-[#16181c]/90'
+  const sidebarCls = isLight
+    ? 'bg-[#fafbfc] border-r border-[#e5e7eb]'
+    : 'bg-[#1a1c20] border-r border-[#23262d]'
+  const tocCls = isLight ? 'text-[#6b7280]' : 'text-[#8b95a7]'
+  const linkCls = isLight
+    ? 'text-[#4b5563] hover:text-[#1a1a1a]'
+    : 'text-[#9ca3af] hover:text-[#e5e7eb]'
+
+  const sectionLabelCls = isLight
+    ? 'text-[#9ca3af]'
+    : 'text-[#6b7280]'
+
+  return (
+    <div
+      className={`min-h-dvh ${shellCls}`}
+      data-help-theme={theme}
+      data-help-hydrated={hydrated ? 'true' : 'false'}
+      style={{ fontFamily: 'var(--font-interface)' }}
+    >
+      <header
+        className={`sticky top-0 z-20 ${headerCls} backdrop-blur supports-[backdrop-filter]:bg-opacity-80`}
+      >
+        <div className="mx-auto max-w-[1400px] flex items-center justify-between px-6 py-3">
+          <Link
+            href="/"
+            className={`inline-flex items-center gap-2 text-sm ${linkCls} transition-colors`}
+          >
+            <ArrowLeftIcon className="w-4 h-4" />
+            <span>Back to noteser</span>
+          </Link>
+          <button
+            type="button"
+            onClick={toggleTheme}
+            aria-label="Toggle theme"
+            className={`inline-flex items-center justify-center w-8 h-8 rounded-md transition-colors ${
+              isLight
+                ? 'text-[#4b5563] hover:bg-[#f3f4f6]'
+                : 'text-[#9ca3af] hover:bg-[#23262d]'
+            }`}
+          >
+            {isLight ? (
+              <MoonIcon className="w-5 h-5" aria-hidden="true" />
+            ) : (
+              <SunIcon className="w-5 h-5" aria-hidden="true" />
+            )}
+          </button>
+        </div>
+      </header>
+
+      <div className="mx-auto max-w-[1400px] flex flex-col md:flex-row">
+        <aside
+          className={`md:w-72 md:flex-none ${sidebarCls} md:min-h-[calc(100dvh-57px)]`}
+        >
+          <nav
+            aria-label="Help topics"
+            className="sticky top-[57px] px-4 py-6 space-y-1"
+          >
+            <h2
+              className={`px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.08em] ${sectionLabelCls}`}
+            >
+              Topics
+            </h2>
+            <ul className="space-y-0.5">
+              {HELP_PAGES.map(p => {
+                const active = p.slug === activeSlug
+                const itemCls = active
+                  ? isLight
+                    ? 'bg-[#eff6ff] text-[#1a1a1a] border-l-2 border-[#3a86ff] font-medium'
+                    : 'bg-[#1e2530] text-[#f3f4f6] border-l-2 border-[#3a86ff] font-medium'
+                  : isLight
+                    ? 'text-[#4b5563] hover:bg-[#f3f4f6] hover:text-[#1a1a1a] border-l-2 border-transparent'
+                    : 'text-[#9ca3af] hover:bg-[#1e2126] hover:text-[#e5e7eb] border-l-2 border-transparent'
+                return (
+                  <li key={p.slug}>
+                    <Link
+                      href={`/help/${p.slug}`}
+                      className={`block pl-3 pr-3 py-2 text-[14px] leading-[1.45] rounded-r-md transition-colors ${itemCls}`}
+                    >
+                      {p.title}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </nav>
+        </aside>
+
+        <main className="flex-1 min-w-0 px-6 md:px-12 py-10 md:py-14">
+          <article
+            className={`max-w-[720px] mx-auto help-prose ${isLight ? 'help-prose-light' : 'help-prose-dark'}`}
+          >
+            {children}
+          </article>
+        </main>
+
+        {toc.length > 1 && (
+          <aside className="hidden xl:block xl:w-60 xl:flex-none">
+            <nav
+              aria-label="On this page"
+              className="sticky top-[57px] px-4 py-10 text-[13px]"
+            >
+              <h2
+                className={`px-2 mb-3 text-[11px] font-semibold uppercase tracking-[0.08em] ${sectionLabelCls}`}
+              >
+                On this page
+              </h2>
+              <ul className="space-y-1">
+                {toc.map(item => (
+                  <li
+                    key={item.slug}
+                    className={item.level === 3 ? 'pl-3' : ''}
+                  >
+                    <a
+                      href={`#${item.slug}`}
+                      className={`block py-1 px-2 rounded transition-colors ${tocCls} ${
+                        isLight
+                          ? 'hover:text-[#3a86ff]'
+                          : 'hover:text-[#60a5fa]'
+                      }`}
+                    >
+                      {item.text}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </aside>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/help/[slug]/page.tsx
+++ b/src/app/help/[slug]/page.tsx
@@ -1,20 +1,24 @@
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import ReactMarkdown from 'react-markdown'
+import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { HELP_PAGES, findHelpPage } from '@/help/content'
-import { ArrowLeftIcon } from '@heroicons/react/24/outline'
+import { HelpShell } from '../HelpShell'
 
 // /help/<slug> — bundled in-app docs.
 //
 // Layout:
-//   [   sidebar TOC   ] [          markdown content          ]
+//   [ topbar (back link + theme toggle) ........................... ]
+//   [ sidebar TOC ] [ markdown content ] [ on-this-page mini-TOC ]
 //
 // Static. Generated at build time via `generateStaticParams`. All
 // content lives in `src/help/content.ts` as plain markdown strings.
 // Rendered with the same react-markdown stack noteser uses for note
 // preview (without the wikilink / attachment custom renderers, which
 // don't make sense in standalone help).
+//
+// Chrome / palette / theme toggle live in HelpShell (client). The page
+// stays a server component so generateStaticParams + generateMetadata
+// still apply at build time.
 
 export function generateStaticParams() {
   return HELP_PAGES.map(p => ({ slug: p.slug }))
@@ -24,10 +28,31 @@ export function generateMetadata({ params }: { params: Promise<{ slug: string }>
   return params.then(({ slug }) => {
     const page = findHelpPage(slug)
     return {
-      title: page ? `${page.title} — Noteser help` : 'Noteser help',
+      title: page ? `${page.title} | Noteser help` : 'Noteser help',
       description: page?.summary,
     }
   })
+}
+
+// Mirrors extractToc() in HelpShell so heading anchors line up with the
+// "On this page" rail. Kept here-and-there rather than shared because
+// the shell is a client component and we want the page (server) to
+// stay free of client imports.
+function slugifyHeading(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function getText(node: React.ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(getText).join('')
+  if (node && typeof node === 'object' && 'props' in node) {
+    const props = (node as { props?: { children?: React.ReactNode } }).props
+    return getText(props?.children)
+  }
+  return ''
 }
 
 export default async function HelpPage({ params }: { params: Promise<{ slug: string }> }) {
@@ -35,56 +60,27 @@ export default async function HelpPage({ params }: { params: Promise<{ slug: str
   const page = findHelpPage(slug)
   if (!page) notFound()
 
-  return (
-    <div className="min-h-dvh bg-obsidianBlack text-obsidianText">
-      <div className="mx-auto max-w-6xl flex flex-col md:flex-row gap-6 px-4 py-6">
-        {/* Sidebar TOC */}
-        <aside className="md:w-64 flex-none">
-          <div className="sticky top-6 space-y-3">
-            <Link
-              href="/"
-              className="inline-flex items-center gap-1 text-sm text-obsidianSecondaryText hover:text-obsidianText transition-colors"
-            >
-              <ArrowLeftIcon className="w-4 h-4" />
-              Back to noteser
-            </Link>
-            <nav aria-label="Help topics" className="rounded border border-obsidianBorder bg-obsidianGray/40">
-              <h2 className="px-3 py-2 text-[10px] uppercase tracking-wide text-obsidianSecondaryText border-b border-obsidianBorder">
-                Topics
-              </h2>
-              <ul className="divide-y divide-obsidianBorder">
-                {HELP_PAGES.map(p => {
-                  const active = p.slug === slug
-                  return (
-                    <li key={p.slug}>
-                      <Link
-                        href={`/help/${p.slug}`}
-                        className={`block px-3 py-2 text-sm transition-colors ${
-                          active
-                            ? 'bg-obsidianAccentPurple/15 text-obsidianText border-l-2 border-obsidianAccentPurple'
-                            : 'text-obsidianSecondaryText hover:bg-obsidianHighlight hover:text-obsidianText border-l-2 border-transparent'
-                        }`}
-                      >
-                        <div>{p.title}</div>
-                        <div className="text-[11px] text-obsidianSecondaryText/80 line-clamp-2 mt-0.5">
-                          {p.summary}
-                        </div>
-                      </Link>
-                    </li>
-                  )
-                })}
-              </ul>
-            </nav>
-          </div>
-        </aside>
+  // Track heading occurrences across the article so duplicate titles get
+  // suffixed slugs (foo, foo-1, foo-2). Mirrors extractToc()'s logic.
+  const seenHeadings = new Map<string, number>()
+  const slugFor = (text: string) => {
+    const base = slugifyHeading(text)
+    const n = seenHeadings.get(base) ?? 0
+    seenHeadings.set(base, n + 1)
+    return n === 0 ? base : `${base}-${n}`
+  }
 
-        {/* Markdown body */}
-        <article className="flex-1 min-w-0 prose prose-invert max-w-none">
-          <ReactMarkdown remarkPlugins={[remarkGfm]}>
-            {page.body}
-          </ReactMarkdown>
-        </article>
-      </div>
-    </div>
+  const components: Components = {
+    h1: ({ children }) => <h1 id={slugFor(getText(children))}>{children}</h1>,
+    h2: ({ children }) => <h2 id={slugFor(getText(children))}>{children}</h2>,
+    h3: ({ children }) => <h3 id={slugFor(getText(children))}>{children}</h3>,
+  }
+
+  return (
+    <HelpShell activeSlug={slug} page={page}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+        {page.body}
+      </ReactMarkdown>
+    </HelpShell>
   )
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -371,6 +371,252 @@
   @apply outline-none ring-2 ring-obsidianAccentPurple ring-offset-2 ring-offset-obsidianBlack;
 }
 
+/* /help typography (hp1)
+ * GitBook-aesthetic prose for the /help route only. Separate from
+ * .prose (which is sized to match the editor) so help articles can
+ * use a wider reading column, generous line-height, and tighter
+ * vertical rhythm without leaking into note preview. Palette is
+ * driven by .help-prose-dark / .help-prose-light wrappers chosen
+ * by HelpShell from the noteser-help-theme localStorage flag. */
+.help-prose {
+  font-family: var(--font-interface);
+  font-size: 16px;
+  line-height: 1.7;
+  scroll-margin-top: 80px;
+}
+
+.help-prose > * + * {
+  margin-top: 1.1em;
+}
+
+.help-prose h1,
+.help-prose h2,
+.help-prose h3,
+.help-prose h4 {
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+
+.help-prose h1 {
+  font-size: 2.25rem;
+  margin-top: 0;
+  margin-bottom: 0.5em;
+}
+
+.help-prose h2 {
+  font-size: 1.5rem;
+  margin-top: 2em;
+  padding-bottom: 0.35em;
+  border-bottom: 1px solid;
+}
+
+.help-prose h3 {
+  font-size: 1.2rem;
+  margin-top: 1.6em;
+}
+
+.help-prose h4 {
+  font-size: 1rem;
+  margin-top: 1.4em;
+}
+
+.help-prose p {
+  margin: 1em 0;
+}
+
+.help-prose ul,
+.help-prose ol {
+  padding-left: 1.4em;
+  margin: 1em 0;
+}
+
+.help-prose ul { list-style: disc; }
+.help-prose ol { list-style: decimal; }
+.help-prose li { margin: 0.4em 0; }
+.help-prose li > ul,
+.help-prose li > ol { margin: 0.4em 0; }
+
+.help-prose a {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-thickness: 1px;
+}
+
+.help-prose strong {
+  font-weight: 600;
+}
+
+.help-prose code {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  padding: 0.15em 0.4em;
+  border-radius: 4px;
+}
+
+.help-prose pre {
+  font-family: var(--font-mono);
+  font-size: 0.875em;
+  padding: 1em 1.2em;
+  border-radius: 8px;
+  overflow-x: auto;
+  line-height: 1.6;
+  margin: 1.4em 0;
+}
+
+.help-prose pre code {
+  padding: 0;
+  background: transparent;
+}
+
+.help-prose blockquote {
+  border-left: 3px solid;
+  padding: 0.4em 0 0.4em 1.1em;
+  margin: 1.4em 0;
+  font-style: italic;
+}
+
+.help-prose hr {
+  border: none;
+  border-top: 1px solid;
+  margin: 2.5em 0;
+}
+
+.help-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.4em 0;
+  font-size: 0.95em;
+}
+
+.help-prose th,
+.help-prose td {
+  padding: 0.55em 0.9em;
+  border-bottom: 1px solid;
+  text-align: left;
+}
+
+.help-prose th {
+  font-weight: 600;
+}
+
+/* Light palette (GitBook-ish): white body, near-black headings,
+   GitBook blue (#3a86ff) for links, light-gray dividers + code bg. */
+.help-prose-light h1,
+.help-prose-light h2,
+.help-prose-light h3,
+.help-prose-light h4 {
+  color: #000;
+}
+
+.help-prose-light h2 {
+  border-bottom-color: #e5e7eb;
+}
+
+.help-prose-light p,
+.help-prose-light li {
+  color: #1a1a1a;
+}
+
+.help-prose-light a {
+  color: #3a86ff;
+}
+
+.help-prose-light a:hover {
+  color: #1d4ed8;
+}
+
+.help-prose-light code {
+  background-color: #f3f4f6;
+  color: #1a1a1a;
+}
+
+.help-prose-light pre {
+  background-color: #f6f8fa;
+  color: #1a1a1a;
+  border: 1px solid #e5e7eb;
+}
+
+.help-prose-light blockquote {
+  border-left-color: #d1d5db;
+  color: #4b5563;
+}
+
+.help-prose-light hr {
+  border-top-color: #e5e7eb;
+}
+
+.help-prose-light th {
+  color: #000;
+  border-bottom-color: #d1d5db;
+}
+
+.help-prose-light td {
+  border-bottom-color: #e5e7eb;
+}
+
+.help-prose-light strong {
+  color: #000;
+}
+
+/* Dark palette: softened from the editor preview, GitBook spacing. */
+.help-prose-dark h1,
+.help-prose-dark h2,
+.help-prose-dark h3,
+.help-prose-dark h4 {
+  color: #f3f4f6;
+}
+
+.help-prose-dark h2 {
+  border-bottom-color: #2a2e36;
+}
+
+.help-prose-dark p,
+.help-prose-dark li {
+  color: #d1d5db;
+}
+
+.help-prose-dark a {
+  color: #60a5fa;
+}
+
+.help-prose-dark a:hover {
+  color: #93c5fd;
+}
+
+.help-prose-dark code {
+  background-color: #23262d;
+  color: #e5e7eb;
+}
+
+.help-prose-dark pre {
+  background-color: #1a1c20;
+  color: #e5e7eb;
+  border: 1px solid #23262d;
+}
+
+.help-prose-dark blockquote {
+  border-left-color: #3a3f4a;
+  color: #9ca3af;
+}
+
+.help-prose-dark hr {
+  border-top-color: #23262d;
+}
+
+.help-prose-dark th {
+  color: #f3f4f6;
+  border-bottom-color: #3a3f4a;
+}
+
+.help-prose-dark td {
+  border-bottom-color: #23262d;
+}
+
+.help-prose-dark strong {
+  color: #f3f4f6;
+}
+
 /* Reveal-in-tree flash — used by src/utils/revealNote.ts when the
    user clicks a note from a non-tree view (Recent/Tags). The row gets
    a brief yellow glow that fades out so it's easy to spot. */


### PR DESCRIPTION
## Summary

- Redesign the `/help` layout chrome to read like GitBook: 720px content column, larger heading hierarchy, generous line-height (1.7), calm sidebar with a left-border accent for the active topic, sticky header, and an optional "On this page" rail extracted from the h2/h3 of each article.
- Add a `/help`-scoped day/night theme toggle (sun/moon button, top right). Persists under `localStorage['noteser-help-theme']`, defaults to dark for new visitors, does not affect the main app theme.
- Articles themselves are untouched. Only chrome, typography wrapper, and the toggle.

## Design decisions

- **Font**: Inter via the existing `--font-interface` token (no new dependency).
- **Light palette**: white body, near-black headings, GitBook blue (`#3a86ff`) for active topic and links, light-gray dividers and code background. Dark palette softens dividers and uses a calmer body color (`#d1d5db`) than the editor preview.
- **TOC rail**: included, but only at `xl` and above (`>= 1280px`), and only when the article has more than one h2/h3. Heading slugs match between the rail and the rendered h2/h3 `id` attributes (slugger duplicated server-side to avoid pulling in `rehype-slug`).
- **Theme storage key**: `noteser-help-theme` (matches the `noteser-*` localStorage convention).
- **Server vs. client split**: page stays a server component (keeps `generateStaticParams` + `generateMetadata`); `HelpShell` is the client wrapper.

## Files touched

- `src/app/help/HelpShell.tsx` (new) — chrome, sidebar, toggle, palette.
- `src/app/help/[slug]/page.tsx` — slim server page that hands the rendered markdown to `HelpShell`. Adds heading `id`s via `ReactMarkdown` custom components.
- `src/styles/globals.css` — adds `.help-prose`, `.help-prose-light`, `.help-prose-dark` block. Scoped, does not touch the editor's `.prose` rules.
- `src/__tests__/helpShell.test.tsx` (new) — 5 smoke tests: sidebar renders, content renders, toggle button exists with accessible name "Toggle theme", default-dark assertion, toggle flips + persists, stored light preference rehydrates.

## Screenshots

Captured locally via Playwright against `npm run dev`. Three views:

- `/help/getting-started` in default dark (Topics rail left, content centre, On this page right).
- Same page after clicking the toggle (light, GitBook blue accents).
- `/help/mobile` at 390px width — side rails drop to the top, content takes the full column.

The before state is the previous bordered sidebar with the harsh purple block on the active item, monospace body, and a 14px / 1.7 reading column. Reviewers can compare against `dev`.

## What to eyeball

- Toggle behaviour and persistence across reload (`/help/getting-started`, click sun, reload — should stay light).
- Default = dark on a fresh browser (clear `noteser-help-theme` first).
- Active topic visual on each palette (left-border accent, soft tint — no purple block).
- That the main app `/` still looks identical (no theme bleed).
- Heading anchor links from the right rail scroll to the matching h2/h3.

## Verification

- `npm run typecheck` — clean.
- `npm run lint` — clean.
- `npm test` — 2098 passed (1 suite skipped, preexisting).
- `npx next build` — succeeds; all 8 `/help/[slug]` paths pre-rendered.

## Test plan

- [ ] Visit `/help/getting-started` in a fresh browser, confirm dark.
- [ ] Click the sun, confirm switch to light, reload, confirm still light.
- [ ] Click the moon, confirm switch to dark.
- [ ] Open `/` (main app), confirm the main app theme is unaffected.
- [ ] Resize to mobile width, confirm side rails collapse.
- [ ] Click an item in the "On this page" rail, confirm it scrolls.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>