### PR TITLE
A11y pass: tree roles, tablist, modal focus trap (#78)

### DIFF
--- a/src/__tests__/a11yRoles.test.tsx
+++ b/src/__tests__/a11yRoles.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * a11yRoles.test.tsx
+ *
+ * Locks in the ARIA semantics added for issue #78. None of these
+ * tests assert visual styling — they assert that the tree, tab
+ * strips, and modal carry the correct roles + attributes screen
+ * readers depend on.
+ *
+ * idb-keyval is mocked so the Zustand persist middleware doesn't hit
+ * IndexedDB (unavailable in jsdom).
+ */
+
+// ── idb-keyval mock ───────────────────────────────────────────────────────────
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+}))
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { FolderTree } from '../components/sidebar/FolderTree'
+import { Modal } from '../components/ui/Modal'
+import { useNoteStore } from '../stores/noteStore'
+import { useFolderStore } from '../stores/folderStore'
+import { useUIStore } from '../stores/uiStore'
+import type { Note, Folder } from '../types'
+
+let counter = 0
+function makeNote(overrides: Partial<Note> = {}): Note {
+  const id = `note-${++counter}`
+  const now = Date.now()
+  return {
+    id,
+    title: `Note ${id}`,
+    content: '',
+    folderId: null,
+    createdAt: now,
+    updatedAt: now,
+    isDeleted: false,
+    deletedAt: null,
+    isPinned: false,
+    templateId: null,
+    ...overrides,
+  }
+}
+
+function makeFolder(overrides: Partial<Folder> = {}): Folder {
+  const id = `folder-${++counter}`
+  const now = Date.now()
+  return {
+    id,
+    name: `Folder ${id}`,
+    parentId: null,
+    createdAt: now,
+    updatedAt: now,
+    isDeleted: false,
+    deletedAt: null,
+    order: 0,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  useNoteStore.setState({ notes: [], selectedNoteId: null })
+  useFolderStore.setState({ folders: [], activeFolderId: null, expandedFolders: {} })
+  useUIStore.setState({ currentView: 'notes' })
+})
+
+describe('FolderTree — ARIA roles', () => {
+  test('container is role="tree" and rows are role="treeitem"', async () => {
+    const f1 = makeFolder()
+    const n1 = makeNote({ folderId: null })
+    useNoteStore.setState({ notes: [n1], selectedNoteId: null })
+    useFolderStore.setState({ folders: [f1], activeFolderId: null, expandedFolders: {} })
+
+    render(<FolderTree onRightClick={() => {}} />)
+
+    await waitFor(() => {
+      expect(screen.getByRole('tree')).toBeInTheDocument()
+    })
+    // Folder + note rows BOTH carry role="treeitem".
+    const items = screen.getAllByRole('treeitem')
+    expect(items.length).toBeGreaterThanOrEqual(2)
+  })
+
+  test('folder rows expose aria-expanded reflecting their open state', async () => {
+    const f1 = makeFolder()
+    useFolderStore.setState({
+      folders: [f1],
+      activeFolderId: null,
+      // Start collapsed.
+      expandedFolders: { [f1.id]: false },
+    })
+
+    render(<FolderTree onRightClick={() => {}} />)
+
+    let row: HTMLElement | null = null
+    await waitFor(() => {
+      row = document.querySelector(`[data-folder-id="${f1.id}"]`) as HTMLElement | null
+      expect(row).not.toBeNull()
+    })
+    // The treeitem is the OUTER wrapper around the row + (when expanded)
+    // the child group. Walk up from the labelled inner row to find it.
+    const treeitem = row!.closest('[role="treeitem"]') as HTMLElement | null
+    expect(treeitem).not.toBeNull()
+    expect(treeitem!.getAttribute('aria-expanded')).toBe('false')
+
+    // Flip to expanded and re-query.
+    await act(async () => {
+      useFolderStore.setState({ expandedFolders: { [f1.id]: true } })
+    })
+    await waitFor(() => {
+      const updated = document.querySelector(`[data-folder-id="${f1.id}"]`)!.closest('[role="treeitem"]')
+      expect(updated!.getAttribute('aria-expanded')).toBe('true')
+    })
+  })
+})
+
+describe('Modal — ARIA + focus management', () => {
+  test('role="dialog" + aria-modal=true + aria-labelledby when a title is set', () => {
+    render(
+      <Modal isOpen={true} onClose={() => {}} title="Test dialog">
+        <button>Inside</button>
+      </Modal>,
+    )
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toHaveAttribute('aria-labelledby', 'modal-title')
+    expect(screen.getByText('Test dialog')).toHaveAttribute('id', 'modal-title')
+  })
+
+  test('moves focus inside the dialog on open and restores it on close', async () => {
+    // Trigger element receives focus first — represents whatever opened
+    // the modal (a sidebar button, a context menu, etc.).
+    const trigger = document.createElement('button')
+    trigger.textContent = 'open'
+    document.body.appendChild(trigger)
+    trigger.focus()
+    expect(document.activeElement).toBe(trigger)
+
+    const { rerender, unmount } = render(
+      <Modal isOpen={true} onClose={() => {}} title="Focus test">
+        <button>First</button>
+        <button>Second</button>
+      </Modal>,
+    )
+
+    // Focus should land on the close button (first focusable) — wait one
+    // frame for the rAF inside Modal to commit.
+    await waitFor(() => {
+      const active = document.activeElement as HTMLElement | null
+      expect(active).not.toBeNull()
+      // First focusable is the X close button (aria-label="Close modal").
+      expect(active!.getAttribute('aria-label')).toBe('Close modal')
+    })
+
+    // Close + verify focus returned to the trigger.
+    rerender(
+      <Modal isOpen={false} onClose={() => {}} title="Focus test">
+        <button>First</button>
+        <button>Second</button>
+      </Modal>,
+    )
+    await waitFor(() => {
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    unmount()
+    document.body.removeChild(trigger)
+  })
+})

--- a/src/components/editor/Pane.tsx
+++ b/src/components/editor/Pane.tsx
@@ -156,7 +156,12 @@ export const Pane = ({ pane }: Props) => {
       onMouseDown={() => { if (!isActive) focusPane(pane.id) }}
     >
       <TabBar pane={pane} />
-      <div className="flex-1 flex flex-col min-h-0">{body}</div>
+      <div
+        className="flex-1 flex flex-col min-h-0"
+        role="tabpanel"
+        id={`editor-tabpanel-${pane.id}`}
+        aria-labelledby={activeTab ? `editor-tab-${activeTab.id}` : undefined}
+      >{body}</div>
 
       {/* Right- and bottom-edge split drop targets — only rendered (and
           only intercepting events) while a tab is actively being

--- a/src/components/editor/TabBar.tsx
+++ b/src/components/editor/TabBar.tsx
@@ -97,6 +97,8 @@ export const TabBar = ({ pane }: Props) => {
   return (
     <>
     <div
+      role="tablist"
+      aria-label="Editor tabs"
       className={`flex items-stretch border-b overflow-x-auto transition-colors ${
         paneIsActive
           ? 'bg-obsidianBlack border-b-obsidianAccentPurple/60'
@@ -128,6 +130,11 @@ export const TabBar = ({ pane }: Props) => {
                 e.preventDefault()
                 setMenu({ tabId: tab.id, x: e.clientX, y: e.clientY })
               }}
+              role="tab"
+              id={`editor-tab-${tab.id}`}
+              aria-selected={active}
+              aria-controls={`editor-tabpanel-${pane.id}`}
+              tabIndex={active ? 0 : -1}
               className={`flex items-center gap-1.5 px-3 py-2 text-sm border-r border-obsidianBorder cursor-pointer max-w-[200px] flex-shrink-0 select-none min-h-[44px] ${
                 active
                   ? 'bg-obsidianBlack text-obsidianText border-t-2 border-t-obsidianAccentPurple'

--- a/src/components/sidebar/FolderTree.tsx
+++ b/src/components/sidebar/FolderTree.tsx
@@ -588,7 +588,7 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
     getFolderRepoPath: (id) => folderRepoPathById.get(id),
   })
 
-  const AttachmentItem = ({ m }: { m: AttachmentMeta }) => (
+  const AttachmentItem = ({ m, depth = 0 }: { m: AttachmentMeta; depth?: number }) => (
     <div
       className="obsidian-file-item"
       draggable
@@ -598,6 +598,9 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
       title={m.path}
       data-testid="attachment-row"
       data-attachment-path={m.path}
+      role="treeitem"
+      aria-level={depth + 1}
+      aria-selected={false}
     >
       <DocumentTextIcon className="w-4 h-4 mr-2 flex-shrink-0" />
       <span className="flex-1 truncate">{attachmentDisplayName(m.path)}</span>
@@ -605,10 +608,11 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
   )
 
   // Render note item
-  const NoteItem = ({ note, className = '' }: { note: typeof notes[0]; className?: string }) => {
+  const NoteItem = ({ note, className = '', depth = 0 }: { note: typeof notes[0]; className?: string; depth?: number }) => {
     const kbFocused = isRowFocused('note', note.id)
     const multiSelected = isSelected(note.id)
     const isCompareSource = compareSourceNoteId === note.id
+    const isActive = selectedNoteId === note.id || multiSelected
     // Mobile-only drag-to-pin. Trash rows are excluded because their
     // primary affordance is restore / permanently delete.
     const swipeEnabled = isMobile && currentView !== 'trash' && !note.isDeleted
@@ -635,6 +639,10 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
           data-testid="note-row"
           data-note-id={note.id}
           data-kb-focused={kbFocused ? 'true' : undefined}
+          role="treeitem"
+          aria-level={depth + 1}
+          aria-selected={isActive}
+          aria-current={kbFocused ? 'true' : undefined}
         >
           <DocumentTextIcon className="w-4 h-4 mr-2 flex-shrink-0" />
           <div className="flex-1 min-w-0">
@@ -678,7 +686,7 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
     const isDropTarget = dragOverTarget === folder.id
     const kbFocused = isRowFocused('folder', folder.id)
     return (
-      <div className="mb-0.5">
+      <div className="mb-0.5" role="treeitem" aria-level={depth + 1} aria-expanded={isExpanded} aria-selected={isActive} aria-current={kbFocused ? 'true' : undefined}>
         <div
           className={`obsidian-folder-item ${
             isActive ? 'bg-obsidianHighlight' : ''
@@ -727,7 +735,7 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
           )}
         </div>
         {isExpanded && (
-          <div>
+          <div role="group">
             {/* Nested child folders first */}
             {childFolders.map(child => (
               <FolderItem key={child.id} folder={child} depth={depth + 1} />
@@ -735,10 +743,10 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
             {/* Then notes + attachments inside this folder */}
             <div style={{ paddingLeft: `${(depth + 1) * 12 + 8}px` }}>
               {folderNotes.map(note => (
-                <NoteItem key={note.id} note={note} />
+                <NoteItem key={note.id} note={note} depth={depth + 1} />
               ))}
               {folderAttachments.map(m => (
-                <AttachmentItem key={m.path} m={m} />
+                <AttachmentItem key={m.path} m={m} depth={depth + 1} />
               ))}
               {folderNotes.length === 0 && childFolders.length === 0 && folderAttachments.length === 0 && (
                 <div className="px-3 py-2 text-xs text-obsidianSecondaryText italic">
@@ -774,7 +782,8 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
             <p className="text-sm">Trash is empty</p>
           </div>
         ) : (
-          deletedNotes.map(note => (
+          <div role="tree" aria-label="Trash">
+          {deletedNotes.map(note => (
             <div
               key={note.id}
               className={`obsidian-file-item ${
@@ -782,6 +791,9 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
               }`}
               onClick={() => handleNoteClick(note.id)}
         onDoubleClick={() => handleNoteDoubleClick(note.id)}
+              role="treeitem"
+              aria-level={1}
+              aria-selected={selectedNoteId === note.id}
             >
               <DocumentTextIcon className="w-4 h-4 mr-2 flex-shrink-0" />
               <span className="flex-1 truncate">{note.title}</span>
@@ -806,7 +818,8 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
                 </button>
               </div>
             </div>
-          ))
+          ))}
+          </div>
         )}
       </div>
     )
@@ -824,9 +837,11 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
             <p className="text-sm">No recent notes</p>
           </div>
         ) : (
-          recentNotes.map(note => (
-            <NoteItem key={note.id} note={note} />
-          ))
+          <div role="tree" aria-label="Recently modified notes">
+            {recentNotes.map(note => (
+              <NoteItem key={note.id} note={note} />
+            ))}
+          </div>
         )}
       </div>
     )
@@ -1014,7 +1029,15 @@ const TrashFolderRow = ({
   const expanded = !!expandedFolders[node.folder.id]
   const childCount = node.childFolders.length + node.notes.length
   return (
-    <div className="mb-0.5" data-testid="trash-folder-row" data-folder-id={node.folder.id}>
+    <div
+      className="mb-0.5"
+      data-testid="trash-folder-row"
+      data-folder-id={node.folder.id}
+      role="treeitem"
+      aria-level={depth + 1}
+      aria-expanded={expanded}
+      aria-selected={false}
+    >
       <div
         className="obsidian-folder-item"
         style={{ paddingLeft: `${depth * 12 + 8}px` }}
@@ -1041,7 +1064,7 @@ const TrashFolderRow = ({
         )}
       </div>
       {expanded && (
-        <div>
+        <div role="group">
           {node.childFolders.map(child => (
             <TrashFolderRow
               key={child.folder.id}
@@ -1095,7 +1118,14 @@ const TrashSyntheticFolder = ({
   expandedFolders, toggleFolderExpanded, onFolderRightClick, renderNote,
 }: TrashSyntheticFolderProps) => {
   return (
-    <div className="mb-0.5" data-testid="trash-synthetic-folder">
+    <div
+      className="mb-0.5"
+      data-testid="trash-synthetic-folder"
+      role="treeitem"
+      aria-level={1}
+      aria-expanded={expanded}
+      aria-selected={false}
+    >
       <div
         className="obsidian-folder-item"
         onClick={onToggle}
@@ -1122,7 +1152,7 @@ const TrashSyntheticFolder = ({
         </span>
       </div>
       {expanded && (
-        <div>
+        <div role="group">
           {/* Deleted folders, nested with their deleted contents. */}
           {trashTree.rootFolders.map(node => (
             <TrashFolderRow

--- a/src/components/sidebar/PinnedMiniStrip.tsx
+++ b/src/components/sidebar/PinnedMiniStrip.tsx
@@ -121,6 +121,8 @@ export const PinnedMiniStrip = ({
 
   return (
     <div
+      role="tablist"
+      aria-label="Sidebar panels"
       className={`relative flex items-center gap-0.5 px-1 py-1 border-b border-obsidianBorder ${
         dropActive ? 'outline outline-2 outline-obsidianAccentPurple/60' : ''
       }`}
@@ -141,6 +143,11 @@ export const PinnedMiniStrip = ({
           <button
             key={id}
             type="button"
+            role="tab"
+            id={`sidebar-tab-${id}`}
+            aria-selected={active}
+            aria-controls={`sidebar-tabpanel-${id}`}
+            tabIndex={active ? 0 : -1}
             draggable
             onDragStart={e => {
               // Right-click on a draggable button fires dragstart on
@@ -171,7 +178,6 @@ export const PinnedMiniStrip = ({
             }}
             title={`${def.title} — drag to reorder, right-click for options`}
             aria-label={def.title}
-            aria-pressed={active}
             data-testid={`sidebar-pinned-tab-${id}`}
             className={[
               'relative flex items-center justify-center py-1.5 max-md:py-2.5 px-3 rounded cursor-grab active:cursor-grabbing transition-colors',

--- a/src/components/sidebar/RightMiniStrip.tsx
+++ b/src/components/sidebar/RightMiniStrip.tsx
@@ -98,6 +98,8 @@ export const RightMiniStrip = ({
 
   return (
     <div
+      role="tablist"
+      aria-label="Right sidebar panels"
       className={`relative flex items-center gap-0.5 px-1 py-1 border-b border-obsidianBorder ${
         dropActive ? 'outline outline-2 outline-obsidianAccentPurple/60' : ''
       }`}
@@ -118,6 +120,11 @@ export const RightMiniStrip = ({
           <button
             key={id}
             type="button"
+            role="tab"
+            id={`right-sidebar-tab-${id}`}
+            aria-selected={active}
+            aria-controls={`right-sidebar-tabpanel-${id}`}
+            tabIndex={active ? 0 : -1}
             draggable
             onDragStart={e => {
               if (e.nativeEvent && e.nativeEvent.button !== 0) return
@@ -138,7 +145,6 @@ export const RightMiniStrip = ({
             }}
             title={`${def.title} — drag to reorder, right-click for options`}
             aria-label={def.title}
-            aria-pressed={active}
             data-testid={`right-sidebar-pinned-tab-${id}`}
             className={[
               'relative flex items-center justify-center py-1.5 max-md:py-2.5 px-3 rounded cursor-grab active:cursor-grabbing transition-colors',

--- a/src/components/sidebar/RightSidebar.tsx
+++ b/src/components/sidebar/RightSidebar.tsx
@@ -45,18 +45,22 @@ export const RightSidebar = ({ hidden = false }: Props) => {
           collapse toggle on the right. Borders the body. */}
       <div className="flex items-center justify-between border-b border-obsidianBorder">
         {open ? (
-          <div className="flex-1 flex items-center px-1 py-1 gap-0.5" role="tablist">
+          <div className="flex-1 flex items-center px-1 py-1 gap-0.5" role="tablist" aria-label="Right sidebar tabs">
             <TabPill
               active={tab === 'properties'}
               label="Properties"
               onClick={() => setTab('properties')}
               testid="right-sidebar-tab-properties"
+              id="right-sidebar-pill-properties"
+              controls="right-sidebar-body"
             />
             <TabPill
               active={tab === 'backlinks'}
               label="Backlinks"
               onClick={() => setTab('backlinks')}
               testid="right-sidebar-tab-backlinks"
+              id="right-sidebar-pill-backlinks"
+              controls="right-sidebar-body"
             />
           </div>
         ) : (
@@ -84,6 +88,9 @@ export const RightSidebar = ({ hidden = false }: Props) => {
           id="right-sidebar-body"
           className="flex-1 min-h-0 overflow-y-auto"
           role="tabpanel"
+          aria-labelledby={
+            tab === 'properties' ? 'right-sidebar-pill-properties' : 'right-sidebar-pill-backlinks'
+          }
         >
           {tab === 'properties' ? <PropertiesPanel /> : <BacklinksView />}
         </div>
@@ -93,12 +100,15 @@ export const RightSidebar = ({ hidden = false }: Props) => {
 }
 
 const TabPill = ({
-  active, label, onClick, testid,
-}: { active: boolean; label: string; onClick: () => void; testid: string }) => (
+  active, label, onClick, testid, id, controls,
+}: { active: boolean; label: string; onClick: () => void; testid: string; id?: string; controls?: string }) => (
   <button
     type="button"
     role="tab"
+    id={id}
     aria-selected={active}
+    aria-controls={controls}
+    tabIndex={active ? 0 : -1}
     onClick={onClick}
     className={`px-2 py-1 text-xs rounded transition-colors ${
       active

--- a/src/components/sidebar/RightSidebarGroup.tsx
+++ b/src/components/sidebar/RightSidebarGroup.tsx
@@ -104,6 +104,9 @@ export const RightSidebarGroup = ({
           className="flex-1 min-h-0 overflow-y-auto"
           data-testid="right-sidebar-group-body"
           data-active-panel={activeTab}
+          role="tabpanel"
+          id={`right-sidebar-tabpanel-${activeTab}`}
+          aria-labelledby={`right-sidebar-tab-${activeTab}`}
         >
           <RightPanelBody id={activeTab} />
         </div>

--- a/src/components/sidebar/SidebarGroup.tsx
+++ b/src/components/sidebar/SidebarGroup.tsx
@@ -129,6 +129,9 @@ export const SidebarGroup = ({
           className="flex-1 min-h-0 overflow-y-auto"
           data-testid="sidebar-group-body"
           data-active-panel={activeTab}
+          role="tabpanel"
+          id={`sidebar-tabpanel-${activeTab}`}
+          aria-labelledby={`sidebar-tab-${activeTab}`}
         >
           <PanelBody id={activeTab} onRightClick={onRightClick} />
         </div>

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useCallback, type ReactNode } from 'react'
+import { useEffect, useCallback, useRef, type ReactNode } from 'react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 
 interface ModalProps {
@@ -18,6 +18,31 @@ interface ModalProps {
   showCloseButton?: boolean
 }
 
+// CSS selector for everything we consider focusable inside the modal —
+// the inline focus trap uses this to find the first/last focusable so
+// Tab / Shift+Tab can wrap between the two ends without escaping. It's
+// the same baseline that focus-trap / focus-trap-react use; we keep an
+// inline version because the dep isn't installed and the requirements
+// here are minimal (no nested traps, no portals).
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'button:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+const getFocusable = (root: HTMLElement): HTMLElement[] => {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter(el => !el.hasAttribute('disabled') && el.tabIndex !== -1)
+}
+
 export const Modal = ({
   isOpen,
   onClose,
@@ -33,6 +58,16 @@ export const Modal = ({
     }
   }, [onClose])
 
+  // Refs for the focus-trap dance:
+  //   - `dialogRef` points at the actual modal panel so we can query its
+  //     focusable children + decide whether a Tab key landed inside.
+  //   - `previouslyFocusedRef` snapshots the element that had focus
+  //     before the modal opened so we can return focus there on close
+  //     (matches every standards-compliant dialog implementation, and
+  //     prevents losing keyboard context when a quick modal closes).
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null)
+
   useEffect(() => {
     if (isOpen) {
       document.addEventListener('keydown', handleEscape)
@@ -43,6 +78,80 @@ export const Modal = ({
       document.body.style.overflow = ''
     }
   }, [isOpen, handleEscape])
+
+  // Focus management. On open: remember the trigger element, then focus
+  // the first focusable inside the modal (falling back to the dialog
+  // root if none exists so screen readers still get an announcement).
+  // On close: restore focus to whatever was focused before the modal
+  // opened. The cleanup runs in two cases — modal unmounts naturally
+  // OR `isOpen` flips false — so a programmatic close (Esc, backdrop
+  // click, action button) still lands the user back on their trigger.
+  useEffect(() => {
+    if (!isOpen) return
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null
+    // Defer focus to the next frame — the dialog content may render its
+    // own children that mount after the initial paint (e.g. lazy lists
+    // inside Settings). Without this, getFocusable() can return an
+    // empty list because the children haven't committed yet.
+    const id = requestAnimationFrame(() => {
+      const root = dialogRef.current
+      if (!root) return
+      const focusables = getFocusable(root)
+      const first = focusables[0]
+      if (first) first.focus()
+      else root.focus()
+    })
+    return () => {
+      cancelAnimationFrame(id)
+      // Restore focus, but only if the previously focused element is
+      // still in the DOM (otherwise blur to body — better than throwing).
+      const prev = previouslyFocusedRef.current
+      if (prev && document.contains(prev)) {
+        prev.focus()
+      }
+    }
+  }, [isOpen])
+
+  // Tab key trap. Wrap focus between the first and last focusable
+  // element inside the dialog so the user can never tab out into the
+  // background (which would also break the screen reader's modal
+  // context). We listen at the document level + filter on Tab + check
+  // the active element is inside the dialog; this also catches the case
+  // where focus has somehow escaped the modal entirely and snaps it back.
+  useEffect(() => {
+    if (!isOpen) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+      const root = dialogRef.current
+      if (!root) return
+      const focusables = getFocusable(root)
+      if (focusables.length === 0) {
+        e.preventDefault()
+        root.focus()
+        return
+      }
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const active = document.activeElement as HTMLElement | null
+      // If focus is somehow OUTSIDE the dialog (escaped via mouse to a
+      // background element behind the modal — rare but possible if the
+      // backdrop loses pointer-events), snap it back to the first input.
+      if (!active || !root.contains(active)) {
+        e.preventDefault()
+        first.focus()
+        return
+      }
+      if (e.shiftKey && active === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [isOpen])
 
   if (!isOpen) return null
 
@@ -67,12 +176,16 @@ export const Modal = ({
           flex column so the header stays pinned and the body scrolls
           when its content overflows (e.g. the Settings modal with many
           sections). role="dialog" + aria-modal=true so screen readers
-          announce noteser modals correctly. */}
+          announce noteser modals correctly. tabIndex=-1 lets the modal
+          root itself receive focus as a last-ditch fallback when the
+          dialog has no focusable children. */}
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? 'modal-title' : undefined}
-        className={`relative w-full ${sizeClasses[size]} mx-4 bg-obsidianGray rounded-lg shadow-obsidian border border-obsidianBorder flex flex-col max-h-[90dvh]`}
+        tabIndex={-1}
+        className={`relative w-full ${sizeClasses[size]} mx-4 bg-obsidianGray rounded-lg shadow-obsidian border border-obsidianBorder flex flex-col max-h-[90dvh] focus:outline-none`}
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}


### PR DESCRIPTION
## Summary

Closes #78. Wires ARIA semantics into components that already implement the underlying behaviour (no DOM restructure, no keyboard-shortcut changes) plus an inline focus trap for the shared `Modal`.

### Tree roles — `sidebar/FolderTree.tsx`

- Folder + note rows get `role="treeitem"` with `aria-level`, `aria-selected`, and (folders) `aria-expanded`.
- Recent + Trash sub-views wrap their lists in `role="tree"` so the same semantics work outside the main file tree.
- `aria-current="true"` rides the existing keyboard-focused row marker so screen reader users hear which row roving focus is parked on.

### Tab strips

- `editor/TabBar`: `role="tablist"` + per-tab `role="tab"` + `aria-selected` + `aria-controls` -> the matching pane's tabpanel id. `tabIndex` tracks active.
- `editor/Pane`: body becomes `role="tabpanel"` with `aria-labelledby` pointing back at the active tab's id.
- `sidebar/PinnedMiniStrip` + `RightMiniStrip`: `role="tablist"` + per-tab `role="tab"`. `aria-pressed` replaced by canonical `aria-selected`.
- `sidebar/SidebarGroup` + `RightSidebarGroup`: body becomes `role="tabpanel"` with `aria-labelledby`.
- `sidebar/RightSidebar` (Properties/Backlinks pills): existing tablist rounded out with `aria-controls` + `aria-labelledby`.

### Modal — `ui/Modal.tsx`

Adds an inline focus trap (no new dep — `focus-trap-react` isn't in the dep list, and the requirements here are minimal):

- On open: snapshot the trigger element, focus the first focusable inside the dialog.
- On close: restore focus to the trigger.
- `Tab` / `Shift+Tab` wrap between the first and last focusable inside the dialog.

`role="dialog"` + `aria-modal` + `aria-labelledby` + the existing Esc-to-close were already in place; this PR only adds the trap + restore.

### Files touched

- `src/components/editor/Pane.tsx` — tabpanel wrapper on the active tab body.
- `src/components/editor/TabBar.tsx` — tablist + tab roles, `aria-controls`, roving tabindex.
- `src/components/sidebar/FolderTree.tsx` — tree/treeitem roles, `aria-level`, `aria-expanded`, `aria-selected`, `aria-current`.
- `src/components/sidebar/PinnedMiniStrip.tsx` — tablist + tab roles, `aria-controls`.
- `src/components/sidebar/RightMiniStrip.tsx` — tablist + tab roles, `aria-controls`.
- `src/components/sidebar/RightSidebar.tsx` — `aria-controls` + `aria-labelledby` on pills.
- `src/components/sidebar/RightSidebarGroup.tsx` — tabpanel wrapper.
- `src/components/sidebar/SidebarGroup.tsx` — tabpanel wrapper.
- `src/components/ui/Modal.tsx` — focus trap, initial focus, focus restore.
- `src/__tests__/a11yRoles.test.tsx` — new: 4 assertions covering tree roles, folder aria-expanded, modal dialog roles, modal focus restore.

## Test plan

- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm test -- --ci` — 192 suites / 2378 tests pass (17 skipped).
- [x] New `a11yRoles.test.tsx` — 4/4 pass.
- [ ] Manual smoke: open Settings modal, Tab through; Esc closes; focus returns to the trigger.
- [ ] Manual smoke: keyboard arrows still navigate the file tree (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)