### PR TITLE
Close out 4 open issues: #27, #28, #30, #34

### DIFF
--- a/src/__tests__/folderTreeLoadingBanner.test.tsx
+++ b/src/__tests__/folderTreeLoadingBanner.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * folderTreeLoadingBanner.test.tsx
+ *
+ * Regression coverage for the "N notes loading…" banner (#30). On a first
+ * clone, note bodies stream in progressively: titles show immediately while
+ * bodies arrive in the background. While any note is still a shell
+ * (contentLoaded === false), FolderTree shows a subtle banner counting the
+ * shells. This locks the behaviour in so it can't silently regress again.
+ *
+ * idb-keyval is mocked so the Zustand persist middleware doesn't hit
+ * IndexedDB (unavailable in jsdom).
+ */
+
+// ── idb-keyval mock ───────────────────────────────────────────────────────────
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+}))
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import { FolderTree } from '../components/sidebar/FolderTree'
+import { useNoteStore } from '../stores/noteStore'
+import { useFolderStore } from '../stores/folderStore'
+import { useUIStore } from '../stores/uiStore'
+import type { Note } from '../types'
+
+let noteCounter = 0
+function makeNote(overrides: Partial<Note> = {}): Note {
+  const id = `note-${++noteCounter}`
+  const now = Date.now()
+  return {
+    id,
+    title: `Note ${id}`,
+    content: '',
+    folderId: null,
+    createdAt: now,
+    updatedAt: now,
+    isDeleted: false,
+    deletedAt: null,
+    isPinned: false,
+    templateId: null,
+    ...overrides,
+  }
+}
+
+function renderTreeWith(notes: Note[]) {
+  useNoteStore.setState({ notes, selectedNoteId: null })
+  useFolderStore.setState({ folders: [], activeFolderId: null, expandedFolders: {} })
+  useUIStore.setState({ currentView: 'notes' })
+  return render(<FolderTree onRightClick={() => {}} />)
+}
+
+beforeEach(() => {
+  useNoteStore.setState({ notes: [], selectedNoteId: null })
+  useFolderStore.setState({ folders: [], activeFolderId: null, expandedFolders: {} })
+})
+
+describe('FolderTree — "N notes loading…" banner', () => {
+  test('shows the banner with the shell count when notes are still loading', async () => {
+    renderTreeWith([
+      makeNote({ contentLoaded: false }),
+      makeNote({ contentLoaded: false }),
+      makeNote({ contentLoaded: true }),
+    ])
+
+    const banner = await screen.findByTestId('shell-loading-banner')
+    expect(banner).toBeInTheDocument()
+    // Two of the three notes are shells.
+    expect(banner).toHaveTextContent('2 notes loading…')
+  })
+
+  test('hides the banner when every note has loaded', async () => {
+    renderTreeWith([
+      makeNote({ contentLoaded: true }),
+      makeNote({}), // undefined === treated as loaded
+    ])
+
+    // Wait for hydration to flush, then assert the banner is absent.
+    await waitFor(() => {
+      expect(screen.queryByTestId('shell-loading-banner')).not.toBeInTheDocument()
+    })
+  })
+
+  test('hides the banner for an empty vault', async () => {
+    renderTreeWith([])
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('shell-loading-banner')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/__tests__/gitProxyOptions.test.ts
+++ b/src/__tests__/gitProxyOptions.test.ts
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment node
+ *
+ * git-proxy CORS preflight guard (#28). The OPTIONS handler used to echo
+ * a permissive `Access-Control-Allow-Origin: *` regardless of the caller.
+ * It now mirrors the GET/POST origin guard: echo the *validated* origin on
+ * success, refuse with a bare 403 (no CORS headers) otherwise.
+ *
+ * Runs in the node environment so the Web Request/Response globals are
+ * visible to Next's spec-extension layer.
+ */
+
+import { OPTIONS } from '@/app/api/git-proxy/[...path]/route'
+import type { NextRequest } from 'next/server'
+
+function makeRequest(headers: Record<string, string> = {}): NextRequest {
+  return new Request('http://localhost:3001/api/git-proxy/github.com/o/r.git/info/refs', {
+    method: 'OPTIONS',
+    headers,
+  }) as unknown as NextRequest
+}
+
+describe('OPTIONS /api/git-proxy', () => {
+  test('allowed origin → 204 echoing that exact origin (never *)', async () => {
+    const res = await OPTIONS(makeRequest({ origin: 'http://localhost:3001' }))
+    expect(res.status).toBe(204)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe('http://localhost:3001')
+    expect(res.headers.get('Access-Control-Allow-Origin')).not.toBe('*')
+    expect(res.headers.get('Vary')).toBe('Origin')
+    expect(res.headers.get('Access-Control-Allow-Methods')).toBe('GET, POST, OPTIONS')
+  })
+
+  test('disallowed origin → 403 with no CORS headers', async () => {
+    const res = await OPTIONS(makeRequest({ origin: 'https://evil.example' }))
+    expect(res.status).toBe(403)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+
+  test('missing Origin/Referer → 403', async () => {
+    const res = await OPTIONS(makeRequest())
+    expect(res.status).toBe(403)
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBeNull()
+  })
+})

--- a/src/__tests__/sourceControlOpenGithub.test.tsx
+++ b/src/__tests__/sourceControlOpenGithub.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * sourceControlOpenGithub.test.tsx
+ *
+ * #34 — the Source Control panel header shows the configured repo name with
+ * an "Open in GitHub" external-link button. Hidden when no repo is
+ * configured. The link omits the /tree/<branch> suffix for default branches
+ * (main/master) and includes it otherwise.
+ *
+ * idb-keyval is mocked so the Zustand persist middleware doesn't hit
+ * IndexedDB (unavailable in jsdom). token is left null so RecentCommits
+ * skips its network fetch.
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+}))
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { SourceControlPanel } from '../components/sidebar/SourceControlPanel'
+import { useNoteStore } from '../stores/noteStore'
+import { useGitHubStore } from '../stores/githubStore'
+import type { SyncRepo } from '../types'
+
+function setRepo(repo: SyncRepo | null) {
+  useGitHubStore.setState({ syncRepo: repo, token: null, lastCommitSha: null, lastSyncedAt: null })
+}
+
+beforeEach(() => {
+  useNoteStore.setState({ notes: [], selectedNoteId: null })
+  setRepo(null)
+})
+
+describe('Source Control "Open in GitHub" (#34)', () => {
+  test('hidden when no repo is configured', () => {
+    render(<SourceControlPanel />)
+    expect(screen.queryByTestId('source-control-open-github')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('source-control-repo-name')).not.toBeInTheDocument()
+  })
+
+  test('shows repo name + link to repo root for a default branch', () => {
+    setRepo({ owner: 'ipapakonstantinou', name: 'noteser', branch: 'main', isPrivate: false })
+    render(<SourceControlPanel />)
+    expect(screen.getByTestId('source-control-repo-name')).toHaveTextContent('ipapakonstantinou/noteser')
+    const link = screen.getByTestId('source-control-open-github')
+    expect(link).toHaveAttribute('href', 'https://github.com/ipapakonstantinou/noteser')
+    expect(link).toHaveAttribute('target', '_blank')
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    expect(link).toHaveAttribute('data-noteser-tip', 'Open in GitHub')
+  })
+
+  test('appends /tree/<branch> for a non-default branch', () => {
+    setRepo({ owner: 'o', name: 'r', branch: 'dev', isPrivate: true })
+    render(<SourceControlPanel />)
+    expect(screen.getByTestId('source-control-open-github')).toHaveAttribute(
+      'href',
+      'https://github.com/o/r/tree/dev',
+    )
+  })
+})

--- a/src/__tests__/trashFolderName.test.tsx
+++ b/src/__tests__/trashFolderName.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * trashFolderName.test.tsx
+ *
+ * #27 — the synthetic ".trash" sidebar row name is user-configurable
+ * (Settings → General/Vault). Renaming is cosmetic: the row keeps its fixed
+ * synthetic identity (TRASH_FOLDER_ID) so trashed notes stay trashed.
+ *
+ * idb-keyval is mocked so the Zustand persist middleware doesn't hit
+ * IndexedDB (unavailable in jsdom).
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+}))
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { FolderTree } from '../components/sidebar/FolderTree'
+import { useNoteStore } from '../stores/noteStore'
+import { useFolderStore } from '../stores/folderStore'
+import { useUIStore } from '../stores/uiStore'
+import { useSettingsStore } from '../stores/settingsStore'
+import type { Note } from '../types'
+
+function deletedNote(): Note {
+  const now = Date.now()
+  return {
+    id: 'trashed-1',
+    title: 'Old note',
+    content: 'gone',
+    folderId: null,
+    createdAt: now,
+    updatedAt: now,
+    isDeleted: true,
+    deletedAt: now,
+    isPinned: false,
+    templateId: null,
+  }
+}
+
+function renderTree() {
+  useNoteStore.setState({ notes: [deletedNote()], selectedNoteId: null })
+  useFolderStore.setState({ folders: [], activeFolderId: null, expandedFolders: {} })
+  useUIStore.setState({ currentView: 'notes' })
+  return render(<FolderTree onRightClick={() => {}} />)
+}
+
+beforeEach(() => {
+  useSettingsStore.setState({ trashFolderName: '.trash' })
+})
+
+describe('configurable trash folder name (#27)', () => {
+  test('defaults to ".trash"', () => {
+    expect(useSettingsStore.getState().trashFolderName).toBe('.trash')
+  })
+
+  test('setTrashFolderName persists the value', () => {
+    useSettingsStore.getState().setTrashFolderName('.recycle')
+    expect(useSettingsStore.getState().trashFolderName).toBe('.recycle')
+  })
+
+  test('synthetic trash row renders the configured name', async () => {
+    useSettingsStore.setState({ trashFolderName: '.recycle' })
+    renderTree()
+    const row = await screen.findByTestId('trash-synthetic-folder')
+    expect(row).toHaveTextContent('.recycle')
+    // Identity is unchanged — still the fixed synthetic id.
+    expect(row.querySelector('[data-folder-id="__trash__"]')).not.toBeNull()
+  })
+})

--- a/src/app/api/git-proxy/[...path]/route.ts
+++ b/src/app/api/git-proxy/[...path]/route.ts
@@ -48,6 +48,20 @@ const FORWARD_RESPONSE_HEADERS = [
   'content-encoding',
 ]
 
+const CORS_ALLOW_HEADERS = 'authorization, content-type, accept, user-agent, git-protocol'
+const CORS_ALLOW_METHODS = 'GET, POST, OPTIONS'
+
+// Apply CORS response headers that echo the *specific* validated origin
+// rather than a permissive `*`. `Vary: Origin` keeps caches from serving
+// one origin's CORS grant to another. Callers must only pass an origin
+// that already cleared `isOriginAllowed`.
+function applyCors(headers: Headers, origin: string) {
+  headers.set('Access-Control-Allow-Origin', origin)
+  headers.set('Vary', 'Origin')
+  headers.set('Access-Control-Allow-Headers', CORS_ALLOW_HEADERS)
+  headers.set('Access-Control-Allow-Methods', CORS_ALLOW_METHODS)
+}
+
 // Single handler used for both GET and POST — the only difference is
 // whether we forward a body.
 async function handle(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
@@ -110,12 +124,9 @@ async function handle(req: NextRequest, { params }: { params: Promise<{ path: st
     const v = upstream.headers.get(h)
     if (v) outHeaders.set(h, v)
   }
-  // CORS — opens the response back up to the browser. The fetch from
-  // isomorphic-git originated from the same noteser origin, so this
-  // is reasonable.
-  outHeaders.set('Access-Control-Allow-Origin', '*')
-  outHeaders.set('Access-Control-Allow-Headers', 'authorization, content-type, accept, user-agent, git-protocol')
-  outHeaders.set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+  // CORS — opens the response back up to the browser. The request already
+  // cleared `isOriginAllowed`, so echo that exact origin (not `*`).
+  applyCors(outHeaders, origin.origin)
 
   return new NextResponse(upstream.body, {
     status: upstream.status,
@@ -131,13 +142,16 @@ export async function POST(req: NextRequest, ctx: { params: Promise<{ path: stri
   return handle(req, ctx)
 }
 
-export async function OPTIONS() {
-  return new NextResponse(null, {
-    status: 204,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Headers': 'authorization, content-type, accept, user-agent, git-protocol',
-      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    },
-  })
+// Preflight. Mirror the GET/POST origin guard so the preflight never
+// advertises a wildcard grant: echo the validated origin on success,
+// refuse with a bare 403 (no CORS headers) otherwise — the browser then
+// blocks the follow-up request.
+export async function OPTIONS(req: NextRequest) {
+  const origin = isOriginAllowed(req)
+  if (!origin.ok) {
+    return new NextResponse(null, { status: 403 })
+  }
+  const headers = new Headers()
+  applyCors(headers, origin.origin)
+  return new NextResponse(null, { status: 204, headers })
 }

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -34,6 +34,7 @@ import { DailyNotesSection, TemplatesSection } from './DailyNotesSection'
 import { ExportSection } from './ExportSection'
 import { ShortcutsSection } from './ShortcutsSection'
 import { FLAGS } from '@/utils/featureFlags'
+import { sanitizeFilename } from '@/utils/sanitizeFilename'
 import {
   Field,
   SettingsSelect,
@@ -184,6 +185,7 @@ function GeneralPanel() {
   const folderSortMode = useSettingsStore(s => s.folderSortMode)
   const showHiddenFolders = useSettingsStore(s => s.showHiddenFolders)
   const trashMode = useSettingsStore(s => s.trashMode)
+  const trashFolderName = useSettingsStore(s => s.trashFolderName)
   const confirmBulkDelete = useSettingsStore(s => s.confirmBulkDelete)
   const confirmBeforeTrash = useSettingsStore(s => s.confirmBeforeTrash)
   const shareDefaultExpiryDays = useSettingsStore(s => s.shareDefaultExpiryDays)
@@ -192,6 +194,7 @@ function GeneralPanel() {
   const setFolderSortMode = useSettingsStore(s => s.setFolderSortMode)
   const setShowHiddenFolders = useSettingsStore(s => s.setShowHiddenFolders)
   const setTrashMode = useSettingsStore(s => s.setTrashMode)
+  const setTrashFolderName = useSettingsStore(s => s.setTrashFolderName)
   const setConfirmBulkDelete = useSettingsStore(s => s.setConfirmBulkDelete)
   const setConfirmBeforeTrash = useSettingsStore(s => s.setConfirmBeforeTrash)
   const setShareDefaultExpiryDays = useSettingsStore(s => s.setShareDefaultExpiryDays)
@@ -281,6 +284,18 @@ function GeneralPanel() {
             { value: 'trash', label: 'Move to trash (recoverable)' },
             { value: 'hardDelete', label: 'Delete immediately (no trash)' },
           ]}
+        />
+      </Field>
+      <Field
+        label="Trash folder"
+        description="Display name for the trash row in the sidebar. Renaming is cosmetic — trashed notes stay trashed and recoverable across the rename. Defaults to `.trash`."
+      >
+        <SettingsTextInput
+          value={trashFolderName}
+          onCommit={setTrashFolderName}
+          normalize={(raw) => sanitizeFilename(raw) || '.trash'}
+          placeholder=".trash"
+          mono
         />
       </Field>
       <Field

--- a/src/components/sidebar/FolderTree.tsx
+++ b/src/components/sidebar/FolderTree.tsx
@@ -51,6 +51,7 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
   }, [isMobile, sidebarCollapsed, toggleSidebar])
   const folderSortMode = useSettingsStore(s => s.folderSortMode)
   const showHiddenFolders = useSettingsStore(s => s.showHiddenFolders)
+  const trashFolderName = useSettingsStore(s => s.trashFolderName)
   const {
     notes,
     selectedNoteId,
@@ -938,6 +939,7 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
       {deletedNotes.length > 0 && (
         <TrashSyntheticFolder
           trashTree={trashTree}
+          name={trashFolderName}
           deletedCount={deletedNotes.length}
           expanded={!!expandedFolders[TRASH_FOLDER_ID]}
           onToggle={() => toggleFolderExpanded(TRASH_FOLDER_ID)}
@@ -1042,6 +1044,9 @@ const TrashFolderRow = ({
 // reserved id "__trash__".
 interface TrashSyntheticFolderProps {
   trashTree: ReturnType<typeof buildTrashTree>
+  // Configurable display name for the synthetic trash row (Settings →
+  // Vault). Cosmetic only — the row's identity stays TRASH_FOLDER_ID.
+  name: string
   deletedCount: number
   expanded: boolean
   onToggle: () => void
@@ -1057,7 +1062,7 @@ interface TrashSyntheticFolderProps {
 }
 
 const TrashSyntheticFolder = ({
-  trashTree, deletedCount, expanded, onToggle, onContextMenu,
+  trashTree, name, deletedCount, expanded, onToggle, onContextMenu,
   expandedFolders, toggleFolderExpanded, onFolderRightClick, renderNote,
 }: TrashSyntheticFolderProps) => {
   return (
@@ -1067,13 +1072,13 @@ const TrashSyntheticFolder = ({
         onClick={onToggle}
         onContextMenu={onContextMenu}
         data-folder-id={TRASH_FOLDER_ID}
-        data-folder-name=".trash"
+        data-folder-name={name}
       >
         <button
           type="button"
           className="mr-1 focus:outline-none"
           onClick={e => { e.stopPropagation(); onToggle() }}
-          aria-label={expanded ? 'Collapse .trash' : 'Expand .trash'}
+          aria-label={expanded ? `Collapse ${name}` : `Expand ${name}`}
         >
           {expanded ? (
             <ChevronDownIcon className="w-3.5 h-3.5" />
@@ -1082,7 +1087,7 @@ const TrashSyntheticFolder = ({
           )}
         </button>
         <FolderIcon className="w-4 h-4 mr-1.5 flex-shrink-0" />
-        <span className="flex-1 truncate">.trash</span>
+        <span className="flex-1 truncate">{name}</span>
         <span className="text-[10px] text-obsidianSecondaryText ml-1">
           {deletedCount}
         </span>

--- a/src/components/sidebar/SourceControlPanel.tsx
+++ b/src/components/sidebar/SourceControlPanel.tsx
@@ -68,9 +68,21 @@ export function groupChangesByFolder(
   return root
 }
 
+// Branches GitHub treats as the repo default — we omit the `/tree/<branch>`
+// suffix for these so the link lands on the repo root.
+const DEFAULT_BRANCHES = new Set(['main', 'master'])
+
+// Build the GitHub web URL for the configured vault repo. Appends
+// `/tree/<branch>` only when the branch isn't the conventional default.
+function repoWebUrl(repo: { owner: string; name: string; branch: string }): string {
+  const base = `https://github.com/${repo.owner}/${repo.name}`
+  return DEFAULT_BRANCHES.has(repo.branch) ? base : `${base}/tree/${repo.branch}`
+}
+
 export function SourceControlPanel() {
   const notes = useNoteStore(s => s.notes)
   const lastSyncedAt = useGitHubStore(s => s.lastSyncedAt)
+  const syncRepo = useGitHubStore(s => s.syncRepo)
   const openNote = useWorkspaceStore(s => s.openNote)
 
   const changes = useMemo(
@@ -87,11 +99,37 @@ export function SourceControlPanel() {
   return (
     <div className="space-y-1" data-testid="source-control-panel">
       <div className="flex items-center justify-between">
-        <div className="text-[11px] uppercase tracking-wide text-obsidianSecondaryText">
-          Source control
+        <div className="flex items-center gap-1 min-w-0">
+          <span className="text-[11px] uppercase tracking-wide text-obsidianSecondaryText flex-none">
+            Source control
+          </span>
+          {syncRepo && (
+            <>
+              <span className="text-[11px] text-obsidianSecondaryText/60 flex-none">·</span>
+              <span
+                className="text-[11px] font-mono text-obsidianSecondaryText truncate"
+                title={`${syncRepo.owner}/${syncRepo.name}`}
+                data-testid="source-control-repo-name"
+              >
+                {syncRepo.owner}/{syncRepo.name}
+              </span>
+              <a
+                href={repoWebUrl(syncRepo)}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={e => e.stopPropagation()}
+                className="flex-none text-obsidianSecondaryText hover:text-obsidianText transition-colors"
+                data-noteser-tip="Open in GitHub"
+                data-testid="source-control-open-github"
+                aria-label="Open in GitHub"
+              >
+                <ArrowTopRightOnSquareIcon className="w-3 h-3" />
+              </a>
+            </>
+          )}
         </div>
         <span
-          className="text-[11px] font-mono text-obsidianSecondaryText"
+          className="text-[11px] font-mono text-obsidianSecondaryText flex-none ml-2"
           data-testid="source-control-count"
         >
           {total > 0 ? `${total} pending` : 'clean'}

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -350,6 +350,12 @@ export interface SettingsState {
   // skip the trash and remove immediately.
   trashMode: TrashMode
 
+  // Display name for the synthetic ".trash" folder in the sidebar. Purely
+  // cosmetic — trashed notes reference the trash by its fixed synthetic id
+  // (TRASH_FOLDER_ID), so renaming never loses anything. Defaults to
+  // `.trash`.
+  trashFolderName: string
+
   // ── Keyboard shortcuts ─────────────────────────────────────────────────
   // Per-shortcut combo override. Keys are `ShortcutDef.id` values from
   // `src/utils/shortcuts.ts`; values are canonical combo strings (e.g.
@@ -480,6 +486,7 @@ export interface SettingsState {
   clearShortcutOverride: (id: string) => void
   resetShortcutOverrides: () => void
   setTrashMode: (mode: TrashMode) => void
+  setTrashFolderName: (name: string) => void
   setConfirmBulkDelete: (value: boolean) => void
   setConfirmBeforeTrash: (value: boolean) => void
   setBetaEnabled: (value: boolean) => void
@@ -572,6 +579,7 @@ export const VAULT_SETTING_KEYS = [
   'dailyNoteTemplateId',
   'weeklyNoteTemplateId',
   'trashMode',
+  'trashFolderName',
   'confirmBulkDelete',
   'betaEnabled',
   'betaFlags',
@@ -620,6 +628,7 @@ const DEFAULTS = {
   calendarWeekStartDay: 1 as CalendarWeekStartDay,
   shortcutOverrides: {} as Record<string, string>,
   trashMode: 'trash' as TrashMode,
+  trashFolderName: '.trash',
   confirmBulkDelete: true,
   confirmBeforeTrash: true,
   betaEnabled: false,
@@ -794,6 +803,7 @@ export const useSettingsStore = create<SettingsState>()(
           }),
         resetShortcutOverrides: () => set({ shortcutOverrides: {} }),
         setTrashMode: (trashMode) => setVault({ trashMode }),
+        setTrashFolderName: (trashFolderName) => setVault({ trashFolderName }),
         setConfirmBulkDelete: (confirmBulkDelete) => setVault({ confirmBulkDelete }),
         // Device-only — same logic as `confirmBulkDelete` lives in the
         // vault slice, but the single-note toggle is per-DEVICE because


### PR DESCRIPTION
Works through the open issue backlog. Four genuinely-open issues fixed here; five others were already implemented on `main` and have been closed with explanatory comments (#29, #31, #32, #33, #39). #67 (repair stale E2E specs) is left for a session with a browser runner, since it depends on the still-open PR #66 and Playwright can't run in this sandbox.

## Changes

- **#28 — git-proxy CORS preflight hardening.** The `OPTIONS` handler echoed `Access-Control-Allow-Origin: *` regardless of caller. It now mirrors the GET/POST origin guard: validate via `isOriginAllowed`, echo the specific origin with `Vary: Origin` on success, refuse with a bare 403 otherwise. The GET/POST success response echoes the validated origin too instead of `*`.
- **#30 — regression test for the "N notes loading…" banner.** Locks in the progressive-clone shell banner in `FolderTree`: shown with the shell count while bodies stream in, hidden when all loaded, hidden for an empty vault.
- **#27 — rename the trash folder.** New vault-scoped `trashFolderName` setting (default `.trash`) with a sanitized Settings input. The synthetic trash sidebar row reads the configured name for its label / aria-labels / data attribute. Cosmetic only — the row keeps its fixed `TRASH_FOLDER_ID`, so trashed notes stay trashed and recoverable across the rename.
- **#34 — "Open in GitHub" in the Source Control panel header.** When a `syncRepo` is configured, the header shows `owner/name` plus a small external-link button (repo root for `main`/`master`, `/tree/<branch>` otherwise). Hidden when no repo is connected.

## Tests

12 new tests across 4 files (`gitProxyOptions`, `folderTreeLoadingBanner`, `trashFolderName`, `sourceControlOpenGithub`). Full suite: **2034 passed**, 17 skipped; `tsc --noEmit` clean.

Closes #27, #28, #30, #34.

https://claude.ai/code/session_014wU9oA8DyaDEpaH8K8Rptk

---
_Generated by [Claude Code](https://claude.ai/code/session_014wU9oA8DyaDEpaH8K8Rptk)_