### PR TITLE
fix(sidebar): keep Move-to-folder submenu open

### DIFF
--- a/src/components/sidebar/ContextMenu.tsx
+++ b/src/components/sidebar/ContextMenu.tsx
@@ -416,6 +416,11 @@ export const ContextMenu = ({ contextMenu, onClose }: ContextMenuProps) => {
   return (
     <div
       ref={menuRef}
+      // Stop click propagation: the sidebar root has an onClick that
+      // closes the menu on ANY click inside, which kills the
+      // submenu-open state (Move to folder, AI) before it can render.
+      // Items that should close the menu call onClose() directly.
+      onClick={e => e.stopPropagation()}
       className="fixed bg-obsidianGray border border-obsidianBorder rounded-lg shadow-obsidian py-1 min-w-[180px] z-50"
       style={{
         top: contextMenu.y,


### PR DESCRIPTION
Stops click propagation in the context menu container. Sidebar root has `onClick={closeContextMenu}` and any click inside the menu was bubbling up and immediately closing the menu, killing the Move-to-folder and AI submenu open-state before it could render.