### PR TITLE
feat(ux): breadcrumb reveal in tree + gist auth copies device code

### DIFF
--- a/src/components/editor/EditorHeader.tsx
+++ b/src/components/editor/EditorHeader.tsx
@@ -16,8 +16,13 @@ interface EditorHeaderProps {
 
 export const EditorHeader = ({ note, paneId, onTitleChange }: EditorHeaderProps) => {
   const { isPreviewMode, togglePreview } = useUIStore()
+  const setCurrentView = useUIStore(s => s.setCurrentView)
+  const sidebarCollapsed = useUIStore(s => s.sidebarCollapsed)
+  const toggleSidebar = useUIStore(s => s.toggleSidebar)
   const { togglePinNote } = useNoteStore()
   const { getFolderById } = useFolderStore()
+  const setActiveFolder = useFolderStore(s => s.setActiveFolder)
+  const setFolderExpanded = useFolderStore(s => s.setFolderExpanded)
   const { isMobile } = useViewport()
   const goBack = useWorkspaceStore(s => s.goBack)
   const goForward = useWorkspaceStore(s => s.goForward)
@@ -35,27 +40,63 @@ export const EditorHeader = ({ note, paneId, onTitleChange }: EditorHeaderProps)
   if (isMobile) return null
 
   // Build a "Folder / Subfolder" trail by walking parentId chain. Empty when
-  // the note is at the root (no folder).
-  const folderTrail: string[] = []
+  // the note is at the root (no folder). We keep id alongside name so the
+  // breadcrumb segments can navigate the sidebar.
+  const folderTrail: { id: string; name: string }[] = []
   let current = note.folderId ? getFolderById(note.folderId) : undefined
   const seen = new Set<string>()
   while (current && !seen.has(current.id)) {
-    folderTrail.unshift(current.name)
+    folderTrail.unshift({ id: current.id, name: current.name })
     seen.add(current.id)
     current = current.parentId ? getFolderById(current.parentId) : undefined
+  }
+
+  // Reveal a folder in the sidebar: switch to the Files view, open the
+  // sidebar if it was collapsed, expand the chain leading to the folder,
+  // and select the folder so the user immediately sees their context.
+  const revealFolder = (folderId: string) => {
+    if (sidebarCollapsed) toggleSidebar()
+    setCurrentView('notes')
+    let walk = getFolderById(folderId)
+    const walked = new Set<string>()
+    while (walk && !walked.has(walk.id)) {
+      setFolderExpanded(walk.id, true)
+      walked.add(walk.id)
+      walk = walk.parentId ? getFolderById(walk.parentId) : undefined
+    }
+    setActiveFolder(folderId)
   }
 
   return (
     <div className="flex flex-col border-b border-obsidianBorder">
       {folderTrail.length > 0 && (
         <div className="flex items-center gap-1 px-4 pt-2 text-[11px] text-obsidianSecondaryText truncate">
-          {folderTrail.map((name, i) => (
-            <span key={i} className="flex items-center gap-1">
-              <span className="truncate">{name}</span>
+          {folderTrail.map((seg, i) => (
+            <span key={seg.id} className="flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() => revealFolder(seg.id)}
+                className="truncate hover:text-obsidianText hover:underline transition-colors"
+                title={`Reveal ${seg.name} in the file tree`}
+                data-testid={`breadcrumb-folder-${i}`}
+              >
+                {seg.name}
+              </button>
               <span className="text-obsidianBorder">/</span>
             </span>
           ))}
-          <span className="truncate text-obsidianText/70">{note.title || 'Untitled'}</span>
+          <button
+            type="button"
+            onClick={() => {
+              const parentId = folderTrail[folderTrail.length - 1]?.id
+              if (parentId) revealFolder(parentId)
+            }}
+            className="truncate text-obsidianText/70 hover:text-obsidianText hover:underline transition-colors"
+            title="Reveal this note in the file tree"
+            data-testid="breadcrumb-note"
+          >
+            {note.title || 'Untitled'}
+          </button>
         </div>
       )}
       <div className="flex items-center gap-2 px-4 py-3">

--- a/src/components/modals/PublishGistModal.tsx
+++ b/src/components/modals/PublishGistModal.tsx
@@ -315,11 +315,19 @@ export const PublishGistModal = () => {
                 href={scopeFlow.verification_uri}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={() => {
+                  // GitHub's device-flow page asks the user to paste the
+                  // user_code. Copy it to the clipboard at click time so
+                  // the destination tab opens with the code already on
+                  // the user's clipboard. Errors are swallowed because a
+                  // failed clipboard write does not block authorisation.
+                  navigator.clipboard?.writeText(scopeFlow.user_code).catch(() => {})
+                }}
                 className="w-full inline-flex items-center justify-center gap-2 px-3 py-2 bg-obsidianAccentPurple text-white rounded text-sm hover:bg-opacity-90 transition-colors no-underline"
                 data-testid="publish-gist-scope-link"
               >
                 <ArrowTopRightOnSquareIcon className="w-4 h-4" />
-                Open GitHub to authorise
+                Copy code and open GitHub
               </a>
             </div>
           )}


### PR DESCRIPTION
## Summary
- EditorHeader breadcrumb segments + the note title are now buttons. Clicking expands the folder chain in the sidebar, switches to the Files view, opens the sidebar if collapsed, and selects the folder. Mirrors the Obsidian / VSCode "reveal in file tree" affordance.
- Publish-as-gist OAuth scope flow: the 'Open GitHub to authorise' link now copies the device-flow user_code to the clipboard at click time and labels itself 'Copy code and open GitHub'. The destination page asks the user to paste the code, so the round-trip stays inside one paste.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [ ] Manual: on dev, click a folder segment in the editor header → sidebar opens to that folder.
- [ ] Manual: in Publish-as-gist (no gist scope yet) → click "Copy code and open GitHub" → paste on GitHub form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)