### PR TITLE
feat(tree): Select for Compare + Compare with Selected on note rows

### DIFF
--- a/src/__tests__/compareSourceState.test.ts
+++ b/src/__tests__/compareSourceState.test.ts
@@ -1,0 +1,132 @@
+/**
+ * compareSourceState.test.ts
+ *
+ * Coverage for the VS Code-style "Select for Compare" flow:
+ *   - uiStore.compareSourceNoteId set/clear via setCompareSource /
+ *     clearCompareSource.
+ *   - workspaceStore.openCompare: opens a new compare tab, no-ops on
+ *     same-id, focuses the existing tab on duplicate pair.
+ *   - The ContextMenu auto-clears the source after dispatching
+ *     openCompare (covered by the contextMenuCompare test file); here we
+ *     verify the store contract in isolation.
+ *
+ * idb-keyval is stubbed so persist middleware doesn't reach IndexedDB.
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+  keys: jest.fn().mockResolvedValue([]),
+}))
+
+import { useUIStore } from '../stores/uiStore'
+import { useWorkspaceStore } from '../stores/workspaceStore'
+
+beforeEach(() => {
+  useUIStore.setState({ compareSourceNoteId: null })
+  useWorkspaceStore.setState({
+    panes: [{ id: 'p1', tabs: [], activeTabId: null }],
+    activePaneId: 'p1',
+    mergeAppliedCount: 0,
+  })
+})
+
+describe('useUIStore — compareSourceNoteId', () => {
+  test('defaults to null', () => {
+    expect(useUIStore.getState().compareSourceNoteId).toBeNull()
+  })
+
+  test('setCompareSource records the id', () => {
+    useUIStore.getState().setCompareSource('n-1')
+    expect(useUIStore.getState().compareSourceNoteId).toBe('n-1')
+  })
+
+  test('setCompareSource(null) clears the id', () => {
+    useUIStore.getState().setCompareSource('n-1')
+    useUIStore.getState().setCompareSource(null)
+    expect(useUIStore.getState().compareSourceNoteId).toBeNull()
+  })
+
+  test('clearCompareSource resets to null', () => {
+    useUIStore.getState().setCompareSource('n-1')
+    useUIStore.getState().clearCompareSource()
+    expect(useUIStore.getState().compareSourceNoteId).toBeNull()
+  })
+})
+
+describe('useWorkspaceStore — openCompare', () => {
+  test('opens a compare tab in the active pane with the two ids', () => {
+    useWorkspaceStore.getState().openCompare('n-left', 'n-right')
+    const { panes } = useWorkspaceStore.getState()
+    expect(panes).toHaveLength(1)
+    expect(panes[0].tabs).toHaveLength(1)
+    const tab = panes[0].tabs[0]
+    expect(tab.kind).toBe('compare')
+    if (tab.kind !== 'compare') throw new Error('expected compare tab')
+    expect(tab.leftNoteId).toBe('n-left')
+    expect(tab.rightNoteId).toBe('n-right')
+    expect(panes[0].activeTabId).toBe(tab.id)
+  })
+
+  test('no-op when the two ids are the same', () => {
+    useWorkspaceStore.getState().openCompare('n-1', 'n-1')
+    expect(useWorkspaceStore.getState().panes[0].tabs).toHaveLength(0)
+  })
+
+  test('focuses the existing tab instead of opening a duplicate', () => {
+    useWorkspaceStore.getState().openCompare('n-a', 'n-b')
+    const firstId = useWorkspaceStore.getState().panes[0].tabs[0].id
+
+    useWorkspaceStore.getState().openCompare('n-a', 'n-b')
+    const { panes } = useWorkspaceStore.getState()
+    expect(panes[0].tabs).toHaveLength(1)
+    expect(panes[0].tabs[0].id).toBe(firstId)
+    expect(panes[0].activeTabId).toBe(firstId)
+  })
+
+  test('treats reversed (left/right swap) as the same pair', () => {
+    useWorkspaceStore.getState().openCompare('n-a', 'n-b')
+    const firstId = useWorkspaceStore.getState().panes[0].tabs[0].id
+
+    useWorkspaceStore.getState().openCompare('n-b', 'n-a')
+    const { panes } = useWorkspaceStore.getState()
+    expect(panes[0].tabs).toHaveLength(1)
+    expect(panes[0].tabs[0].id).toBe(firstId)
+  })
+
+  test('compare tabs are excluded from persisted state (partialize)', () => {
+    useWorkspaceStore.setState({
+      panes: [{
+        id: 'p1',
+        tabs: [
+          { id: 't1', kind: 'note', noteId: 'n-1', isPreview: false },
+          { id: 't2', kind: 'compare', leftNoteId: 'n-a', rightNoteId: 'n-b' },
+        ],
+        activeTabId: 't2',
+      }],
+      activePaneId: 'p1',
+      mergeAppliedCount: 0,
+    })
+
+    const persisted = useWorkspaceStore.persist.getOptions().partialize?.(
+      useWorkspaceStore.getState(),
+    ) as { panes: { tabs: { kind: string }[] }[] } | undefined
+
+    expect(persisted).toBeTruthy()
+    const persistedTabs = persisted!.panes[0].tabs
+    expect(persistedTabs).toHaveLength(1)
+    expect(persistedTabs[0].kind).toBe('note')
+  })
+})
+
+describe('integration — opening a compare tab does not clear the source by itself', () => {
+  // The store doesn't touch uiStore — clearing is the ContextMenu's job
+  // after dispatching openCompare. This test pins that contract so a
+  // future refactor moving the clear into the store is visible.
+  test('openCompare leaves compareSourceNoteId untouched', () => {
+    useUIStore.getState().setCompareSource('n-a')
+    useWorkspaceStore.getState().openCompare('n-a', 'n-b')
+    expect(useUIStore.getState().compareSourceNoteId).toBe('n-a')
+  })
+})

--- a/src/__tests__/contextMenuCompare.test.tsx
+++ b/src/__tests__/contextMenuCompare.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * contextMenuCompare.test.tsx
+ *
+ * VS Code-style "Select for Compare" / "Compare with Selected" entries
+ * on the note context menu. The two items appear/disappear based on:
+ *   - whether a compare source is set (uiStore.compareSourceNoteId)
+ *   - whether the right-click target is the same note as the source
+ *   - whether the target is trashed
+ *
+ * Clicking "Compare with Selected" calls workspaceStore.openCompare and
+ * auto-clears the source so the tree highlight goes away.
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+  keys: jest.fn().mockResolvedValue([]),
+}))
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { ContextMenu } from '../components/sidebar/ContextMenu'
+import { useNoteStore } from '../stores/noteStore'
+import { useFolderStore } from '../stores/folderStore'
+import { useUIStore } from '../stores/uiStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import { useGitHubStore } from '../stores/githubStore'
+import { useWorkspaceStore } from '../stores/workspaceStore'
+import type { ContextMenuState } from '@/types'
+
+function renderMenu(state: NonNullable<ContextMenuState>, onClose = jest.fn()) {
+  return render(<ContextMenu contextMenu={state} onClose={onClose} />)
+}
+
+function seedNotes() {
+  useNoteStore.setState({
+    notes: [
+      {
+        id: 'note-a',
+        title: 'Note A',
+        content: 'aaa',
+        folderId: null,
+        createdAt: 1,
+        updatedAt: 1,
+        isDeleted: false,
+        deletedAt: null,
+        isPinned: false,
+        templateId: null,
+      },
+      {
+        id: 'note-b',
+        title: 'Note B',
+        content: 'bbb',
+        folderId: null,
+        createdAt: 1,
+        updatedAt: 1,
+        isDeleted: false,
+        deletedAt: null,
+        isPinned: false,
+        templateId: null,
+      },
+      {
+        id: 'note-trashed',
+        title: 'gone',
+        content: '',
+        folderId: null,
+        createdAt: 1,
+        updatedAt: 1,
+        isDeleted: true,
+        deletedAt: 1,
+        isPinned: false,
+        templateId: null,
+      },
+    ],
+    selectedNoteId: null,
+  })
+}
+
+beforeEach(() => {
+  seedNotes()
+  useFolderStore.setState({ folders: [], deletedFolderPaths: [], activeFolderId: null })
+  useUIStore.setState({ modal: { type: null }, compareSourceNoteId: null })
+  useSettingsStore.setState({ aiProvider: 'off' })
+  useGitHubStore.setState({ token: null, user: null })
+  useWorkspaceStore.setState({
+    panes: [{ id: 'p1', tabs: [], activeTabId: null }],
+    activePaneId: 'p1',
+    mergeAppliedCount: 0,
+  })
+})
+
+describe('ContextMenu — Select for Compare', () => {
+  test('Select for Compare is always present on an active note', () => {
+    renderMenu({ type: 'note', id: 'note-a', x: 10, y: 10 })
+    expect(screen.getByText('Select for Compare')).toBeInTheDocument()
+  })
+
+  test('Compare with Selected is hidden when no source is set', () => {
+    renderMenu({ type: 'note', id: 'note-a', x: 10, y: 10 })
+    expect(screen.queryByText('Compare with Selected')).not.toBeInTheDocument()
+  })
+
+  test('clicking Select for Compare records the source id', async () => {
+    const user = userEvent.setup()
+    const onClose = jest.fn()
+    renderMenu({ type: 'note', id: 'note-a', x: 10, y: 10 }, onClose)
+
+    await user.click(screen.getByText('Select for Compare'))
+
+    expect(useUIStore.getState().compareSourceNoteId).toBe('note-a')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  test('Select for Compare is hidden on a trashed note', () => {
+    renderMenu({ type: 'note', id: 'note-trashed', x: 10, y: 10 })
+    expect(screen.queryByText('Select for Compare')).not.toBeInTheDocument()
+  })
+})
+
+describe('ContextMenu — Compare with Selected', () => {
+  test('appears when a different note is the source', () => {
+    useUIStore.setState({ compareSourceNoteId: 'note-a' })
+    renderMenu({ type: 'note', id: 'note-b', x: 10, y: 10 })
+    expect(screen.getByText('Compare with Selected')).toBeInTheDocument()
+  })
+
+  test('is hidden when right-clicking the SAME note as the source', () => {
+    useUIStore.setState({ compareSourceNoteId: 'note-a' })
+    renderMenu({ type: 'note', id: 'note-a', x: 10, y: 10 })
+    expect(screen.queryByText('Compare with Selected')).not.toBeInTheDocument()
+  })
+
+  test('is hidden on a trashed note even when a source is set', () => {
+    useUIStore.setState({ compareSourceNoteId: 'note-a' })
+    renderMenu({ type: 'note', id: 'note-trashed', x: 10, y: 10 })
+    expect(screen.queryByText('Compare with Selected')).not.toBeInTheDocument()
+  })
+
+  test('clicking it opens a compare tab and clears the source', async () => {
+    const user = userEvent.setup()
+    useUIStore.setState({ compareSourceNoteId: 'note-a' })
+    renderMenu({ type: 'note', id: 'note-b', x: 10, y: 10 })
+
+    await user.click(screen.getByText('Compare with Selected'))
+
+    // Source cleared.
+    expect(useUIStore.getState().compareSourceNoteId).toBeNull()
+    // A compare tab opened in the active pane with the right ids.
+    const tabs = useWorkspaceStore.getState().panes[0].tabs
+    expect(tabs).toHaveLength(1)
+    expect(tabs[0].kind).toBe('compare')
+    if (tabs[0].kind !== 'compare') throw new Error('expected compare tab')
+    expect(tabs[0].leftNoteId).toBe('note-a')
+    expect(tabs[0].rightNoteId).toBe('note-b')
+  })
+})

--- a/src/components/editor/CompareView.tsx
+++ b/src/components/editor/CompareView.tsx
@@ -1,0 +1,153 @@
+'use client'
+
+import { useMemo } from 'react'
+import { DocumentDuplicateIcon } from '@heroicons/react/24/outline'
+import { Button } from '@/components/ui'
+import { useNoteStore, useWorkspaceStore } from '@/stores'
+import { diffByLine, type DiffHunk } from '@/utils/lineDiff'
+
+interface Props {
+  tabId: string
+  leftNoteId: string
+  rightNoteId: string
+}
+
+// Read-only side-by-side diff between two notes. Mirrors VS Code's
+// "Compare with Selected" surface — no Apply, no resolve actions; the
+// user closes the tab when done.
+export const CompareView = ({ tabId, leftNoteId, rightNoteId }: Props) => {
+  const notes = useNoteStore(s => s.notes)
+  const closeTab = useWorkspaceStore(s => s.closeTab)
+
+  const left = notes.find(n => n.id === leftNoteId) ?? null
+  const right = notes.find(n => n.id === rightNoteId) ?? null
+
+  const rows = useMemo<DisplayRow[]>(() => {
+    if (!left || !right) return []
+    return buildSideRows(diffByLine(left.content, right.content))
+  }, [left, right])
+
+  if (!left || !right) {
+    return (
+      <div className="flex-1 h-full flex flex-col items-center justify-center text-obsidianSecondaryText text-sm">
+        One or both notes are no longer available.
+        <Button variant="ghost" onClick={() => closeTab(tabId)} className="mt-3">
+          Close
+        </Button>
+      </div>
+    )
+  }
+
+  const changedCount = rows.filter(r => r.kind === 'change').length
+
+  return (
+    <div className="flex-1 h-full flex flex-col overflow-hidden bg-obsidianBlack">
+      <div className="px-4 py-2 border-b border-obsidianBorder flex items-center gap-2">
+        <DocumentDuplicateIcon className="w-5 h-5 flex-shrink-0 text-obsidianAccentPurple" />
+        <div className="flex-1 min-w-0">
+          <div className="text-sm text-obsidianText truncate">
+            {left.title || 'Untitled'} <span className="text-obsidianSecondaryText">↔</span> {right.title || 'Untitled'}
+          </div>
+          <div className="text-xs text-obsidianSecondaryText">
+            Compare · {changedCount} change{changedCount === 1 ? '' : 's'} · read only
+          </div>
+        </div>
+        <Button variant="ghost" onClick={() => closeTab(tabId)}>Close</Button>
+      </div>
+
+      <div className="flex-1 overflow-auto p-4">
+        <div className="grid grid-cols-2 gap-3 font-mono text-xs">
+          <SidePanel
+            title={left.title || 'Untitled'}
+            side="left"
+            rows={rows}
+          />
+          <SidePanel
+            title={right.title || 'Untitled'}
+            side="right"
+            rows={rows}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+type DisplayRow =
+  | { kind: 'equal'; leftLine: string; rightLine: string; leftLineNo: number; rightLineNo: number }
+  | { kind: 'change'; leftLine: string | null; rightLine: string | null; leftLineNo: number | null; rightLineNo: number | null }
+
+// Walk hunks into aligned left/right rows. `change` hunks pad the shorter
+// side with null lines so both columns line up vertically — the same way
+// VS Code's side-by-side diff stacks unmatched lines.
+function buildSideRows(hunks: DiffHunk[]): DisplayRow[] {
+  const out: DisplayRow[] = []
+  let leftLineNo = 0
+  let rightLineNo = 0
+  for (const h of hunks) {
+    if (h.type === 'equal') {
+      for (const line of h.lines) {
+        leftLineNo++
+        rightLineNo++
+        out.push({ kind: 'equal', leftLine: line, rightLine: line, leftLineNo, rightLineNo })
+      }
+      continue
+    }
+    const maxLen = Math.max(h.localLines.length, h.remoteLines.length)
+    for (let i = 0; i < maxLen; i++) {
+      const hasLeft = i < h.localLines.length
+      const hasRight = i < h.remoteLines.length
+      if (hasLeft) leftLineNo++
+      if (hasRight) rightLineNo++
+      out.push({
+        kind: 'change',
+        leftLine: hasLeft ? h.localLines[i] : null,
+        rightLine: hasRight ? h.remoteLines[i] : null,
+        leftLineNo: hasLeft ? leftLineNo : null,
+        rightLineNo: hasRight ? rightLineNo : null,
+      })
+    }
+  }
+  return out
+}
+
+const SidePanel = ({
+  title,
+  side,
+  rows,
+}: {
+  title: string
+  side: 'left' | 'right'
+  rows: DisplayRow[]
+}) => (
+  <div className="border border-obsidianBorder rounded overflow-hidden">
+    <div className="px-2 py-1 bg-obsidianDarkGray text-obsidianText border-b border-obsidianBorder truncate" title={title}>
+      {title}
+    </div>
+    <div>
+      {rows.map((row, idx) => {
+        const text = side === 'left' ? row.leftLine : row.rightLine
+        const lineNo = side === 'left' ? row.leftLineNo : row.rightLineNo
+        const present = text != null
+        const isChange = row.kind === 'change'
+        const bg = !present
+          ? 'bg-obsidianHighlight/30'
+          : isChange
+            ? side === 'left' ? 'bg-red-950/25' : 'bg-green-950/25'
+            : ''
+        return (
+          <div key={idx} className={`flex ${bg}`} data-testid={`compare-row-${side}`}>
+            <div className="select-none w-10 text-right pr-2 py-0.5 text-obsidianSecondaryText/60 flex-shrink-0">
+              {lineNo ?? ''}
+            </div>
+            <pre className="flex-1 py-0.5 px-2 text-obsidianText whitespace-pre-wrap break-words min-w-0">
+              {present ? (text === '' ? ' ' : text) : ''}
+            </pre>
+          </div>
+        )
+      })}
+    </div>
+  </div>
+)
+
+export default CompareView

--- a/src/components/editor/Pane.tsx
+++ b/src/components/editor/Pane.tsx
@@ -11,6 +11,7 @@ import { EditorContent } from './EditorContent'
 import { TabBar } from './TabBar'
 import { MergeEditorView } from './MergeEditorView'
 import { MergeBatchView } from './MergeBatchView'
+import { CompareView } from './CompareView'
 import { WelcomePane } from './WelcomePane'
 import { EmptyState } from '@/components/ui'
 import type { PaneState } from '@/stores/workspaceStore'
@@ -104,6 +105,14 @@ export const Pane = ({ pane, allowSplitDropZone }: Props) => {
     body = <MergeEditorView tabId={activeTab.id} conflict={activeTab.conflict} />
   } else if (activeTab.kind === 'merge-batch') {
     body = <MergeBatchView tabId={activeTab.id} conflicts={activeTab.conflicts} />
+  } else if (activeTab.kind === 'compare') {
+    body = (
+      <CompareView
+        tabId={activeTab.id}
+        leftNoteId={activeTab.leftNoteId}
+        rightNoteId={activeTab.rightNoteId}
+      />
+    )
   } else if (activeTab.kind === 'welcome') {
     body = <WelcomePane tabId={activeTab.id} />
   } else {

--- a/src/components/editor/TabBar.tsx
+++ b/src/components/editor/TabBar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRef, useState } from 'react'
-import { DocumentTextIcon, ExclamationTriangleIcon, XMarkIcon, SparklesIcon } from '@heroicons/react/24/outline'
+import { DocumentTextIcon, DocumentDuplicateIcon, ExclamationTriangleIcon, XMarkIcon, SparklesIcon } from '@heroicons/react/24/outline'
 import { useNoteStore, useWorkspaceStore } from '@/stores'
 import { TAB_DRAG_MIME } from '@/hooks'
 import type { Tab, PaneState } from '@/stores/workspaceStore'
@@ -102,7 +102,9 @@ export const TabBar = ({ pane }: Props) => {
                 ? <ExclamationTriangleIcon className="w-4 h-4 text-amber-400 flex-shrink-0" />
                 : tab.kind === 'welcome'
                   ? <SparklesIcon className="w-4 h-4 text-obsidianAccentPurple flex-shrink-0" />
-                  : <DocumentTextIcon className="w-4 h-4 flex-shrink-0" />}
+                  : tab.kind === 'compare'
+                    ? <DocumentDuplicateIcon className="w-4 h-4 text-obsidianAccentPurple flex-shrink-0" />
+                    : <DocumentTextIcon className="w-4 h-4 flex-shrink-0" />}
               <span className={`truncate flex-1 min-w-0 ${title.italic ? 'italic' : ''}`}>{title.text}</span>
               <button
                 onClick={(e) => { e.stopPropagation(); closeTab(tab.id) }}
@@ -154,6 +156,14 @@ function renderTitle(tab: Tab, notes: Array<{ id: string; title: string }>): Ren
   }
   if (tab.kind === 'welcome') {
     return { text: 'Welcome', tooltip: 'Welcome — getting started', italic: false }
+  }
+  if (tab.kind === 'compare') {
+    const leftNote = notes.find(n => n.id === tab.leftNoteId)
+    const rightNote = notes.find(n => n.id === tab.rightNoteId)
+    const leftTitle = leftNote?.title || 'Untitled'
+    const rightTitle = rightNote?.title || 'Untitled'
+    const text = `${leftTitle} ↔ ${rightTitle}`
+    return { text, tooltip: `Compare: ${leftTitle} ↔ ${rightTitle}`, italic: false }
   }
   const note = notes.find(n => n.id === tab.noteId)
   const text = note?.title || 'Untitled'

--- a/src/components/sidebar/ContextMenu.tsx
+++ b/src/components/sidebar/ContextMenu.tsx
@@ -15,6 +15,7 @@ import {
   ArrowUturnLeftIcon,
   ClockIcon,
   ShareIcon,
+  ArrowsRightLeftIcon,
 } from '@heroicons/react/24/outline'
 import { useNoteStore, useFolderStore, useUIStore, useWorkspaceStore, useSettingsStore, useGitHubStore } from '@/stores'
 import type { ContextMenuState, Folder } from '@/types'
@@ -68,6 +69,13 @@ export const ContextMenu = ({ contextMenu, onClose }: ContextMenuProps) => {
   } = useNoteStore()
   const { getFolderById, addFolder, deleteFolder, getActiveFolders, getDeletedFolders, restoreFolders, toggleFolderExpanded, expandedFolders } = useFolderStore()
   const openNote = useWorkspaceStore(s => s.openNote)
+  const openCompare = useWorkspaceStore(s => s.openCompare)
+  // VS Code-style compare flow: a previously right-clicked note may be
+  // pending as the "left" side. Reading the id here (not the action) so
+  // both Select for Compare and Compare with Selected stay in sync.
+  const compareSourceNoteId = useUIStore(s => s.compareSourceNoteId)
+  const setCompareSource = useUIStore(s => s.setCompareSource)
+  const clearCompareSource = useUIStore(s => s.clearCompareSource)
   // "Publish as gist" reuses the GitHub OAuth token. Hooked up here at
   // the top of the component so it sits BEFORE the early `if (!item)
   // return` below — react-hooks/rules-of-hooks won't accept a hook
@@ -323,6 +331,28 @@ export const ContextMenu = ({ contextMenu, onClose }: ContextMenuProps) => {
     onClose()
   }
 
+  const handleSelectForCompare = () => {
+    if (isNote) setCompareSource(contextMenu.id)
+    onClose()
+  }
+
+  const handleCompareWithSelected = () => {
+    if (isNote && compareSourceNoteId && compareSourceNoteId !== contextMenu.id) {
+      openCompare(compareSourceNoteId, contextMenu.id)
+      // Auto-clear once a compare opens — matches VS Code's behaviour
+      // and keeps the tree highlight from lingering after the diff
+      // surface is already on screen.
+      clearCompareSource()
+    }
+    onClose()
+  }
+
+  const canCompareWithSelected =
+    isNote &&
+    !!compareSourceNoteId &&
+    compareSourceNoteId !== contextMenu.id &&
+    !isTrashedNote
+
   const handleNewNoteInFolder = () => {
     if (!isNote) {
       const note = addNote({ folderId: contextMenu.id })
@@ -444,6 +474,20 @@ export const ContextMenu = ({ contextMenu, onClose }: ContextMenuProps) => {
             label="Duplicate"
             onClick={handleDuplicate}
           />
+          {!isTrashedNote && (
+            <MenuButton
+              icon={ArrowsRightLeftIcon}
+              label="Select for Compare"
+              onClick={handleSelectForCompare}
+            />
+          )}
+          {canCompareWithSelected && (
+            <MenuButton
+              icon={ArrowsRightLeftIcon}
+              label="Compare with Selected"
+              onClick={handleCompareWithSelected}
+            />
+          )}
           {canViewHistory && (
             <MenuButton
               icon={ClockIcon}

--- a/src/components/sidebar/FolderTree.tsx
+++ b/src/components/sidebar/FolderTree.tsx
@@ -41,6 +41,8 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
   const { currentView } = useUIStore()
   const renameRequest = useUIStore(s => s.renameRequest)
   const clearRenameRequest = useUIStore(s => s.clearRenameRequest)
+  const compareSourceNoteId = useUIStore(s => s.compareSourceNoteId)
+  const clearCompareSource = useUIStore(s => s.clearCompareSource)
   const { isMobile } = useViewport()
   const sidebarCollapsed = useUIStore(s => s.sidebarCollapsed)
   const toggleSidebar = useUIStore(s => s.toggleSidebar)
@@ -160,6 +162,19 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
     useNoteStore.getState().deleteNotes(ids)
     clearSelection()
   }
+
+  // Global Esc handler — clears a pending compare source so the highlight
+  // doesn't linger. Listening on window means the shortcut works from
+  // anywhere (editor, sidebar, etc.) the way VS Code's compare flow does.
+  useEffect(() => {
+    if (!compareSourceNoteId) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      clearCompareSource()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [compareSourceNoteId, clearCompareSource])
 
   // Global Delete / Backspace handler. The per-tree onKeyDown only fires
   // when the tree itself has focus — after clicking a note row, focus
@@ -592,6 +607,7 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
   const NoteItem = ({ note, className = '' }: { note: typeof notes[0]; className?: string }) => {
     const kbFocused = isRowFocused('note', note.id)
     const multiSelected = isSelected(note.id)
+    const isCompareSource = compareSourceNoteId === note.id
     // Mobile-only drag-to-pin. Trash rows are excluded because their
     // primary affordance is restore / permanently delete.
     const swipeEnabled = isMobile && currentView !== 'trash' && !note.isDeleted
@@ -604,7 +620,10 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
           className={`obsidian-file-item ${
             multiSelected ? 'bg-obsidianAccentPurple/25 border-l-2 border-obsidianAccentPurple -ml-[2px] pl-[10px]' :
               selectedNoteId === note.id ? 'bg-obsidianHighlight' : ''
-          } ${kbFocused ? 'ring-1 ring-inset ring-obsidianAccentPurple' : ''} ${className}`}
+          } ${kbFocused ? 'ring-1 ring-inset ring-obsidianAccentPurple' : ''} ${
+            isCompareSource ? 'italic border-l-2 border-obsidianAccentPurple -ml-[2px] pl-[10px] ring-1 ring-inset ring-obsidianAccentPurple/60' : ''
+          } ${className}`}
+          data-compare-source={isCompareSource ? 'true' : undefined}
           draggable={currentView !== 'trash' && !multiSelected && !note.isDeleted}
           onDragStart={e => beginNoteDrag(e, note.id)}
           onDragEnd={endDrag}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -126,6 +126,12 @@ interface UIState {
   // and puts the matching EditableText into edit mode, then clears it.
   renameRequest: { type: 'note' | 'folder'; id: string } | null
 
+  // VS Code-style "Select for Compare" pending source. The note id the
+  // user marked as the LEFT side of a pending compare; null when nothing
+  // is selected. Cleared on Esc, after the compare tab opens, or
+  // explicitly via clearCompareSource.
+  compareSourceNoteId: string | null
+
   // Actions
   toggleSidebar: () => void
   setSidebarWidth: (width: number) => void
@@ -157,6 +163,8 @@ interface UIState {
   setCurrentView: (view: UIState['currentView']) => void
   requestRename: (target: { type: 'note' | 'folder'; id: string }) => void
   clearRenameRequest: () => void
+  setCompareSource: (noteId: string | null) => void
+  clearCompareSource: () => void
 }
 
 export const useUIStore = create<UIState>()(
@@ -187,6 +195,7 @@ export const useUIStore = create<UIState>()(
       modal: { type: null },
       currentView: 'notes',
       renameRequest: null,
+      compareSourceNoteId: null,
 
       // Actions
       toggleSidebar: () => {
@@ -336,6 +345,8 @@ export const useUIStore = create<UIState>()(
 
       requestRename: (target) => set({ renameRequest: target }),
       clearRenameRequest: () => set({ renameRequest: null }),
+      setCompareSource: (noteId) => set({ compareSourceNoteId: noteId }),
+      clearCompareSource: () => set({ compareSourceNoteId: null }),
     }),
     {
       name: STORAGE_KEYS.ui,

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -36,6 +36,12 @@ export type Tab =
   // it also flips `settingsStore.onboardingShown` so it doesn't
   // reappear on the next session.
   | { id: string; kind: 'welcome' }
+  // Read-only side-by-side diff between two notes (VS Code "Compare
+  // with Selected"). Snapshots the two note ids at open time; the
+  // view re-reads current content from the noteStore so live edits
+  // reflect into the diff. Not persisted — closed on reload, same
+  // as the welcome tab.
+  | { id: string; kind: 'compare'; leftNoteId: string; rightNoteId: string }
 
 export interface PaneState {
   id: string
@@ -64,6 +70,10 @@ interface WorkspaceState {
   // Open (or focus, if already open) the Welcome tab. Lives in the
   // active pane. Idempotent — calling twice is a no-op past the first.
   openWelcome: () => void
+  // Open a read-only side-by-side compare of two notes in a new tab.
+  // No-op if the two ids are the same. If a compare tab for this pair
+  // is already open in any pane it is focused instead of duplicated.
+  openCompare: (leftNoteId: string, rightNoteId: string) => void
   openMergeConflicts: (conflicts: ConflictTabData[]) => void
   // Opens a SINGLE summary tab covering all conflicts. Replaces any
   // existing merge-conflict / merge-batch tabs in the workspace.
@@ -359,6 +369,37 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         set({ panes: next, activePaneId: targetPaneId })
       },
 
+      openCompare: (leftNoteId, rightNoteId) => {
+        if (leftNoteId === rightNoteId) return
+        const state = get()
+        // Focus an existing compare tab for the same pair (either order)
+        // instead of opening a duplicate.
+        const existing = state.panes
+          .flatMap(p => p.tabs.map(t => ({ pane: p, tab: t })))
+          .find(({ tab }) =>
+            tab.kind === 'compare' &&
+            ((tab.leftNoteId === leftNoteId && tab.rightNoteId === rightNoteId) ||
+             (tab.leftNoteId === rightNoteId && tab.rightNoteId === leftNoteId)),
+          )
+        if (existing) {
+          const next = state.panes.map(p =>
+            p.id === existing.pane.id ? { ...p, activeTabId: existing.tab.id } : p,
+          )
+          set({ panes: next, activePaneId: existing.pane.id })
+          return
+        }
+        const targetPaneId = state.activePaneId ?? state.panes[0]?.id
+        if (!targetPaneId) return
+        const id = uuidv4()
+        const newTab: Tab = { id, kind: 'compare', leftNoteId, rightNoteId }
+        const next = state.panes.map(p =>
+          p.id === targetPaneId
+            ? { ...p, tabs: [...p.tabs, newTab], activeTabId: id }
+            : p,
+        )
+        set({ panes: next, activePaneId: targetPaneId })
+      },
+
       promoteTab: (tabId) => {
         set(state => ({
           panes: state.panes.map(p => ({
@@ -627,7 +668,11 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         const liveIds = new Set(notes.filter(n => !n.isDeleted).map(n => n.id))
         const state = get()
         const next = state.panes.map(p => {
-          const cleanTabs = p.tabs.filter(t => t.kind !== 'note' || liveIds.has(t.noteId))
+          const cleanTabs = p.tabs.filter(t => {
+            if (t.kind === 'note') return liveIds.has(t.noteId)
+            if (t.kind === 'compare') return liveIds.has(t.leftNoteId) && liveIds.has(t.rightNoteId)
+            return true
+          })
           const stillActive = cleanTabs.find(t => t.id === p.activeTabId)
           return { ...p, tabs: cleanTabs, activeTabId: stillActive?.id ?? cleanTabs[cleanTabs.length - 1]?.id ?? null }
         })
@@ -672,7 +717,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         return persisted as { panes: PaneState[]; activePaneId: string | null }
       },
       partialize: (state) => ({
-        // Persist only note tabs.
+        // Persist only note tabs. Welcome / merge-* / compare tabs are
+        // point-in-time surfaces; dropping them on reload is correct.
         panes: state.panes.map(p => ({
           ...p,
           tabs: p.tabs.filter(t => t.kind === 'note'),


### PR DESCRIPTION
## Summary

VS Code-style two-step compare flow on the noteser file tree.

- Adds two right-click menu items on note rows: **Select for Compare** marks a note as the left side of a pending compare; **Compare with Selected** opens a read-only side-by-side diff between the marked note and the right-clicked target. "Compare with Selected" is only shown when a different note is already selected as the source and the target is not trashed.
- The pending source is shown in the tree with italic text + a left-border accent + subtle ring. Pressing Esc anywhere clears it; opening the diff also auto-clears.
- The diff tab is a new `compare` tab kind on the workspace store. It snapshots the two note ids at open time, re-reads content live from `useNoteStore` (so concurrent edits reflect into the diff), uses `diffByLine` from `src/utils/lineDiff.ts` to produce hunks, and renders a two-column read-only view. No Apply, no resolve buttons.

## Design decision

Picked a **new `compare` tab kind** over reusing `merge-conflict`. Reusing `merge-conflict` would force a host of conditionals in `MergeEditorView` (no Apply, no per-hunk choice UI, no conflict-resolution callbacks, no `ConflictTabData` shape because there is no remote/local distinction), and the brief explicitly says not to refactor `MergeEditorView`'s apply logic. A dedicated `CompareView` keeps both surfaces clean and small — the new component is ~100 lines of read-only rendering on top of the existing `diffByLine` util.

Both `partialize` and `pruneStaleTabs` updated to handle the new kind (compare tabs don't persist; mid-session deletion of a note in a compare tab drops the tab on the next prune).

## Files touched

- `src/stores/uiStore.ts` — new `compareSourceNoteId` + `setCompareSource` / `clearCompareSource`.
- `src/stores/workspaceStore.ts` — new `compare` tab kind + `openCompare` action (focuses an existing tab for the same pair instead of duplicating, no-op on same id).
- `src/components/sidebar/ContextMenu.tsx` — two new menu entries gated on the rules above.
- `src/components/sidebar/FolderTree.tsx` — visual highlight on the compare source row + global Esc clears the mark.
- `src/components/editor/CompareView.tsx` — new read-only side-by-side diff view.
- `src/components/editor/Pane.tsx`, `TabBar.tsx` — render the new tab kind with an icon + sensible title.
- `src/__tests__/compareSourceState.test.ts`, `src/__tests__/contextMenuCompare.test.tsx` — unit + tree-level coverage.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` clean (179 suites, 2134 tests pass)
- [ ] Right-click a note, pick Select for Compare; row turns italic with a left-border accent.
- [ ] Right-click the SAME note — Compare with Selected is hidden.
- [ ] Right-click a different note — Compare with Selected appears; clicking it opens a side-by-side diff tab and clears the highlight.
- [ ] Press Esc while a source is pending — the highlight clears.
- [ ] Opening the same pair twice focuses the existing tab.
- [ ] Reloading drops compare tabs (not persisted).