### PR TITLE
fix(sidebar): cross-sidebar tab drag (left↔right) now works

### DIFF
--- a/src/components/sidebar/PinnedMiniStrip.tsx
+++ b/src/components/sidebar/PinnedMiniStrip.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from 'react'
 import { SIDEBAR_PANEL_DRAG_MIME } from './SidebarSection'
 import { PANELS, TAB_DRAG_MIME } from './sidebarPanelRegistry'
+import { RIGHT_TAB_DRAG_MIME } from './rightPanelRegistry'
 import { type SidebarTabId } from '@/stores'
 
 // Mini tab strip rendered ABOVE each pinned group's content. One
@@ -148,6 +149,11 @@ export const PinnedMiniStrip = ({
               // bleeding into a phantom drag.
               if (e.nativeEvent && e.nativeEvent.button !== 0) return
               e.dataTransfer.setData(SIDEBAR_PANEL_DRAG_MIME, id)
+              // Mirror onto the right-side MIME so dropping this tab in
+              // the right sidebar passes its drop-zone filter. The
+              // right-side drop handler calls moveTabAcrossSidebars
+              // which routes the move correctly.
+              e.dataTransfer.setData(RIGHT_TAB_DRAG_MIME, id)
               e.dataTransfer.effectAllowed = 'move'
             }}
             onDragOver={onIconDragOver(idx)}

--- a/src/components/sidebar/RightMiniStrip.tsx
+++ b/src/components/sidebar/RightMiniStrip.tsx
@@ -6,6 +6,7 @@ import {
   rightPanelDef,
   type RightSidebarTabId,
 } from './rightPanelRegistry'
+import { SIDEBAR_PANEL_DRAG_MIME } from './SidebarSection'
 
 // Mini tab strip for the RIGHT sidebar — copy of PinnedMiniStrip but
 // pinned (no pun intended) to the right-side registry + drag MIME.
@@ -121,6 +122,11 @@ export const RightMiniStrip = ({
             onDragStart={e => {
               if (e.nativeEvent && e.nativeEvent.button !== 0) return
               e.dataTransfer.setData(RIGHT_TAB_DRAG_MIME, id)
+              // Mirror onto the left-side MIME so dropping this tab in
+              // the left sidebar passes its drop-zone filter. The
+              // left-side drop handler calls moveTabAcrossSidebars
+              // which routes the move correctly.
+              e.dataTransfer.setData(SIDEBAR_PANEL_DRAG_MIME, id)
               e.dataTransfer.effectAllowed = 'move'
             }}
             onDragOver={onIconDragOver(idx)}


### PR DESCRIPTION
Mirror the drag MIMEs on each MiniStrip's drag-start so the opposite-side drop zones accept the payload. The drop handlers already route through `moveTabAcrossSidebars`, so once the drop fires the cross-side move executes correctly.