### PR TITLE
fix(editor): single Mod+L for task convert + caret on the right

### DIFF
--- a/src/__tests__/toggleCheckboxStatusCursor.test.ts
+++ b/src/__tests__/toggleCheckboxStatusCursor.test.ts
@@ -1,0 +1,43 @@
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+}))
+
+import { EditorState } from '@codemirror/state'
+import { EditorView } from '@codemirror/view'
+import { toggleCheckboxStatus } from '../components/editor/CodeMirrorEditor'
+
+function setup(doc: string, anchor: number) {
+  const state = EditorState.create({ doc, selection: { anchor } })
+  return new EditorView({ state })
+}
+
+describe('Mod+L (toggleCheckboxStatus) caret placement', () => {
+  test('empty line converts to a task and parks the caret AFTER "- [ ] "', () => {
+    const view = setup('', 0)
+    const handled = toggleCheckboxStatus(view)
+    expect(handled).toBe(true)
+    expect(view.state.doc.toString()).toBe('- [ ] ')
+    expect(view.state.selection.main.head).toBe(6)
+  })
+
+  test('plain line "hello" converts to "- [ ] hello" with caret at end', () => {
+    const view = setup('hello', 5)
+    toggleCheckboxStatus(view)
+    expect(view.state.doc.toString()).toBe('- [ ] hello')
+    expect(view.state.selection.main.head).toBe(11)
+  })
+
+  test('existing task line flips done/undone without being forced to end', () => {
+    const doc = '- [ ] task'
+    const view = setup(doc, 8)
+    toggleCheckboxStatus(view)
+    // The task got marked done (possibly with a date stamp appended via
+    // toggleTaskLineText). We do NOT teleport the caret to the new end of
+    // line — that's the trap the convert-from-plain path corrects, and we
+    // want the flip case to keep its old behaviour (CodeMirror's default
+    // selection mapping after a whole-line replace).
+    expect(view.state.doc.toString()).toMatch(/^- \[x\] task/)
+  })
+})

--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -131,30 +131,49 @@ function renumberDocument(view: EditorView): void {
 // through toggleTaskLineText so the ✅-date stamp + recurring-task behaviour is
 // preserved; on a plain/bullet/ordered line we convert it into an unchecked
 // task. Works across a multi-line selection.
-const toggleCheckboxStatus: Command = (view) => {
+export const toggleCheckboxStatus: Command = (view) => {
   const { state } = view
   const range = state.selection.main
   const fromLine = state.doc.lineAt(range.from)
   const toLine = state.doc.lineAt(range.to)
 
   const changes: { from: number; to: number; insert: string }[] = []
+  let firstLineNewText: string | null = null
+  let firstLineWasTask = false
   for (let n = fromLine.number; n <= toLine.number; n++) {
     const line = state.doc.line(n)
     const parts = splitListLine(line.text)
     let next: string
     if (parts.kind === 'task') {
-      // Existing task → flip done/undone with metadata-aware helper.
       const flipped = toggleTaskLineText(line.text)
       next = flipped ?? line.text
     } else {
-      // plain / bullet / ordered → unchecked task, keeping any carrier.
       const carrier = parts.kind === 'ordered' ? parts.carrier : '- '
       next = `${parts.indent}${carrier}[ ] ${parts.body}`
     }
     if (next !== line.text) changes.push({ from: line.from, to: line.to, insert: next })
+    if (n === fromLine.number) {
+      firstLineNewText = next
+      firstLineWasTask = parts.kind === 'task'
+    }
   }
   if (changes.length === 0) return false
-  view.dispatch({ changes, scrollIntoView: true })
+  // When the user converts a plain/bullet/ordered line into a NEW task with
+  // an empty cursor, park the caret at the end of the rewritten line so they
+  // can keep typing. Existing-task flips leave the caret alone (cursor
+  // position carries useful intent for the done/undone case).
+  const shouldMoveCaret =
+    range.empty &&
+    fromLine.number === toLine.number &&
+    !firstLineWasTask &&
+    firstLineNewText != null
+  view.dispatch({
+    changes,
+    selection: shouldMoveCaret
+      ? { anchor: fromLine.from + (firstLineNewText as string).length }
+      : undefined,
+    scrollIntoView: true,
+  })
   renumberDocument(view)
   return true
 }
@@ -706,52 +725,6 @@ export function CodeMirrorEditor({
     // renumber ordered runs so "1." sequences stay 1,2,3 after the move.
     { key: 'Alt-ArrowUp', preventDefault: true, run: moveLineThenRenumber(moveLineUp) },
     { key: 'Alt-ArrowDown', preventDefault: true, run: moveLineThenRenumber(moveLineDown) },
-    {
-      // Alt+L toggles the "- [ ]" task bullet (add on plain lines, remove
-      // on task lines). Alt+Shift+L toggles the [x]/[ ] checkmark
-      // (Obsidian-style with ✅ date stamp).
-      //
-      // CodeMirror's idiom for "same base key with/without Shift" is one
-      // binding with both `run` (no shift) and `shift` (with shift). An
-      // earlier attempt registered them as two separate bindings
-      // (`Alt-l` + `Alt-Shift-l`); CodeMirror's chord resolver did NOT
-      // pick the Shift variant for Alt+Shift+L and Alt-l ran on every
-      // press. The `shift` field on the base binding is the documented
-      // way to disambiguate. (Caught by the qa-tester sweep on
-      // 2026-05-21.)
-      key: 'Alt-l',
-      preventDefault: true,
-      run(view) {
-        const { state } = view
-        const { head } = state.selection.main
-        const line = state.doc.lineAt(head)
-        const taskMatch = line.text.match(/^(\s*)([-*+]\s+\[[ xX]\]\s+)/)
-        if (taskMatch) {
-          const indent = taskMatch[1].length
-          const markerLen = taskMatch[2].length
-          view.dispatch({
-            changes: { from: line.from + indent, to: line.from + indent + markerLen, insert: '' },
-            selection: { anchor: Math.max(line.from, head - markerLen) },
-          })
-        } else {
-          const indent = line.text.match(/^(\s*)/)![1].length
-          const insertAt = line.from + indent
-          view.dispatch({
-            changes: { from: insertAt, to: insertAt, insert: '- [ ] ' },
-            selection: { anchor: head + 6 },
-          })
-        }
-        return true
-      },
-      shift(view) {
-        const { head } = view.state.selection.main
-        const line = view.state.doc.lineAt(head)
-        const newLine = toggleTaskLineText(line.text)
-        if (newLine == null || newLine === line.text) return false
-        view.dispatch({ changes: { from: line.from, to: line.to, insert: newLine } })
-        return true
-      },
-    },
     {
       // Open the "Create or edit Task" modal for the task line under the
       // cursor. Mirrors Obsidian Tasks' Mod+Shift+T binding. No-op for lines


### PR DESCRIPTION
## Summary
- Drop the Alt+L task-insert binding. Fold its behaviour into Mod+L so there's one shortcut for "task this line".
- On a plain/bullet/ordered line, Mod+L now parks the caret at the end of the rewritten line (no more landing to the LEFT of '- [ ] '). Existing-task flips keep CodeMirror's default mapping.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] New `toggleCheckboxStatusCursor.test.ts` covers empty + plain-line + existing-task paths.
- [ ] Manual: on dev, Mod+L on an empty line → cursor lands after '- [ ] ', type immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)