### PR TITLE
feat(editor): vertical splits + 3-pane workspace (Obsidian parity)

### DIFF
--- a/src/__tests__/workspaceSplits.test.ts
+++ b/src/__tests__/workspaceSplits.test.ts
@@ -1,0 +1,267 @@
+/**
+ * workspaceSplits.test.ts
+ *
+ * Coverage for the multi-pane split workspace:
+ *   - splitTabRight / splitTabDown create a fresh pane on the requested side
+ *     and update the LayoutNode tree.
+ *   - The 3-pane cap is enforced — a fourth split is rejected (the tab
+ *     moves into the newest existing pane instead).
+ *   - Closing the last tab in a pane re-collapses the layout so the
+ *     surviving panes' arrangement is preserved.
+ *   - The persisted v2 → v3 workspace migration wraps the flat panes[]
+ *     array into a horizontal-cascade layout tree and survives a reload
+ *     (running the migrate function twice is idempotent).
+ */
+
+import {
+  useWorkspaceStore,
+  migrateWorkspace,
+  type LayoutNode,
+  type PaneState,
+} from '../stores/workspaceStore'
+import { useNoteStore } from '../stores/noteStore'
+
+const makeNote = (id: string, title: string) => ({
+  id,
+  title,
+  content: `# ${title}`,
+  folderId: null,
+  createdAt: Date.now(),
+  updatedAt: Date.now(),
+  isDeleted: false,
+  deletedAt: null,
+  isPinned: false,
+  templateId: null,
+})
+
+function leafIds(node: LayoutNode): string[] {
+  if (node.kind === 'leaf') return [node.paneId]
+  return [...leafIds(node.children[0]), ...leafIds(node.children[1])]
+}
+
+beforeEach(() => {
+  useWorkspaceStore.setState({
+    panes: [{ id: 'p1', tabs: [], activeTabId: null }],
+    layout: { kind: 'leaf', paneId: 'p1' },
+    activePaneId: 'p1',
+    mergeAppliedCount: 0,
+    histories: {},
+  })
+  useNoteStore.setState({
+    notes: [makeNote('A', 'Alpha'), makeNote('B', 'Beta'), makeNote('C', 'Gamma'), makeNote('D', 'Delta')],
+    selectedNoteId: null,
+  })
+})
+
+const tabIdOfNote = (paneId: string, noteId: string): string => {
+  const pane = useWorkspaceStore.getState().panes.find(p => p.id === paneId)!
+  const tab = pane.tabs.find(t => t.kind === 'note' && t.noteId === noteId)
+  if (!tab) throw new Error(`no tab for ${noteId} in ${paneId}`)
+  return tab.id
+}
+
+test('splitTabDown creates a vertical split with a new pane below', () => {
+  const ws = () => useWorkspaceStore.getState()
+  ws().openNote('A', { preview: false })
+  const aTab = tabIdOfNote('p1', 'A')
+
+  ws().splitTabDown(aTab)
+
+  const state = ws()
+  expect(state.panes).toHaveLength(2)
+  expect(state.layout.kind).toBe('split')
+  if (state.layout.kind !== 'split') throw new Error('unreachable')
+  expect(state.layout.direction).toBe('vertical')
+  const ids = leafIds(state.layout)
+  expect(ids).toHaveLength(2)
+  expect(ids).toContain('p1')
+
+  const newPaneId = state.panes.find(p => p.id !== 'p1')!.id
+  const newPane = state.panes.find(p => p.id === newPaneId)!
+  expect(newPane.tabs).toHaveLength(1)
+  expect(newPane.tabs[0].kind === 'note' && newPane.tabs[0].noteId === 'A').toBe(true)
+  expect(state.activePaneId).toBe(newPaneId)
+})
+
+test('splitTabRight creates a horizontal split with a new pane to the right', () => {
+  const ws = () => useWorkspaceStore.getState()
+  ws().openNote('A', { preview: false })
+  ws().splitTabRight(tabIdOfNote('p1', 'A'))
+
+  const state = ws()
+  expect(state.panes).toHaveLength(2)
+  expect(state.layout.kind).toBe('split')
+  if (state.layout.kind !== 'split') throw new Error('unreachable')
+  expect(state.layout.direction).toBe('horizontal')
+})
+
+test('a 4th split is rejected — workspace stays at 3 panes (tab moves into newest pane)', () => {
+  const ws = () => useWorkspaceStore.getState()
+  ws().openNote('A', { preview: false })
+  ws().openNote('B', { preview: false })
+  ws().openNote('C', { preview: false })
+  ws().openNote('D', { preview: false })
+
+  ws().splitTabRight(tabIdOfNote('p1', 'A'))
+  ws().splitTabDown(tabIdOfNote('p1', 'B'))
+  expect(ws().panes).toHaveLength(3)
+
+  ws().splitTabRight(tabIdOfNote('p1', 'C'))
+  expect(ws().panes).toHaveLength(3)
+
+  const newest = ws().panes[ws().panes.length - 1]
+  const hasC = newest.tabs.some(t => t.kind === 'note' && t.noteId === 'C')
+  expect(hasC).toBe(true)
+
+  ws().splitTabDown(tabIdOfNote('p1', 'D'))
+  expect(ws().panes).toHaveLength(3)
+})
+
+test('closing the last tab in a split pane re-collapses the layout', () => {
+  const ws = () => useWorkspaceStore.getState()
+  ws().openNote('A', { preview: false })
+  ws().openNote('B', { preview: false })
+  // p1 = [A, B]. Split A out to the right — p1 keeps B, new pane gets A.
+  ws().splitTabRight(tabIdOfNote('p1', 'A'))
+  expect(ws().panes).toHaveLength(2)
+  expect(ws().layout.kind).toBe('split')
+
+  const newPaneId = ws().panes.find(p => p.id !== 'p1')!.id
+  const lonelyTab = ws().panes.find(p => p.id === newPaneId)!.tabs[0]
+  ws().closeTab(lonelyTab.id)
+
+  expect(ws().panes).toHaveLength(1)
+  expect(ws().layout.kind).toBe('leaf')
+  if (ws().layout.kind === 'leaf') {
+    expect((ws().layout as { kind: 'leaf'; paneId: string }).paneId).toBe('p1')
+  }
+})
+
+test('closing one of three panes collapses to a single split (not a single leaf)', () => {
+  const ws = () => useWorkspaceStore.getState()
+  ws().openNote('A', { preview: false })
+  ws().openNote('B', { preview: false })
+  ws().openNote('C', { preview: false })
+
+  ws().splitTabRight(tabIdOfNote('p1', 'A'))
+  ws().splitTabDown(tabIdOfNote('p1', 'B'))
+  expect(ws().panes).toHaveLength(3)
+
+  const allPanes = ws().panes
+  const pane2 = allPanes.find(p => p.tabs.some(t => t.kind === 'note' && t.noteId === 'A'))!
+  ws().closeTab(pane2.tabs[0].id)
+
+  expect(ws().panes).toHaveLength(2)
+  expect(ws().layout.kind).toBe('split')
+})
+
+describe('workspace migration', () => {
+  test('v1 → v3 wraps the legacy { tabs, activeTabId } into a single-pane workspace + leaf layout', () => {
+    const legacy = {
+      tabs: [
+        { id: 't1', kind: 'note', noteId: 'A', isPreview: false },
+        { id: 't2', kind: 'note', noteId: 'B', isPreview: true },
+      ],
+      activeTabId: 't1',
+    }
+    const migrated = migrateWorkspace(legacy, 1)
+    expect(migrated.panes).toHaveLength(1)
+    expect(migrated.panes[0].tabs).toHaveLength(2)
+    expect(migrated.layout.kind).toBe('leaf')
+    if (migrated.layout.kind === 'leaf') {
+      expect(migrated.layout.paneId).toBe(migrated.panes[0].id)
+    }
+  })
+
+  test('v2 → v3 derives a horizontal-cascade layout from the flat panes[] array', () => {
+    const v2: { panes: PaneState[]; activePaneId: string | null } = {
+      panes: [
+        { id: 'pA', tabs: [], activeTabId: null },
+        { id: 'pB', tabs: [], activeTabId: null },
+      ],
+      activePaneId: 'pA',
+    }
+    const migrated = migrateWorkspace(v2, 2)
+    expect(migrated.panes.map(p => p.id)).toEqual(['pA', 'pB'])
+    expect(migrated.layout.kind).toBe('split')
+    if (migrated.layout.kind !== 'split') throw new Error('unreachable')
+    expect(migrated.layout.direction).toBe('horizontal')
+    expect(leafIds(migrated.layout).sort()).toEqual(['pA', 'pB'])
+  })
+
+  test('migration is idempotent across reloads (running migrateWorkspace on its own output preserves shape)', () => {
+    const v2: { panes: PaneState[]; activePaneId: string | null } = {
+      panes: [
+        { id: 'pA', tabs: [], activeTabId: null },
+        { id: 'pB', tabs: [], activeTabId: null },
+      ],
+      activePaneId: 'pA',
+    }
+    const once = migrateWorkspace(v2, 2)
+    const twice = migrateWorkspace(once, 3)
+    expect(twice.panes.map(p => p.id)).toEqual(once.panes.map(p => p.id))
+    expect(twice.layout).toEqual(once.layout)
+  })
+
+  test('v3 already-migrated payload with a layout passes through (reconciled, but pane ids preserved)', () => {
+    const v3 = {
+      panes: [
+        { id: 'pA', tabs: [], activeTabId: null },
+        { id: 'pB', tabs: [], activeTabId: null },
+      ],
+      activePaneId: 'pA',
+      layout: {
+        kind: 'split',
+        direction: 'vertical',
+        ratio: 0.5,
+        children: [
+          { kind: 'leaf', paneId: 'pA' },
+          { kind: 'leaf', paneId: 'pB' },
+        ],
+      },
+    }
+    const out = migrateWorkspace(v3, 3)
+    expect(out.layout.kind).toBe('split')
+    if (out.layout.kind !== 'split') throw new Error('unreachable')
+    expect(out.layout.direction).toBe('vertical')
+    expect(leafIds(out.layout).sort()).toEqual(['pA', 'pB'])
+  })
+
+  test('a layout that references a missing pane is reconciled — dead leaves are dropped', () => {
+    const broken = {
+      panes: [{ id: 'pA', tabs: [], activeTabId: null }],
+      activePaneId: 'pA',
+      layout: {
+        kind: 'split',
+        direction: 'horizontal',
+        ratio: 0.5,
+        children: [
+          { kind: 'leaf', paneId: 'pA' },
+          { kind: 'leaf', paneId: 'ghost' },
+        ],
+      },
+    }
+    const out = migrateWorkspace(broken, 3)
+    const ids = leafIds(out.layout)
+    expect(ids).toEqual(['pA'])
+  })
+})
+
+test('setLayoutRatio updates the divider position for the split between two panes', () => {
+  const ws = () => useWorkspaceStore.getState()
+  ws().openNote('A', { preview: false })
+  ws().splitTabRight(tabIdOfNote('p1', 'A'))
+
+  const newPaneId = ws().panes.find(p => p.id !== 'p1')!.id
+  ws().setLayoutRatio('p1', newPaneId, 0.7)
+
+  const layout = ws().layout
+  expect(layout.kind).toBe('split')
+  if (layout.kind !== 'split') throw new Error('unreachable')
+  expect(layout.ratio).toBeCloseTo(0.7)
+
+  ws().setLayoutRatio('p1', newPaneId, 0.001)
+  const layout2 = ws().layout
+  if (layout2.kind !== 'split') throw new Error('unreachable')
+  expect(layout2.ratio).toBeCloseTo(0.05)
+})

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -1,85 +1,148 @@
 'use client'
 
