### PR TITLE
Sidebar section keyboard-resize (a11y) + XSS-sink ESLint rules

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -61,11 +61,16 @@ _Nothing right now._
   follow-up from the 2026-05-30 git-proxy security fix (see SECURITY.md
   audit log). Echo only allowed origins rather than `*`. Low priority;
   the actual handler is already guarded.
-- **ESLint rule migration off `next lint`** — the noteser repo is on
-  flat-config via FlatCompat, but `next/core-web-vitals` silently drops
-  custom rule blocks in that wrapping (verified 2026-05-30 trying to
-  add an XSS-sink ban). A hand-written `eslint.config.mjs` without the
-  next preset would let real lint rules land. ~1h scope.
+- ~~**ESLint rule migration off `next lint`**~~ — DONE. The custom-rule
+  drop was NOT inherent to the next preset: placing the rules in their
+  OWN top-level flat-config object (after the `compat.extends(...)`
+  spread, not inside it) lands them cleanly — no need to drop
+  `next/core-web-vitals`. `eslint.config.mjs` now carries the XSS-sink
+  bans (`no-restricted-syntax` for `dangerouslySetInnerHTML` + `.innerHTML
+  =`, `no-restricted-imports` for `rehype-raw`), scoped to skip
+  `__tests__`. They mirror the static-source Jest guards in
+  `markdownXssGuard.test.tsx` and fire live on `npm run lint`. Verified
+  all three catch a planted violation; clean repo still lints green.
 
 ## User feedback pending clarification
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,56 @@ const compat = new FlatCompat({
   baseDirectory: __dirname
 })
 
-const eslintConfig = [...compat.extends('next/core-web-vitals')]
+// Raw-HTML / XSS sink bans. These mirror the static-source security
+// guards in src/__tests__/markdownXssGuard.test.tsx (no rehype-raw, no
+// dangerouslySetInnerHTML, no `.innerHTML =`). The Jest guards stay as
+// the belt; these lint rules are the suspenders — they surface the same
+// regressions live in the editor / on every `npm run lint`, before a
+// contributor even runs the suite.
+//
+// NB: this block lives in its OWN flat-config object (NOT inside the
+// FlatCompat-wrapped next preset). Custom `rules` placed inside the
+// compat.extends() output get silently dropped; a top-level object in
+// the exported array applies cleanly to every linted file.
+const xssSinkBans = {
+  // Scope to production source only. Tests legitimately build DOM
+  // fixtures via `.innerHTML =`, and the matching Jest guard
+  // (markdownXssGuard.test.tsx) already excludes `__tests__` from its
+  // walk — so the lint rule honours the same boundary.
+  ignores: ['**/__tests__/**', '**/*.test.ts', '**/*.test.tsx'],
+  rules: {
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: "JSXAttribute[name.name='dangerouslySetInnerHTML']",
+        message:
+          'dangerouslySetInnerHTML is banned (XSS). Render through react-markdown or escape with escapeHTML first. See markdownXssGuard.test.tsx.',
+      },
+      {
+        selector:
+          "AssignmentExpression[left.type='MemberExpression'][left.property.name='innerHTML']",
+        message:
+          'Assigning .innerHTML is a raw-HTML XSS sink. Use textContent, or a sanitized render path. See markdownXssGuard.test.tsx.',
+      },
+    ],
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'rehype-raw',
+            message:
+              'rehype-raw re-enables raw HTML in markdown (XSS). It must never be added to the render pipeline. See markdownXssGuard.test.tsx.',
+          },
+        ],
+      },
+    ],
+  },
+}
+
+const eslintConfig = [
+  ...compat.extends('next/core-web-vitals'),
+  xssSinkBans,
+]
 
 export default eslintConfig

