### PR TITLE
fix(editor): list-cycle parks caret after the new marker

### DIFF
--- a/src/__tests__/cycleListTypeCommand.test.ts
+++ b/src/__tests__/cycleListTypeCommand.test.ts
@@ -1,0 +1,42 @@
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+}))
+
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { cycleListTypeCommand } from '../components/editor/CodeMirrorEditor'
+
+function setup(doc: string, anchor: number) {
+  const state = EditorState.create({
+    doc,
+    selection: { anchor },
+  })
+  const view = new EditorView({ state })
+  return view
+}
+
+describe('cycleListTypeCommand cursor placement', () => {
+  test('cycling an empty line to a task lands the caret AFTER the new "- [ ] " marker', () => {
+    const view = setup('', 0)
+    const handled = cycleListTypeCommand(view)
+    expect(handled).toBe(true)
+    expect(view.state.doc.toString()).toBe('1. ')
+    expect(view.state.selection.main.head).toBe(3)
+  })
+
+  test('cycling again advances state and keeps caret AFTER the new marker', () => {
+    const view = setup('1. ', 3)
+    cycleListTypeCommand(view)
+    expect(view.state.doc.toString()).toBe('- [ ] ')
+    expect(view.state.selection.main.head).toBe(6)
+  })
+
+  test('cycling a populated line places the caret at the end of the rewritten line', () => {
+    const view = setup('hello', 5)
+    cycleListTypeCommand(view)
+    expect(view.state.doc.toString()).toBe('1. hello')
+    expect(view.state.selection.main.head).toBe(8)
+  })
+})

--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -166,7 +166,7 @@ const toggleCheckboxStatus: Command = (view) => {
 // (this mirrors how the other list toggles read intent off the leading line).
 // Indentation/nesting is preserved by the pure helpers; ordered runs are then
 // renumbered so "1." sequences read 1,2,3.
-const cycleListTypeCommand: Command = (view) => {
+export const cycleListTypeCommand: Command = (view) => {
   const { state } = view
   const range = state.selection.main
   const fromLine = state.doc.lineAt(range.from)
@@ -175,13 +175,27 @@ const cycleListTypeCommand: Command = (view) => {
   const target = nextCycleState(cycleState(fromLine.text))
 
   const changes: { from: number; to: number; insert: string }[] = []
+  let firstLineNewText: string | null = null
   for (let n = fromLine.number; n <= toLine.number; n++) {
     const line = state.doc.line(n)
     const next = setCycleState(line.text, target)
     if (next !== line.text) changes.push({ from: line.from, to: line.to, insert: next })
+    if (n === fromLine.number) firstLineNewText = next
   }
   if (changes.length === 0) return false
-  view.dispatch({ changes, scrollIntoView: true })
+  // Park the caret AFTER the new marker on the first affected line so the
+  // user can keep typing without first pressing End. Without this, CodeMirror
+  // anchors the cursor to the LEFT of the inserted marker, which is the
+  // wrong UX for the "convert this line into a task" use case.
+  const firstNewLength = firstLineNewText?.length ?? fromLine.length
+  const cursorAfterMarker = fromLine.from + firstNewLength
+  view.dispatch({
+    changes,
+    selection: range.empty && fromLine.number === toLine.number
+      ? { anchor: cursorAfterMarker }
+      : undefined,
+    scrollIntoView: true,
+  })
   renumberDocument(view)
   return true
 }


### PR DESCRIPTION
## Summary
- Mod+Alt+Shift+L (list-cycle) was dispatching a whole-line replace without setting selection, so CodeMirror parked the caret to the LEFT of the new '- [ ] '. User had to press End before typing.
- This PR sets the post-dispatch selection to the end of the rewritten line when the command fires with a single empty cursor on a single line. Multi-line / range cases stay as they were (no single right answer).
- Also exports `cycleListTypeCommand` so the new test can drive it directly.

## Test plan
- [x] New `cycleListTypeCommand.test.ts` covers: empty → numbered (caret at 3), numbered → task (caret at 6), populated line cycled (caret at end).
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [ ] Manual: on dev, press the cycle on an empty line and type immediately — text should land after '- [ ] '.

🤖 Generated with [Claude Code](https://claude.com/claude-code)