-import { useRef, useState } from 'react'
+import { useRef, useCallback } from 'react'
 import { useWorkspaceStore } from '@/stores'
 import { useViewport } from '@/hooks'
 import { Pane } from './Pane'
+import type { LayoutNode, PaneState } from '@/stores/workspaceStore'
 
-// Renders the workspace's panes side by side. For v1 we cap at 2 panes
-// (horizontal split). The divider between them is draggable to resize.
+// Renders the workspace's panes laid out according to the layout tree.
+// Up to MAX_PANES (3) panes total; arrangements include horizontal,
+// vertical, and L-shapes (a horizontal split whose right or left child
+// is itself a vertical split).
 
-const DEFAULT_LEFT_RATIO = 0.5
-// Smallest fraction of the editor width a single pane may shrink to via
-// the divider drag. Was 0.15 (a hard 15% floor that blocked normal
-// shrinking); lowered to 0.05 so a pane can be made small like the other
-// resizable panels while still leaving a grabbable sliver + the divider.
 const MIN_PANE_RATIO = 0.05
 
 export const Editor = () => {
   const panes = useWorkspaceStore(s => s.panes)
+  const layout = useWorkspaceStore(s => s.layout)
   const activePaneId = useWorkspaceStore(s => s.activePaneId)
-  const [leftRatio, setLeftRatio] = useState(DEFAULT_LEFT_RATIO)
-  const containerRef = useRef<HTMLDivElement>(null)
-  const dragRef = useRef<{ startX: number; startRatio: number } | null>(null)
   const { isMobile } = useViewport()
 
-  // Mobile: there isn't room for a horizontal split, so render only the
-  // active pane. The second pane's tabs stay in the store — when the
-  // viewport grows back past the breakpoint, the split reappears intact.
+  const paneById = (id: string): PaneState | undefined => panes.find(p => p.id === id)
+
+  // Mobile: there isn't room for a split, so render only the active pane.
+  // The other panes' tabs stay in the store — when the viewport grows back
+  // past the breakpoint, the layout reappears intact.
   if (isMobile && panes.length > 1) {
     const active = panes.find(p => p.id === activePaneId) ?? panes[0]
     return (
       <div className="flex h-full w-full overflow-hidden">
-        <Pane pane={active} allowSplitDropZone={false} />
+        <Pane pane={active} />
       </div>
     )
   }
 
-  // Single pane: no divider, full width.
   if (panes.length <= 1) {
     return (
       <div className="flex h-full w-full overflow-hidden">
-        <Pane pane={panes[0]} allowSplitDropZone={!isMobile} />
+        <Pane pane={panes[0]} />
       </div>
     )
   }
 
-  // Two panes: horizontal split with draggable divider.
-  const onDividerMouseDown = (e: React.MouseEvent) => {
+  return (
+    <div className="flex h-full w-full overflow-hidden">
+      <LayoutRenderer node={layout} paneById={paneById} />
+    </div>
+  )
+}
+
+interface LayoutRendererProps {
+  node: LayoutNode
+  paneById: (id: string) => PaneState | undefined
+}
+
+const LayoutRenderer = ({ node, paneById }: LayoutRendererProps) => {
+  if (node.kind === 'leaf') {
+    const pane = paneById(node.paneId)
+    if (!pane) return null
+    return <Pane pane={pane} />
+  }
+  return <Split node={node} paneById={paneById} />
+}
+
+interface SplitProps {
+  node: Extract<LayoutNode, { kind: 'split' }>
+  paneById: (id: string) => PaneState | undefined
+}
+
+// A split renders its two children with a draggable divider between
+// them. Direction picks the axis: horizontal stacks side-by-side,
+// vertical stacks top-over-bottom. The ratio (size of the FIRST child)
+// is sourced from and written back to the layout tree.
+const Split = ({ node, paneById }: SplitProps) => {
+  const setLayoutRatio = useWorkspaceStore(s => s.setLayoutRatio)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<{ start: number; startRatio: number } | null>(null)
+
+  // Pick a representative pane id from each subtree to identify the
+  // divider when persisting the new ratio. setLayoutRatio matches a
+  // split by ANY pair of pane ids that straddle it, so we just use the
+  // first leaf on each side.
+  const firstLeafId = (n: LayoutNode): string =>
+    n.kind === 'leaf' ? n.paneId : firstLeafId(n.children[0])
+  const leftId = firstLeafId(node.children[0])
+  const rightId = firstLeafId(node.children[1])
+
+  const onDividerMouseDown = useCallback((e: React.MouseEvent) => {
     e.preventDefault()
-    dragRef.current = { startX: e.clientX, startRatio: leftRatio }
+    const isHorizontal = node.direction === 'horizontal'
+    dragRef.current = {
+      start: isHorizontal ? e.clientX : e.clientY,
+      startRatio: node.ratio,
+    }
     const handleMove = (ev: MouseEvent) => {
       if (!containerRef.current || !dragRef.current) return
       const rect = containerRef.current.getBoundingClientRect()
-      const delta = (ev.clientX - dragRef.current.startX) / rect.width
+      const total = isHorizontal ? rect.width : rect.height
+      if (total <= 0) return
+      const delta = ((isHorizontal ? ev.clientX : ev.clientY) - dragRef.current.start) / total
       const next = dragRef.current.startRatio + delta
-      // Clamp so neither pane vanishes entirely, but allow panes to be
-      // dragged quite small (like the other resizable panels). A tiny
-      // floor keeps a sliver of each pane grabbable so the divider can't
-      // be lost off-screen.
-      setLeftRatio(Math.min(1 - MIN_PANE_RATIO, Math.max(MIN_PANE_RATIO, next)))
+      const clamped = Math.min(1 - MIN_PANE_RATIO, Math.max(MIN_PANE_RATIO, next))
+      setLayoutRatio(leftId, rightId, clamped)
     }
     const handleUp = () => {
       dragRef.current = null
       window.removeEventListener('mousemove', handleMove)
       window.removeEventListener('mouseup', handleUp)
+      document.body.style.userSelect = ''
+      document.body.style.cursor = ''
     }
+    document.body.style.userSelect = 'none'
+    document.body.style.cursor = node.direction === 'horizontal' ? 'col-resize' : 'row-resize'
     window.addEventListener('mousemove', handleMove)
     window.addEventListener('mouseup', handleUp)
-  }
+  }, [leftId, node.direction, node.ratio, rightId, setLayoutRatio])
+
+  const isHorizontal = node.direction === 'horizontal'
+  const containerClass = isHorizontal
+    ? 'flex h-full w-full min-h-0 min-w-0 overflow-hidden flex-row'
+    : 'flex h-full w-full min-h-0 min-w-0 overflow-hidden flex-col'
+  const firstStyle: React.CSSProperties = isHorizontal
+    ? { width: `${node.ratio * 100}%` }
+    : { height: `${node.ratio * 100}%` }
+  const secondStyle: React.CSSProperties = isHorizontal
+    ? { width: `${(1 - node.ratio) * 100}%` }
+    : { height: `${(1 - node.ratio) * 100}%` }
+  const dividerClass = isHorizontal
+    ? 'w-1 cursor-col-resize bg-obsidianBorder hover:bg-obsidianAccentPurple/60 flex-shrink-0 transition-colors'
+    : 'h-1 cursor-row-resize bg-obsidianBorder hover:bg-obsidianAccentPurple/60 flex-shrink-0 transition-colors'
 
   return (
-    <div ref={containerRef} className="flex h-full w-full overflow-hidden">
-      <div style={{ width: `${leftRatio * 100}%` }} className="flex min-w-0 flex-shrink-0">
-        <Pane pane={panes[0]} allowSplitDropZone={false} />
+    <div ref={containerRef} className={containerClass}>
+      <div style={firstStyle} className={`${isHorizontal ? 'flex' : 'flex flex-col'} min-w-0 min-h-0 flex-shrink-0`}>
+        <LayoutRenderer node={node.children[0]} paneById={paneById} />
       </div>
       <div
         onMouseDown={onDividerMouseDown}
-        className="w-1 cursor-col-resize bg-obsidianBorder hover:bg-obsidianAccentPurple/60 flex-shrink-0 transition-colors"
+        className={dividerClass}
         title="Drag to resize"
+        data-testid="editor-resize-handle"
+        data-direction={node.direction}
       />
-      <div style={{ width: `${(1 - leftRatio) * 100}%` }} className="flex min-w-0 flex-shrink-0">
-        <Pane pane={panes[1]} allowSplitDropZone={false} />
+      <div style={secondStyle} className={`${isHorizontal ? 'flex' : 'flex flex-col'} min-w-0 min-h-0 flex-shrink-0`}>
+        <LayoutRenderer node={node.children[1]} paneById={paneById} />
       </div>
     </div>
   )

--- a/src/components/editor/Pane.tsx
+++ b/src/components/editor/Pane.tsx
@@ -21,21 +21,20 @@ import type { PaneState } from '@/stores/workspaceStore'
 // elsewhere to create a split.
 interface Props {
   pane: PaneState
-  // True when this is the only pane and we should expose the right-edge
-  // drop zone for creating a split. The second pane never offers it (we
-  // only support 2 panes for now).
-  allowSplitDropZone: boolean
 }
 
-export const Pane = ({ pane, allowSplitDropZone }: Props) => {
+export const Pane = ({ pane }: Props) => {
   const { notes, updateNote } = useNoteStore()
   const { isPreviewMode } = useUIStore()
   const focusPane = useWorkspaceStore(s => s.focusPane)
   const promoteTab = useWorkspaceStore(s => s.promoteTab)
   const splitTabRight = useWorkspaceStore(s => s.splitTabRight)
+  const splitTabDown = useWorkspaceStore(s => s.splitTabDown)
   const activePaneId = useWorkspaceStore(s => s.activePaneId)
+  const paneCount = useWorkspaceStore(s => s.panes.length)
+  const canSplitMore = paneCount < 3
 
-  const [splitDropActive, setSplitDropActive] = useState(false)
+  const [splitDropActive, setSplitDropActive] = useState<null | 'right' | 'bottom'>(null)
   const tabDragActive = useTabDragActive()
   const activeTab = pane.tabs.find(t => t.id === pane.activeTabId) ?? null
   const isActive = pane.id === activePaneId
@@ -45,18 +44,21 @@ export const Pane = ({ pane, allowSplitDropZone }: Props) => {
   // even mount in that case (see render below).
   const { isMobile } = useViewport()
 
-  const handleRightEdgeDragOver = (e: React.DragEvent) => {
+  const makeEdgeDragOver = (zone: 'right' | 'bottom') => (e: React.DragEvent) => {
     if (!e.dataTransfer.types.includes(TAB_DRAG_MIME)) return
     e.preventDefault()
     e.dataTransfer.dropEffect = 'move'
-    setSplitDropActive(true)
+    setSplitDropActive(zone)
   }
-  const handleRightEdgeDrop = (e: React.DragEvent) => {
+  const handleEdgeDrop = (zone: 'right' | 'bottom') => (e: React.DragEvent) => {
     if (!e.dataTransfer.types.includes(TAB_DRAG_MIME)) return
     e.preventDefault()
     const tabId = e.dataTransfer.getData(TAB_DRAG_MIME)
-    if (tabId) splitTabRight(tabId)
-    setSplitDropActive(false)
+    if (tabId) {
+      if (zone === 'right') splitTabRight(tabId)
+      else splitTabDown(tabId)
+    }
+    setSplitDropActive(null)
   }
 
   let body: React.ReactNode
@@ -156,26 +158,46 @@ export const Pane = ({ pane, allowSplitDropZone }: Props) => {
       <TabBar pane={pane} />
       <div className="flex-1 flex flex-col min-h-0">{body}</div>
 
-      {/* Right-edge split drop target — only rendered (and only intercepts
-          events) while a tab is actively being dragged. Otherwise clicks in
-          the right portion of the editor would get eaten. */}
-      {allowSplitDropZone && tabDragActive && !isMobile && (
-        <div
-          onDragOver={handleRightEdgeDragOver}
-          onDragLeave={() => setSplitDropActive(false)}
-          onDrop={handleRightEdgeDrop}
-          className={`absolute top-0 right-0 h-full w-1/3 z-10 transition-colors ${
-            splitDropActive
-              ? 'bg-obsidianAccentPurple/20 border-l-2 border-obsidianAccentPurple'
-              : 'bg-obsidianAccentPurple/5 border-l border-obsidianAccentPurple/40 border-dashed'
-          }`}
-        >
-          {!splitDropActive && (
-            <div className="absolute top-1/2 -translate-y-1/2 right-3 text-xs text-obsidianAccentPurple/80 font-medium pointer-events-none">
-              Drop to split →
-            </div>
-          )}
-        </div>
+      {/* Right- and bottom-edge split drop targets — only rendered (and
+          only intercepting events) while a tab is actively being
+          dragged. Otherwise clicks in those regions would get eaten. */}
+      {canSplitMore && tabDragActive && !isMobile && (
+        <>
+          <div
+            onDragOver={makeEdgeDragOver('right')}
+            onDragLeave={() => setSplitDropActive(null)}
+            onDrop={handleEdgeDrop('right')}
+            data-testid="pane-drop-right"
+            className={`absolute top-0 right-0 h-2/3 w-1/3 z-10 transition-colors ${
+              splitDropActive === 'right'
+                ? 'bg-obsidianAccentPurple/20 border-l-2 border-obsidianAccentPurple'
+                : 'bg-obsidianAccentPurple/5 border-l border-obsidianAccentPurple/40 border-dashed'
+            }`}
+          >
+            {splitDropActive !== 'right' && (
+              <div className="absolute top-1/2 -translate-y-1/2 right-3 text-xs text-obsidianAccentPurple/80 font-medium pointer-events-none">
+                Drop to split right →
+              </div>
+            )}
+          </div>
+          <div
+            onDragOver={makeEdgeDragOver('bottom')}
+            onDragLeave={() => setSplitDropActive(null)}
+            onDrop={handleEdgeDrop('bottom')}
+            data-testid="pane-drop-bottom"
+            className={`absolute bottom-0 left-0 right-0 h-1/3 z-10 transition-colors ${
+              splitDropActive === 'bottom'
+                ? 'bg-obsidianAccentPurple/20 border-t-2 border-obsidianAccentPurple'
+                : 'bg-obsidianAccentPurple/5 border-t border-obsidianAccentPurple/40 border-dashed'
+            }`}
+          >
+            {splitDropActive !== 'bottom' && (
+              <div className="absolute left-1/2 -translate-x-1/2 bottom-3 text-xs text-obsidianAccentPurple/80 font-medium pointer-events-none">
+                Drop to split down ↓
+              </div>
+            )}
+          </div>
+        </>
       )}
     </div>
   )

--- a/src/components/editor/TabBar.tsx
+++ b/src/components/editor/TabBar.tsx
@@ -37,8 +37,6 @@ export const TabBar = ({ pane }: Props) => {
   useEffect(() => {
     if (!menu) return
     const onDown = (e: MouseEvent) => {
-      // Don't dismiss when the click lands on the menu itself; menu
-      // items already call setMenu(null) before/after running.
       const el = e.target as HTMLElement | null
       if (el?.closest('[data-testid="tab-context-menu"]')) return
       setMenu(null)

--- a/src/components/editor/TabBar.tsx
+++ b/src/components/editor/TabBar.tsx
@@ -1,7 +1,15 @@
 'use client'
 
-import { useRef, useState } from 'react'
-import { DocumentTextIcon, DocumentDuplicateIcon, ExclamationTriangleIcon, XMarkIcon, SparklesIcon } from '@heroicons/react/24/outline'
+import { useEffect, useRef, useState } from 'react'
+import {
+  DocumentTextIcon,
+  DocumentDuplicateIcon,
+  ExclamationTriangleIcon,
+  XMarkIcon,
+  SparklesIcon,
+  ArrowsRightLeftIcon,
+  ArrowsUpDownIcon,
+} from '@heroicons/react/24/outline'
 import { useNoteStore, useWorkspaceStore } from '@/stores'
 import { TAB_DRAG_MIME } from '@/hooks'
 import type { Tab, PaneState } from '@/stores/workspaceStore'
@@ -18,7 +26,31 @@ export const TabBar = ({ pane }: Props) => {
   const closeTab = useWorkspaceStore(s => s.closeTab)
   const moveTab = useWorkspaceStore(s => s.moveTab)
   const promoteTab = useWorkspaceStore(s => s.promoteTab)
+  const splitTabRight = useWorkspaceStore(s => s.splitTabRight)
+  const splitTabDown = useWorkspaceStore(s => s.splitTabDown)
+  const paneCount = useWorkspaceStore(s => s.panes.length)
   const notes = useNoteStore(s => s.notes)
+  const canSplitMore = paneCount < 3
+
+  const [menu, setMenu] = useState<{ tabId: string; x: number; y: number } | null>(null)
+  // Close on click-out / Esc — mirrors the sidebar ContextMenu pattern.
+  useEffect(() => {
+    if (!menu) return
+    const onDown = (e: MouseEvent) => {
+      // Don't dismiss when the click lands on the menu itself; menu
+      // items already call setMenu(null) before/after running.
+      const el = e.target as HTMLElement | null
+      if (el?.closest('[data-testid="tab-context-menu"]')) return
+      setMenu(null)
+    }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setMenu(null) }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [menu])
 
   const [dragOverIdx, setDragOverIdx] = useState<number | null>(null)
   // A genuine (slightly slow) double-click does not reliably fire the native
@@ -65,9 +97,12 @@ export const TabBar = ({ pane }: Props) => {
   }
 
   return (
+    <>
     <div
-      className={`flex items-stretch border-b border-obsidianBorder overflow-x-auto ${
-        paneIsActive ? 'bg-obsidianBlack' : 'bg-obsidianBlack/95'
+      className={`flex items-stretch border-b overflow-x-auto transition-colors ${
+        paneIsActive
+          ? 'bg-obsidianBlack border-b-obsidianAccentPurple/60'
+          : 'bg-obsidianBlack/95 border-b-obsidianBorder'
       }`}
       onDragLeave={(e) => { if (e.currentTarget === e.target) setDragOverIdx(null) }}
     >
@@ -91,6 +126,10 @@ export const TabBar = ({ pane }: Props) => {
               onClick={() => handleTabClick(tab.id)}
               onDoubleClick={() => promoteTab(tab.id)}
               onAuxClick={(e) => { if (e.button === 1) { e.preventDefault(); closeTab(tab.id) } }}
+              onContextMenu={(e) => {
+                e.preventDefault()
+                setMenu({ tabId: tab.id, x: e.clientX, y: e.clientY })
+              }}
               className={`flex items-center gap-1.5 px-3 py-2 text-sm border-r border-obsidianBorder cursor-pointer max-w-[200px] flex-shrink-0 select-none min-h-[44px] ${
                 active
                   ? 'bg-obsidianBlack text-obsidianText border-t-2 border-t-obsidianAccentPurple'
@@ -124,6 +163,81 @@ export const TabBar = ({ pane }: Props) => {
           </div>
         )
       })}
+    </div>
+    {menu && (
+      <TabContextMenu
+        x={menu.x}
+        y={menu.y}
+        canSplit={canSplitMore}
+        onSplitRight={() => { splitTabRight(menu.tabId); setMenu(null) }}
+        onSplitDown={() => { splitTabDown(menu.tabId); setMenu(null) }}
+        onClose={() => { closeTab(menu.tabId); setMenu(null) }}
+      />
+    )}
+    </>
+  )
+}
+
+interface TabContextMenuProps {
+  x: number
+  y: number
+  canSplit: boolean
+  onSplitRight: () => void
+  onSplitDown: () => void
+  onClose: () => void
+}
+
+const TabContextMenu = ({ x, y, canSplit, onSplitRight, onSplitDown, onClose }: TabContextMenuProps) => {
+  const ref = useRef<HTMLDivElement>(null)
+  // Nudge the menu back into view if it would render off the right/bottom
+  // edge — matches the sidebar ContextMenu adjustment.
+  useEffect(() => {
+    if (!ref.current) return
+    const el = ref.current
+    const rect = el.getBoundingClientRect()
+    if (rect.right > window.innerWidth) {
+      el.style.left = `${Math.max(8, window.innerWidth - rect.width - 8)}px`
+    }
+    if (rect.bottom > window.innerHeight) {
+      el.style.top = `${Math.max(8, window.innerHeight - rect.height - 8)}px`
+    }
+  }, [])
+
+  return (
+    <div
+      ref={ref}
+      role="menu"
+      data-testid="tab-context-menu"
+      className="fixed bg-obsidianGray border border-obsidianBorder rounded-lg shadow-obsidian py-1 min-w-[180px] z-50"
+      style={{ top: y, left: x }}
+    >
+      <button
+        onClick={onSplitRight}
+        disabled={!canSplit}
+        data-testid="tab-context-split-right"
+        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-obsidianText hover:bg-obsidianHighlight disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+      >
+        <ArrowsRightLeftIcon className="w-4 h-4" />
+        Split right
+      </button>
+      <button
+        onClick={onSplitDown}
+        disabled={!canSplit}
+        data-testid="tab-context-split-down"
+        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-obsidianText hover:bg-obsidianHighlight disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+      >
+        <ArrowsUpDownIcon className="w-4 h-4" />
+        Split down
+      </button>
+      <div className="my-1 border-t border-obsidianBorder" />
+      <button
+        onClick={onClose}
+        data-testid="tab-context-close"
+        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-obsidianText hover:bg-obsidianHighlight transition-colors"
+      >
+        <XMarkIcon className="w-4 h-4" />
+        Close tab
+      </button>
     </div>
   )
 }

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -49,8 +49,21 @@ export interface PaneState {
   activeTabId: string | null
 }
 
+// Layout tree describing how panes are arranged on screen. Leaves point
+// back to a PaneState by id; splits arrange their two children either
+// side-by-side (horizontal) or stacked top-over-bottom (vertical). A
+// 3-pane workspace is two nested splits — e.g. a 'right' split whose
+// right child is a 'down' split forms an L-shape. We carry a per-split
+// ratio so the divider drag can persist.
+export type LayoutNode =
+  | { kind: 'leaf'; paneId: string }
+  | { kind: 'split'; direction: 'horizontal' | 'vertical'; ratio: number; children: [LayoutNode, LayoutNode] }
+
+export const MAX_PANES = 3
+
 interface WorkspaceState {
-  panes: PaneState[]              // length 1 or 2 (horizontal split)
+  panes: PaneState[]              // length 1..MAX_PANES
+  layout: LayoutNode              // mirrors panes[] arrangement
   activePaneId: string | null
   // Bumped each time the user clicks Apply on a merge tab; reset to 0 when a
   // new openMergeConflicts batch starts.
@@ -96,6 +109,16 @@ interface WorkspaceState {
   // Take the tab out of its current pane and put it in a brand-new pane that
   // sits to the right (or alone if there's nowhere to go).
   splitTabRight: (tabId: string) => void
+  // Same shape as splitTabRight but stacks the new pane BELOW the source —
+  // Obsidian's "Split down". No-op once the workspace already holds
+  // MAX_PANES panes.
+  splitTabDown: (tabId: string) => void
+  // Persist a divider drag for a particular split node (looked up by the
+  // ids of the two panes immediately on either side of it; order doesn't
+  // matter). Ratio is the size fraction of the FIRST child in tree order
+  // (left for horizontal, top for vertical) and is clamped to a small
+  // floor so a pane can't be dragged to zero.
+  setLayoutRatio: (paneA: string, paneB: string, ratio: number) => void
 
   // ── Navigation history (Back / Forward) ────────────────────────────────
   // Move the given pane (default: active pane) back / forward through its
@@ -118,6 +141,218 @@ function findTab(panes: PaneState[], tabId: string): { paneIdx: number; tabIdx: 
 
 function makePane(): PaneState {
   return { id: uuidv4(), tabs: [], activeTabId: null }
+}
+
+const DEFAULT_SPLIT_RATIO = 0.5
+
+function leaf(paneId: string): LayoutNode {
+  return { kind: 'leaf', paneId }
+}
+
+// Collect all pane ids the layout currently references, in tree order.
+function leafIds(node: LayoutNode): string[] {
+  if (node.kind === 'leaf') return [node.paneId]
+  return [...leafIds(node.children[0]), ...leafIds(node.children[1])]
+}
+
+// Find the leaf for a given pane id and return the path from the root
+// (list of child indices, 0 or 1, taken at each split).
+function pathTo(node: LayoutNode, paneId: string, acc: number[] = []): number[] | null {
+  if (node.kind === 'leaf') return node.paneId === paneId ? acc : null
+  const l = pathTo(node.children[0], paneId, [...acc, 0])
+  if (l) return l
+  return pathTo(node.children[1], paneId, [...acc, 1])
+}
+
+// Replace the subtree at `path` with a new node. Pure — returns a new
+// tree, leaves the original untouched.
+function replaceAt(node: LayoutNode, path: number[], next: LayoutNode): LayoutNode {
+  if (path.length === 0) return next
+  if (node.kind === 'leaf') return node // path was bogus — shouldn't happen
+  const [head, ...rest] = path
+  const newChild = replaceAt(node.children[head], rest, next)
+  const children: [LayoutNode, LayoutNode] = head === 0
+    ? [newChild, node.children[1]]
+    : [node.children[0], newChild]
+  return { ...node, children }
+}
+
+// Split the leaf for `paneId` into a new split node containing the
+// original leaf in `originalSide` (0 = first child) and a fresh leaf for
+// `newPaneId` on the opposite side. Returns the new tree; caller must
+// also add the new pane to panes[].
+function splitLeaf(
+  layout: LayoutNode,
+  paneId: string,
+  newPaneId: string,
+  direction: 'horizontal' | 'vertical',
+  originalSide: 0 | 1 = 0,
+): LayoutNode {
+  const path = pathTo(layout, paneId)
+  if (!path) return layout
+  const original = leaf(paneId)
+  const fresh = leaf(newPaneId)
+  const children: [LayoutNode, LayoutNode] = originalSide === 0
+    ? [original, fresh]
+    : [fresh, original]
+  return replaceAt(layout, path, {
+    kind: 'split',
+    direction,
+    ratio: DEFAULT_SPLIT_RATIO,
+    children,
+  })
+}
+
+// Drop the leaf for `paneId` from the layout. The parent split collapses
+// into its surviving child (so the tree never holds a one-child split).
+// Returns null if the layout would end up empty — caller is expected to
+// substitute a fresh single-leaf root.
+function removeLeaf(layout: LayoutNode, paneId: string): LayoutNode | null {
+  if (layout.kind === 'leaf') {
+    return layout.paneId === paneId ? null : layout
+  }
+  const path = pathTo(layout, paneId)
+  if (!path) return layout
+  // Walk to the parent of the doomed leaf and replace the parent split
+  // with whichever child survives.
+  const parentPath = path.slice(0, -1)
+  const lastIdx = path[path.length - 1] as 0 | 1
+  // Resolve the parent split node.
+  let parent: LayoutNode = layout
+  for (const step of parentPath) {
+    if (parent.kind !== 'split') return layout
+    parent = parent.children[step]
+  }
+  if (parent.kind !== 'split') return layout
+  const survivor = parent.children[lastIdx === 0 ? 1 : 0]
+  return replaceAt(layout, parentPath, survivor)
+}
+
+// Find the split node that has BOTH the given pane ids as descendants on
+// opposite sides — i.e. the divider that sits visually between them.
+// Used to look up the ratio for a drag handle.
+function findSplitBetween(node: LayoutNode, a: string, b: string): { path: number[] } | null {
+  if (node.kind === 'leaf') return null
+  const inLeft = leafIds(node.children[0])
+  const inRight = leafIds(node.children[1])
+  const aLeft = inLeft.includes(a)
+  const aRight = inRight.includes(a)
+  const bLeft = inLeft.includes(b)
+  const bRight = inRight.includes(b)
+  if ((aLeft && bRight) || (aRight && bLeft)) return { path: [] }
+  const downLeft = findSplitBetween(node.children[0], a, b)
+  if (downLeft) return { path: [0, ...downLeft.path] }
+  const downRight = findSplitBetween(node.children[1], a, b)
+  if (downRight) return { path: [1, ...downRight.path] }
+  return null
+}
+
+// Shared core for Split right / Split down. Direction picks how the new
+// pane sits relative to the original (horizontal = right, vertical =
+// below). The 4th-split rejection lives here so both entry points stay
+// in sync. Once the workspace already holds MAX_PANES panes we fall
+// back to moving the tab into the most-recently-created pane, which is
+// the pre-3-pane behaviour for splitTabRight.
+function splitTabInternal(
+  set: (partial: Partial<WorkspaceState>) => void,
+  get: () => WorkspaceState,
+  tabId: string,
+  direction: 'horizontal' | 'vertical',
+): void {
+  const state = get()
+  const loc = findTab(state.panes, tabId)
+  if (!loc) return
+
+  if (state.panes.length >= MAX_PANES) {
+    // No room for a new pane — drop the tab into the last pane the user
+    // created (panes are appended on split, so panes[last] is "the
+    // newest one"). Preserves the "splitting a third time = move into
+    // an existing split" affordance. We move INLINE rather than via
+    // moveTab so a now-empty source pane isn't compacted away — the
+    // 3-pane layout must stay 3 panes (Obsidian leaves an empty leaf
+    // sitting where the user is, mirroring splitTabRight's own "leave
+    // the original pane in place but empty" rule below).
+    const targetPane = state.panes[state.panes.length - 1]
+    if (targetPane.id === state.panes[loc.paneIdx].id) return
+    const sourcePane = state.panes[loc.paneIdx]
+    const tab = sourcePane.tabs[loc.tabIdx]
+    const next = state.panes.map(p => {
+      if (p.id === sourcePane.id) {
+        const tabs = p.tabs.filter(t => t.id !== tabId)
+        const stillActive = p.activeTabId === tabId
+          ? (tabs[loc.tabIdx]?.id ?? tabs[loc.tabIdx - 1]?.id ?? null)
+          : p.activeTabId
+        return { ...p, tabs, activeTabId: stillActive }
+      }
+      if (p.id === targetPane.id) {
+        return { ...p, tabs: [...p.tabs, tab], activeTabId: tab.id }
+      }
+      return p
+    })
+    set({ panes: next, activePaneId: targetPane.id })
+    selectNoteFromActive(next, targetPane.id)
+    return
+  }
+
+  const sourcePane = state.panes[loc.paneIdx]
+  const tab = sourcePane.tabs[loc.tabIdx]
+
+  const draft = state.panes.map(p => ({ ...p, tabs: [...p.tabs] }))
+  draft[loc.paneIdx].tabs.splice(loc.tabIdx, 1)
+  if (draft[loc.paneIdx].activeTabId === tabId) {
+    const remaining = draft[loc.paneIdx].tabs
+    draft[loc.paneIdx].activeTabId = remaining[loc.tabIdx]?.id ?? remaining[loc.tabIdx - 1]?.id ?? null
+  }
+
+  const newPane: PaneState = { id: uuidv4(), tabs: [tab], activeTabId: tab.id }
+  // Obsidian behaviour: splitting the ONLY tab leaves the original pane
+  // in place but empty. compactPanes intentionally is NOT called here.
+  const panes: PaneState[] = [...draft, newPane]
+  const layout = splitLeaf(state.layout, sourcePane.id, newPane.id, direction)
+  set({ panes, layout, activePaneId: newPane.id })
+  selectNoteFromActive(panes, newPane.id)
+}
+
+// Re-derive a layout for a flat list of panes when the persisted layout
+// is missing / stale (e.g. v2 → v3 migration, or partialize dropped it).
+// Pre-v3 always meant a horizontal split between 1 or 2 panes.
+function flatLayout(panes: PaneState[]): LayoutNode {
+  if (panes.length === 0) return leaf(uuidv4()) // unreachable in practice
+  if (panes.length === 1) return leaf(panes[0].id)
+  // Recursively build a right-leaning horizontal cascade.
+  const [first, ...rest] = panes
+  return {
+    kind: 'split',
+    direction: 'horizontal',
+    ratio: DEFAULT_SPLIT_RATIO,
+    children: [leaf(first.id), flatLayout(rest)],
+  }
+}
+
+// Drop layout entries that point at panes that no longer exist, and
+// re-add any orphaned panes as right-side leaves so they don't vanish.
+// Called by `set`-wrappers after pane-list mutations.
+function reconcileLayout(layout: LayoutNode | undefined, panes: PaneState[]): LayoutNode {
+  const paneIds = new Set(panes.map(p => p.id))
+  // Prune dead leaves.
+  let pruned: LayoutNode | null = layout ?? null
+  if (pruned) {
+    const dead = leafIds(pruned).filter(id => !paneIds.has(id))
+    for (const id of dead) {
+      pruned = pruned ? removeLeaf(pruned, id) : null
+    }
+  }
+  if (!pruned) return flatLayout(panes)
+  // Append any panes missing from the layout as horizontal splits on the
+  // right edge — this is the historical "new pane goes to the right"
+  // behaviour and only fires on recovery paths.
+  const present = new Set(leafIds(pruned))
+  let out = pruned
+  for (const p of panes) {
+    if (present.has(p.id)) continue
+    out = { kind: 'split', direction: 'horizontal', ratio: DEFAULT_SPLIT_RATIO, children: [out, leaf(p.id)] }
+  }
+  return out
 }
 
 function selectNoteFromActive(panes: PaneState[], activePaneId: string | null): void {
@@ -241,10 +476,71 @@ function navigateInPane(
   selectNoteFromActive(next, paneId)
 }
 
+// Migrate persisted workspace state to the current shape. Exported for
+// tests so the v1→v3 / v2→v3 / no-op paths can be exercised directly
+// without round-tripping through the persist middleware.
+//
+// v1 → v2 collapsed legacy `{ tabs, activeTabId }` into a single-pane
+// workspace; v2 → v3 keeps the flat panes[] but now also derives a
+// LayoutNode tree so the renderer can describe horizontal AND vertical
+// splits. The migration ALWAYS produces a fresh layout from the flat
+// panes list — pre-v3 only ever supported a horizontal cascade.
+export function migrateWorkspace(persisted: unknown, version: number): {
+  panes: PaneState[]
+  layout: LayoutNode
+  activePaneId: string | null
+  recents?: string[]
+} {
+  let panes: PaneState[] = []
+  let activePaneId: string | null = null
+  let recents: string[] | undefined
+
+  if (version < 2 && persisted && typeof persisted === 'object') {
+    const p = persisted as { tabs?: Tab[]; activeTabId?: string | null }
+    const tabs = (p.tabs ?? []).filter(t => t.kind === 'note')
+    panes = [{ id: uuidv4(), tabs, activeTabId: p.activeTabId ?? null }]
+    activePaneId = null
+  } else if (persisted && typeof persisted === 'object') {
+    const p = persisted as {
+      panes?: PaneState[]
+      activePaneId?: string | null
+      recents?: string[]
+      layout?: LayoutNode
+    }
+    panes = Array.isArray(p.panes) && p.panes.length > 0
+      ? p.panes
+      : [makePane()]
+    activePaneId = p.activePaneId ?? null
+    recents = p.recents
+    // If the persisted blob already has a layout (e.g. mid-migration
+    // double-call), trust it — reconcileLayout will scrub any stale leaves.
+    if (p.layout) {
+      return {
+        panes,
+        layout: reconcileLayout(p.layout, panes),
+        activePaneId,
+        recents,
+      }
+    }
+  } else {
+    panes = [makePane()]
+  }
+
+  return {
+    panes,
+    layout: flatLayout(panes),
+    activePaneId,
+    recents,
+  }
+}
+
 export const useWorkspaceStore = create<WorkspaceState>()(
   persist(
-    (set, get) => ({
-      panes: [makePane()],
+    (set, get) => {
+      const initialPane = makePane()
+      return {
+      panes: [initialPane],
+      layout: leaf(initialPane.id),
       activePaneId: null,
       mergeAppliedCount: 0,
       histories: {},
@@ -472,6 +768,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           i === loc.paneIdx ? { ...p, tabs: newTabs, activeTabId: newActiveTabId } : p,
         )
         const compacted = compactPanes(updatedPanes)
+        const layout = reconcileLayout(state.layout, compacted)
 
         // Did we just close the last merge tab (per-conflict OR batch
         // summary) in the whole workspace?
@@ -497,6 +794,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
 
         set({
           panes: compacted,
+          layout,
           activePaneId: newActivePaneId,
           mergeAppliedCount: lastMergeGone ? 0 : state.mergeAppliedCount,
         })
@@ -557,43 +855,40 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         draft[dstIdx].activeTabId = tab.id
 
         const compacted = compactPanes(draft)
+        const layout = reconcileLayout(state.layout, compacted)
         // If the moved tab's destination pane got compacted away (shouldn't
         // happen because we just inserted into it), fall back.
         const dstStillExists = compacted.some(p => p.id === toPaneId)
         const newActive = dstStillExists ? toPaneId : compacted[0].id
-        set({ panes: compacted, activePaneId: newActive })
+        set({ panes: compacted, layout, activePaneId: newActive })
         selectNoteFromActive(compacted, newActive)
       },
 
       splitTabRight: (tabId) => {
+        splitTabInternal(set, get, tabId, 'horizontal')
+      },
+
+      splitTabDown: (tabId) => {
+        splitTabInternal(set, get, tabId, 'vertical')
+      },
+
+      setLayoutRatio: (paneA, paneB, ratio) => {
         const state = get()
-        if (state.panes.length >= 2) {
-          // Already split — move the tab to the right pane instead.
-          const rightPane = state.panes[1]
-          get().moveTab(tabId, rightPane.id, rightPane.tabs.length)
-          return
+        const found = findSplitBetween(state.layout, paneA, paneB)
+        if (!found) return
+        const clamped = Math.max(0.05, Math.min(0.95, ratio))
+        // Walk to the node at `path` and rebuild with a new ratio.
+        const updateRatio = (node: LayoutNode, path: number[]): LayoutNode => {
+          if (node.kind === 'leaf') return node
+          if (path.length === 0) return { ...node, ratio: clamped }
+          const [head, ...rest] = path
+          const newChild = updateRatio(node.children[head], rest)
+          const children: [LayoutNode, LayoutNode] = head === 0
+            ? [newChild, node.children[1]]
+            : [node.children[0], newChild]
+          return { ...node, children }
         }
-        const loc = findTab(state.panes, tabId)
-        if (!loc) return
-        const tab = state.panes[loc.paneIdx].tabs[loc.tabIdx]
-
-        const draft = state.panes.map(p => ({ ...p, tabs: [...p.tabs] }))
-        draft[loc.paneIdx].tabs.splice(loc.tabIdx, 1)
-        if (draft[loc.paneIdx].activeTabId === tabId) {
-          const remaining = draft[loc.paneIdx].tabs
-          draft[loc.paneIdx].activeTabId = remaining[loc.tabIdx]?.id ?? remaining[loc.tabIdx - 1]?.id ?? null
-        }
-
-        const newPane: PaneState = { id: uuidv4(), tabs: [tab], activeTabId: tab.id }
-        // Obsidian behaviour: splitting the ONLY tab leaves the
-        // original pane in place but empty. Previously we dropped
-        // the empty left pane and ended up with just one pane (the
-        // new right one), which is functionally a no-op split — the
-        // tab "moved" rather than "split". Keep both panes always;
-        // an empty pane renders an EmptyState in Pane.tsx.
-        const panes: PaneState[] = [...draft, newPane]
-        set({ panes, activePaneId: newPane.id })
-        selectNoteFromActive(panes, newPane.id)
+        set({ layout: updateRatio(state.layout, found.path) })
       },
 
       goBack: (paneId) => {
@@ -653,7 +948,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           const stillActive = p.tabs.find(t => t.id === p.activeTabId)
           return stillActive ? p : { ...p, activeTabId: p.tabs[p.tabs.length - 1]?.id ?? null }
         })
-        set({ panes: next, activePaneId: newActive, mergeAppliedCount: 0 })
+        const layout = reconcileLayout(state.layout, next)
+        set({ panes: next, layout, activePaneId: newActive, mergeAppliedCount: 0 })
         selectNoteFromActive(next, newActive)
       },
 
@@ -690,6 +986,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
         }
         set({
           panes: compacted,
+          layout: reconcileLayout(state.layout, compacted),
           activePaneId: newActive,
           histories,
           recents: pruneRecents(state.recents, liveIds),
@@ -697,25 +994,15 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       },
       resetToEmptyWorkspace: () => {
         const pane = makePane()
-        set({ panes: [pane], activePaneId: pane.id, histories: {} })
+        set({ panes: [pane], layout: leaf(pane.id), activePaneId: pane.id, histories: {} })
         useNoteStore.getState().selectNote(null)
       },
-    }),
+      }
+    },
     {
       name: STORAGE_KEYS.workspace,
-      version: 2, // bumped: shape changed from tabs[] to panes[]
-      migrate: (persisted, version) => {
-        // v1 had { tabs, activeTabId }. Merge into a single pane.
-        if (version < 2 && persisted && typeof persisted === 'object') {
-          const p = persisted as { tabs?: Tab[]; activeTabId?: string | null }
-          const tabs = (p.tabs ?? []).filter(t => t.kind === 'note')
-          return {
-            panes: [{ id: uuidv4(), tabs, activeTabId: p.activeTabId ?? null }],
-            activePaneId: null,
-          }
-        }
-        return persisted as { panes: PaneState[]; activePaneId: string | null }
-      },
+      version: 3, // bumped: layout tree added alongside flat panes[]
+      migrate: migrateWorkspace,
       partialize: (state) => ({
         // Persist only note tabs. Welcome / merge-* / compare tabs are
         // point-in-time surfaces; dropping them on reload is correct.
@@ -723,6 +1010,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
           ...p,
           tabs: p.tabs.filter(t => t.kind === 'note'),
         })),
+        layout: state.layout,
         activePaneId: state.activePaneId,
         recents: state.recents,
       }),


### PR DESCRIPTION
## Summary
- Adds **Split down** alongside the existing Split right, and lifts the editor pane cap from 2 → 3.
- Replaces the implicit "left/right" pane arrangement with an explicit `LayoutNode` tree (`leaf | split { horizontal | vertical, ratio, children }`). The tree models every 3-pane arrangement — three columns, three rows, or L-shapes.
- Tab-strip context menu surfaces Split right / Split down / Close tab; bottom-border on the active pane's tab strip lights up purple.
- Persist version bumped 2 → 3 with a migration that derives a horizontal-cascade layout from the legacy flat `panes[]` array.

## Layout model — positional vs tree
Went with the tree model: minimal renderer surface (recursive `<Split>` component), no second source of truth, and the divider drag can update the exact split it sits over. The flat `panes[]` array is kept alongside the tree so existing consumers (`useKeyboardShortcuts`, `OutlineView`, `MobileTopBar`, etc.) keep working unchanged.

```
1 pane:   [ A ]        2 panes:   [ A | B ]        [ A ]
                                                   [---]
                                                   [ B ]

3 panes:  [ A | B | C ]    [ A | B ]        [ A | B ]
                           [-------]        [---|   ]
                           [   C   ]        [ C |   ]
```

## Files
- `src/stores/workspaceStore.ts` — `LayoutNode`, `MAX_PANES`, `splitTabDown`, `setLayoutRatio`, layout helpers, exported `migrateWorkspace` (v1/v2/v3).
- `src/components/editor/Editor.tsx` — recursive `<LayoutRenderer>` + per-split draggable divider (col-resize / row-resize).
- `src/components/editor/Pane.tsx` — right- and bottom-edge tab drop zones; drop zones hide once the 3-pane cap is reached.
- `src/components/editor/TabBar.tsx` — right-click context menu (Split right / Split down / Close tab); active-pane border highlight.
- `src/__tests__/workspaceSplits.test.ts` — 11 new tests.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` — 2145 tests passing (one pre-existing failure in untracked `scripts/demo-clip.spec.ts`, unrelated to this PR)
- [ ] Manual: open two notes, right-click a tab → Split down, drag the horizontal divider, drag a third tab to the bottom drop zone, close one of the three panes, reload and confirm the layout persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)