--- a/src/__tests__/groupResizeHandle.test.tsx
+++ b/src/__tests__/groupResizeHandle.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * groupResizeHandle.test.tsx
+ *
+ * The GroupResizeHandle is the horizontal divider the user drags to
+ * trade height between two stacked sidebar groups (backlog #36 — sidebar
+ * sections were collapse-only and squeezed the file tree). These tests
+ * cover the interactive paths:
+ *   - mouse drag trades height between the pair and clamps at the minimum
+ *   - arrow-key resize (accessibility) nudges the boundary and clamps
+ *   - Home / End push the boundary to either extreme
+ *   - double-click releases both heights back to flex distribution
+ *   - the ARIA separator contract (role/orientation/valuenow range)
+ *
+ * The component is presentational — it emits (above, below) pairs via
+ * onResize and never touches a store — so these tests assert on the
+ * callback arguments directly.
+ */
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { GroupResizeHandle } from '../components/sidebar/GroupResizeHandle'
+import { MIN_GROUP_HEIGHT } from '../stores/settingsStore'
+
+const getHandle = () => screen.getByTestId('sidebar-group-resize-handle')
+
+// A roomy pair so the default 16px / 64px steps stay clear of the
+// MIN_GROUP_HEIGHT floor unless a test deliberately pushes into it.
+const ABOVE = 200
+const BELOW = 200
+const TOTAL = ABOVE + BELOW
+
+function renderHandle(overrides: Partial<React.ComponentProps<typeof GroupResizeHandle>> = {}) {
+  const onResize = jest.fn()
+  const onReset = jest.fn()
+  render(
+    <GroupResizeHandle
+      aboveHeight={ABOVE}
+      belowHeight={BELOW}
+      onResize={onResize}
+      onReset={onReset}
+      {...overrides}
+    />,
+  )
+  return { onResize, onReset }
+}
+
+describe('GroupResizeHandle — ARIA', () => {
+  test('exposes a horizontal separator with the pair height range', () => {
+    renderHandle()
+    const handle = getHandle()
+    expect(handle).toHaveAttribute('role', 'separator')
+    expect(handle).toHaveAttribute('aria-orientation', 'horizontal')
+    expect(handle).toHaveAttribute('aria-valuenow', String(ABOVE))
+    expect(handle).toHaveAttribute('aria-valuemin', String(MIN_GROUP_HEIGHT))
+    // Max = whole budget minus the floor reserved for the lower group.
+    expect(handle).toHaveAttribute('aria-valuemax', String(TOTAL - MIN_GROUP_HEIGHT))
+    expect(handle).toHaveAttribute('tabindex', '0')
+  })
+})
+
+describe('GroupResizeHandle — mouse drag', () => {
+  test('dragging down grows the group above and shrinks the one below', () => {
+    const { onResize } = renderHandle()
+    const handle = getHandle()
+
+    fireEvent.mouseDown(handle, { button: 0, clientY: 100 })
+    fireEvent.mouseMove(window, { clientY: 150 }) // +50px down
+    expect(onResize).toHaveBeenLastCalledWith(ABOVE + 50, BELOW - 50)
+
+    fireEvent.mouseUp(window)
+  })
+
+  test('dragging far up clamps the upper group at the minimum', () => {
+    const { onResize } = renderHandle()
+    const handle = getHandle()
+
+    fireEvent.mouseDown(handle, { button: 0, clientY: 100 })
+    fireEvent.mouseMove(window, { clientY: -9999 }) // way past the top
+    expect(onResize).toHaveBeenLastCalledWith(MIN_GROUP_HEIGHT, TOTAL - MIN_GROUP_HEIGHT)
+    fireEvent.mouseUp(window)
+  })
+
+  test('a right-button mousedown does not start a drag', () => {
+    const { onResize } = renderHandle()
+    const handle = getHandle()
+
+    fireEvent.mouseDown(handle, { button: 2, clientY: 100 })
+    fireEvent.mouseMove(window, { clientY: 300 })
+    expect(onResize).not.toHaveBeenCalled()
+  })
+
+  test('mouse move after release does not keep resizing', () => {
+    const { onResize } = renderHandle()
+    const handle = getHandle()
+
+    fireEvent.mouseDown(handle, { button: 0, clientY: 100 })
+    fireEvent.mouseMove(window, { clientY: 120 })
+    fireEvent.mouseUp(window)
+    const callsAfterRelease = onResize.mock.calls.length
+    fireEvent.mouseMove(window, { clientY: 400 })
+    expect(onResize.mock.calls.length).toBe(callsAfterRelease)
+  })
+})
+
+describe('GroupResizeHandle — keyboard', () => {
+  test('ArrowDown / ArrowUp nudge the boundary by the step', () => {
+    const { onResize } = renderHandle()
+    const handle = getHandle()
+
+    fireEvent.keyDown(handle, { key: 'ArrowDown' })
+    expect(onResize).toHaveBeenLastCalledWith(ABOVE + 16, BELOW - 16)
+
+    fireEvent.keyDown(handle, { key: 'ArrowUp' })
+    expect(onResize).toHaveBeenLastCalledWith(ABOVE - 16, BELOW + 16)
+  })
+
+  test('Shift+Arrow takes a larger step', () => {
+    const { onResize } = renderHandle()
+    fireEvent.keyDown(getHandle(), { key: 'ArrowDown', shiftKey: true })
+    expect(onResize).toHaveBeenLastCalledWith(ABOVE + 64, BELOW - 64)
+  })
+
+  test('Home / End push the boundary to either extreme', () => {
+    const { onResize } = renderHandle()
+    const handle = getHandle()
+
+    fireEvent.keyDown(handle, { key: 'End' })
+    expect(onResize).toHaveBeenLastCalledWith(TOTAL - MIN_GROUP_HEIGHT, MIN_GROUP_HEIGHT)
+
+    fireEvent.keyDown(handle, { key: 'Home' })
+    expect(onResize).toHaveBeenLastCalledWith(MIN_GROUP_HEIGHT, TOTAL - MIN_GROUP_HEIGHT)
+  })
+
+  test('an unrelated key is ignored', () => {
+    const { onResize } = renderHandle()
+    fireEvent.keyDown(getHandle(), { key: 'a' })
+    expect(onResize).not.toHaveBeenCalled()
+  })
+})
+
+describe('GroupResizeHandle — double-click reset', () => {
+  test('double-click releases both heights', () => {
+    const { onReset } = renderHandle()
+    fireEvent.doubleClick(getHandle())
+    expect(onReset).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/sidebar/GroupResizeHandle.tsx
+++ b/src/components/sidebar/GroupResizeHandle.tsx
@@ -1,13 +1,43 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { MIN_GROUP_HEIGHT } from '@/stores/settingsStore'
+
+// Keyboard step (px) when the handle is focused and the user presses the
+// arrow keys. Shift multiplies for a coarser jump. Mirrors the constants
+// on the horizontal SidebarResizeHandle so both affordances feel the same.
+const KEY_STEP = 16
+const KEY_STEP_LARGE = 64
+
+// Trade `delta` pixels between the two adjacent groups while keeping their
+// combined height (`total`) constant, clamping BOTH ends so neither group
+// can be squeezed below MIN_GROUP_HEIGHT. Whichever end hits the floor
+// first stops moving; the other side keeps the remaining budget. Shared by
+// the drag (mousemove) and keyboard paths so they can't drift apart.
+function resolvePair(nextAbove: number, total: number): { above: number; below: number } {
+  let above = nextAbove
+  let below = total - nextAbove
+  if (above < MIN_GROUP_HEIGHT) {
+    above = MIN_GROUP_HEIGHT
+    below = total - MIN_GROUP_HEIGHT
+  } else if (below < MIN_GROUP_HEIGHT) {
+    below = MIN_GROUP_HEIGHT
+    above = total - MIN_GROUP_HEIGHT
+  }
+  return { above, below }
+}
 
 // Vertical drag handle sitting between two stacked sidebar groups.
 // Drag down to grow the group ABOVE + shrink the group BELOW; drag up
 // to reverse. Double-click releases both heights (null = flex
 // distribution), giving the user a quick "snap back" gesture matching
 // the behaviour of the horizontal SidebarResizeHandle.
+//
+// Keyboard parity with the horizontal handle: focus the separator and use
+// ArrowUp / ArrowDown to nudge the boundary (Shift for a coarser step),
+// Home / End to push it to either extreme. The component exposes the
+// standard ARIA separator value range so screen readers announce the
+// resize.
 //
 // The component is a thin gesture wrapper — measuring + committing the
 // heights is delegated to the caller via `onResize`. The caller owns
@@ -50,19 +80,8 @@ export const GroupResizeHandle = ({
       if (!startRef.current) return
       const dy = e.clientY - startRef.current.y
       const total = startRef.current.above + startRef.current.below
-      // Clamp BOTH ends so neither group can be squeezed below the
-      // minimum. Whichever end hits the floor first stops moving — the
-      // other side keeps the remaining budget.
-      let nextAbove = startRef.current.above + dy
-      let nextBelow = startRef.current.below - dy
-      if (nextAbove < MIN_GROUP_HEIGHT) {
-        nextAbove = MIN_GROUP_HEIGHT
-        nextBelow = total - MIN_GROUP_HEIGHT
-      } else if (nextBelow < MIN_GROUP_HEIGHT) {
-        nextBelow = MIN_GROUP_HEIGHT
-        nextAbove = total - MIN_GROUP_HEIGHT
-      }
-      onResize(nextAbove, nextBelow)
+      const { above, below } = resolvePair(startRef.current.above + dy, total)
+      onResize(above, below)
     }
     const onUp = () => {
       setDragging(false)
@@ -93,20 +112,58 @@ export const GroupResizeHandle = ({
     setDragging(true)
   }
 
+  // Keyboard resize. ArrowDown grows the group above (boundary moves
+  // down), ArrowUp shrinks it — matching the drag direction. Home / End
+  // push the boundary to either extreme within the pair's budget.
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const total = aboveHeight + belowHeight
+      const step = e.shiftKey ? KEY_STEP_LARGE : KEY_STEP
+      let targetAbove: number
+      switch (e.key) {
+        case 'ArrowDown':
+          targetAbove = aboveHeight + step
+          break
+        case 'ArrowUp':
+          targetAbove = aboveHeight - step
+          break
+        case 'Home':
+          targetAbove = MIN_GROUP_HEIGHT
+          break
+        case 'End':
+          targetAbove = total - MIN_GROUP_HEIGHT
+          break
+        default:
+          return
+      }
+      e.preventDefault()
+      const { above, below } = resolvePair(targetAbove, total)
+      onResize(above, below)
+    },
+    [aboveHeight, belowHeight, onResize],
+  )
+
   return (
     <div
       role="separator"
       aria-orientation="horizontal"
       aria-label={ariaLabel}
+      aria-valuenow={Math.round(aboveHeight)}
+      aria-valuemin={MIN_GROUP_HEIGHT}
+      aria-valuemax={Math.round(aboveHeight + belowHeight - MIN_GROUP_HEIGHT)}
+      tabIndex={0}
       onMouseDown={onMouseDown}
       onDoubleClick={onReset}
+      onKeyDown={onKeyDown}
       data-testid="sidebar-group-resize-handle"
-      className={`group relative h-2 cursor-row-resize flex-shrink-0 flex items-center justify-center ${
-        dragging ? 'bg-obsidianAccentPurple' : 'hover:bg-obsidianAccentPurple/30'
+      className={`group relative h-2 cursor-row-resize flex-shrink-0 flex items-center justify-center outline-none ${
+        dragging
+          ? 'bg-obsidianAccentPurple'
+          : 'hover:bg-obsidianAccentPurple/30 focus-visible:bg-obsidianAccentPurple/30'
       } transition-colors`}
     >
       {!dragging && (
-        <span className="block w-8 h-[2px] rounded-full bg-obsidianBorder group-hover:bg-obsidianAccentPurple/80 transition-colors" />
+        <span className="block w-8 h-[2px] rounded-full bg-obsidianBorder group-hover:bg-obsidianAccentPurple/80 group-focus-visible:bg-obsidianAccentPurple/80 transition-colors" />
       )}
     </div>
   )


### PR DESCRIPTION
Two small, independent improvements picked up from the open backlog/roadmap.

## 1. Keyboard-resizable stacked sidebar groups (a11y parity) — `b8a28c1`

The vertical `GroupResizeHandle` between stacked sidebar sections was mouse-drag only, while the horizontal column `SidebarResizeHandle` already supported arrow-key resize. This closes that gap (backlog #36 — sections were collapse-only and squeezed the file tree):

- Separator is now focusable (`tabIndex=0`) with **ArrowUp/ArrowDown** to nudge the boundary (Shift for a coarser step) and **Home/End** to push it to either extreme within the pair's budget.
- Standard `aria-valuenow` / `aria-valuemin` / `aria-valuemax` range so screen readers announce the resize.
- Shared the clamp arithmetic (`resolvePair`) between the drag and keyboard paths so they can't drift apart.
- New `groupResizeHandle.test.tsx` (10 tests): drag, keyboard, `MIN_GROUP_HEIGHT` clamping, reset, ARIA contract.

## 2. XSS-sink bans as real ESLint rules — `48ed28e`

The raw-HTML XSS guards lived only as static-source Jest scans (`markdownXssGuard.test.tsx`). The flat ESLint config was believed to silently drop custom rule blocks under the FlatCompat-wrapped `next/core-web-vitals` preset — but the drop isn't inherent to the preset: a custom rules object placed at the **top level** of the exported array (after the `compat.extends` spread, not nested inside it) lands cleanly.

- `no-restricted-syntax` bans `dangerouslySetInnerHTML` and `.innerHTML =`.
- `no-restricted-imports` bans `rehype-raw`.
- Scoped to skip `__tests__` (tests legitimately build DOM fixtures — matching the Jest guard's own `__tests__` exclusion).
- Roadmap item updated to DONE.

The Jest guards stay as the belt; these are the suspenders — the same regressions are now caught live on `npm run lint` / in-editor, before the suite runs.

## Verification

- New handle tests: **10/10**. Full suite: **2032 passed** (17 skipped).
- `npm run typecheck` clean, `npm run lint` clean on the repo.
- Planted a production-file violation with all three sinks — each rule fired; probe removed.

https://claude.ai/code/session_01B9QCHeH9eXwuz68YQsNj3A