### PR TITLE
Competitor research sweep: deep-dive on 8 clusters (#82-#89)

### DIFF
--- a/docs/competitive-analysis.md
+++ b/docs/competitive-analysis.md
@@ -24,14 +24,14 @@ live `tasks` query blocks). No browser/git rival pairs both.
 
 | Tool | Storage | Browser? | Why it matters |
 |---|---|---|---|
-| **NotesHub** | GitHub / generic git / FS | Yes + native apps | The single closest rival. $3.99 one-time. Has offline, Kanban, whiteboard, Mermaid/LaTeX. Its conflict resolution is *opaque "automatic"* — noteser's transparent per-hunk merge is the edge. |
-| **SilverBullet** | Files on your server | PWA (self-host) | Programmable (Lua), offline PWA. Needs a server; no git-as-storage, no merge UX. |
-| **GitJournal** | Any git over SSH | Mobile-only | Owns mobile-git. A mobile-weak noteser loses to it on phones. |
-| **StackEdit** | GitHub/Drive/Dropbox | Yes | Closest "browser + GitHub" precedent, but a single-document editor, not a vault/PKM. |
-| **Obsidian** | Local files | **No official web** | The gravity well. noteser's core wedge is exactly Obsidian's most persistent gap: no browser version. Shipped Bases, official Web Clipper, Canvas, and AI in 2025. |
-
-Disaffected-user pools worth targeting: **Logseq** (multi-year DB-migration
-limbo, reports of data loss), **Notion** (restrictive offline + lock-in).
+| **NotesHub** | GitHub / generic git / FS / iCloud | Yes + native apps everywhere | Single closest rival. $3.99 one-time. Offline, Kanban, whiteboard, Mermaid/LaTeX, real-time collab. Conflict resolution is *opaque "automatic"* — transparent per-hunk merge is the only durable edge. See `docs/research/competitors/noteshub.md`. |
+| **SilverBullet** | Files on your server | PWA (self-host) | Programmable (Space Lua), Objects/Queries DSL, true offline PWA. Needs a server; no git-as-storage; no merge UX. Reference design for the properties/DB-views work (#72). See `silverbullet.md`. |
+| **GitJournal** | Any git over SSH | Mobile-only | Owns mobile-git. Complementary, not overlapping — but a weak PWA cedes phones to it (#68). Reported "failed to save" / crashes argue for #69 retry + queued-state UI. See `gitjournal.md`. |
+| **StackEdit / HackMD / CodiMD** | GitHub/Drive/Dropbox; or hosted DB | Yes | StackEdit is the closest "browser + GitHub" precedent (single-doc, no offline, opaque sync — stackedit #1176). HackMD/CodiMD are team real-time collab over a hosted DB. None is a vault/PKM. See `stackedit-hackmd.md`. |
+| **Obsidian** | Local files | **No official web** | The gravity well. Core wedge is exactly Obsidian's persistent gap. Shipped Bases, official Web Clipper (with AI Interpreter), Canvas (JSON Canvas), Claude/AI Skills in 2025-26. obsidian-git #803 is the demand signal for noteser's merge UX. See `obsidian.md`. |
+| **Logseq** | Local md/org + sync | Limited | Cautionary tale: DB-migration limbo since 2022, stalled development, data-loss reports. Disaffected-user pool addressable via a clean import (#73) + stability positioning (#75). See `logseq.md`. |
+| **Privacy/E2E cluster** (Anytype, Standard Notes, Notesnook, Joplin) | E2E hosted / P2P / self-host | Varies | Defines the encrypted pole. Do not compete on privacy (#75). Joplin's "sync broke and lost data" thread *reinforces* the merge UX wedge. See `privacy-e2e-cluster.md`. |
+| **Notion alternatives** (AFFiNE, SiYuan, Trilium) | CRDT / md+sidecars / SQLite | Mostly self-host | "DB-in-notes + blocks + graph" pole. SiYuan sets the bar for thousands-of-notes performance (#79); AFFiNE for canvas; Trilium warns against in-app scripting. See `notion-alternatives.md`. |
 
 ## Gaps vs the field (priority-ordered)
 
@@ -65,6 +65,53 @@ fight it).
   version control + portability, not privacy.**
 - **Breadth is a losing game** vs NotesHub/Obsidian. Double down on the
   merge + tasks + interop wedge.
+
+## Lessons surfaced by deeper research
+
+Findings from the 2026-06-06 sweep of `docs/research/competitors/` that
+were not in the original analysis. Each ties back to a priority or
+backlog issue.
+
+- **NotesHub still resolves conflicts opaquely.** The 2026 review of
+  about.noteshub.app and the GitHub org found no sign of a transparent
+  per-hunk merge UI. The wedge (#75) is intact; lead with it in copy.
+- **Joplin's "sync that constantly broke" thread is a positive signal
+  for noteser, not a warning.** It is direct evidence that
+  trustworthy sync + merge is an unmet need at the file-storage tier,
+  which is exactly the axis #69 (rate-limit / retry hardening) +
+  per-hunk merge address.
+- **SiYuan markets explicitly on thousands-of-notes performance.**
+  This sets a concrete bar for #79: 5,000 notes load under a second,
+  search under 200 ms, sync does not refetch the full tree (ETag from
+  #69 + incremental Fuse.js index updates).
+- **Obsidian Bases is now the de facto frontmatter-properties standard.**
+  #72 must stay file-compatible with Bases' frontmatter shape; do not
+  invent a parallel schema. This also opens the Obsidian-import path
+  in #73 for free.
+- **JSON Canvas (Obsidian) is the open canvas format to target.** If
+  a canvas surface ever ships (low priority today), prefer JSON Canvas
+  over a CRDT-shaped format. AFFiNE's edgeless canvas is not the
+  interop target.
+- **Kanban does not need a separate data model.** NotesHub bundles it
+  as a feature, but a `kanban` view derived from `- [ ]` lines plus
+  status tags maps onto existing Obsidian Tasks data — a cheap parity
+  move that reinforces the tasks-interop wedge.
+- **A "noteser + GitJournal" pairing is the right mobile story until
+  the PWA lands.** GitJournal owns mobile-git; the messaging "use
+  GitJournal on your phone, noteser in the browser, same repo" buys
+  time on #68 without ceding the mobile narrative.
+- **Standard Notes' "your data will outlive the app" framing maps
+  cleanly onto noteser's pitch** ("the files are in your repo, a
+  plain markdown editor can open them"). Reuse the longevity framing
+  in #75 positioning copy without claiming E2E.
+- **Trilium's in-app scripting is a cautionary tale for any
+  programmability work.** Avoid a user-script runtime. A scoped
+  templater is safer than a Space-Lua-style surface, and far easier
+  to migrate later (relevant if #72 grows toward derived views).
+- **The "browser anywhere" pitch reads as hollow without an
+  installable PWA.** Every serious rival except StackEdit and the
+  HackMD family has offline-first. #68 is the single highest-leverage
+  unblocker; it also de-risks the GitHub rate-limit story (#69).
 
 ## Top recommendations
 

--- a/docs/research/competitors/gitjournal.md
+++ b/docs/research/competitors/gitjournal.md
@@ -1,0 +1,66 @@
+# GitJournal
+
+## What it is
+
+GitJournal is a mobile-first markdown notes app that stores notes
+directly in a git repository. It owns the "git on a phone" niche the way
+NotesHub owns "git in a browser."
+
+## Storage model
+
+Any git repository reachable over SSH: GitHub, GitLab, Gitea, or a
+self-hosted server. Notes are plain markdown with optional YAML
+frontmatter. The app clones the repo to device storage, edits locally,
+and pushes when the user triggers sync or when auto-sync fires.
+
+## Killer features
+
+- Offline-first. The clone lives on the device; no network is required
+  to read or edit.
+- No account is required at the GitJournal layer; the only credential is
+  the user's git remote.
+- Folder hierarchy with arbitrary depth.
+- Backlinks (paid tier).
+- Tag and metadata search.
+- Free on Android, $3.99 one-time on iOS.
+
+## What noteser cannot do that they can
+
+- A real mobile experience built around the phone keyboard, swipe
+  gestures, and lifecycle. noteser is a browser app that resizes; it
+  was not designed for phone use.
+- Offline-first sync. GitJournal works on a plane; noteser cannot
+  reach GitHub there.
+- Background sync that handles SSH key auth, push retries, and
+  intermittent connectivity.
+- Install via the Play Store and App Store; that is the channel where
+  phone-first users discover note apps.
+
+## What they cannot do that noteser can
+
+- Run in a browser at all. GitJournal is mobile-only.
+- Per-hunk three-way merge. GitJournal's conflict story is "the user
+  resolves the file by hand."
+- Multi-pane workspace, tab strip, and other desk-style ergonomics.
+- Fast iteration from a desk: reload a tab, see the change.
+
+## Lessons for noteser
+
+- The mobile question is not optional. A weak PWA cedes phones to
+  GitJournal and that is half the use case. Prioritize #68 (offline
+  PWA) and treat the mobile layout as a launch-blocker, not polish.
+- Reported pain points on GitJournal include "failed to save note" and
+  occasional crashes during sync. The lesson is that git on a flaky
+  network is hard. noteser's #69 (rate-limit and sync hardening) should
+  include explicit retry, idempotency, and a user-visible "queued
+  changes" state.
+- GitJournal is complementary, not directly competitive. The right
+  framing is "noteser is the desktop and browser side of the same
+  git-storage workflow that GitJournal handles on your phone." A
+  recommended-pairing note may even be worth keeping.
+
+## Sources
+
+- https://gitjournal.io/ - visited 2026-06-06.
+- https://github.com/GitJournal/GitJournal - visited 2026-06-06.
+- https://medevel.com/gitjournal/ - review referenced from #84.

--- a/docs/research/competitors/logseq.md
+++ b/docs/research/competitors/logseq.md
@@ -1,0 +1,79 @@
+# Logseq
+
+## What it is
+
+Logseq is an outliner-style, local-first PKM with a strong
+journal-and-blocks model. It is free, open-source, and has a passionate
+user base. As of 2026 it is also a cautionary tale: stuck in a
+multi-year database migration with reports of stalled development and
+data-loss risk.
+
+## Storage model
+
+Local markdown or Org-mode files on disk, organized around a daily
+journal page and a graph of block references. Sync is via git, Syncthing,
+iCloud, or the optional Logseq Sync service. The on-disk format is
+human-readable but encodes a block tree, so round-tripping to plain
+markdown is lossy.
+
+## Killer features
+
+- Outliner-first editing: every line is a block with its own
+  identifier, collapsible and embeddable anywhere else.
+- Block references and block embeds, where any block can be transcluded
+  into another note by ID.
+- Daily journal pages as the default capture surface.
+- Queries (a Datalog-style DSL over the block graph) for live, derived
+  views.
+- Whiteboards (in the stable build) and PDF annotation.
+- Flashcards with spaced-repetition tied to blocks.
+- Free and self-hostable. No subscription is required for the core.
+
+## What noteser cannot do that they can
+
+- Outliner-style block editing as the default. noteser is a flat-text
+  markdown editor.
+- Block references and embeds. noteser has wikilinks at the file level
+  only.
+- A graph view and a backlinks panel.
+- A Datalog-style query layer over note metadata.
+- Built-in flashcards and PDF annotation.
+- A daily-journal flow with a one-click "today" capture.
+
+## What they cannot do that noteser can
+
+- Ship a stable database backend. The DB migration has been in limbo
+  since 2022; as of early 2026 the DB version still has not landed and
+  development looks stalled. Users in the community discuss "sync
+  hiccups and random data loss."
+- Round-trip cleanly to plain markdown. The on-disk file is shaped by
+  the block model and is awkward to edit outside Logseq.
+- Run in a browser. The web demo exists but is not the supported path.
+- Offer a merge UI for the git workflow many users adopt; conflicts
+  are resolved by hand.
+
+## Lessons for noteser
+
+- The migration-refugee pool is real and addressable. Ship a clean
+  Logseq import path (#73) that reads the journal hierarchy and the
+  page graph into plain markdown plus wikilinks. Position copy (#75)
+  around "boring, file-on-disk, version-controlled markdown that will
+  outlive the app."
+- The stability story matters more than feature parity for this
+  audience. Stability claims have to be earnable: invest in the merge
+  UX, the sync robustness items in #69, and a no-data-loss test
+  harness before marketing on it.
+- Block references are nice but not the wedge. A wikilink-level model
+  plus Bases-style frontmatter (#72) is closer to where the broader
+  market is settling. Do not adopt Logseq's block-tree on-disk format;
+  it is exactly the lock-in users are escaping.
+- Daily-journal capture is cheap to add and meaningful to migrators.
+  The calendar view already exists; a one-key "open today's note" is
+  a small step from there.
+
+## Sources
+
+- https://discuss.logseq.com/t/concerns-on-db-version-and-future-state-from-a-3-year-user/29225
+  - community thread referenced from #87.
+- https://www.solanky.dev/p/logseq-migration-journey-challenges-delays-and-hopes
+  - migration retrospective referenced from #87.

--- a/docs/research/competitors/noteshub.md
+++ b/docs/research/competitors/noteshub.md
@@ -1,0 +1,72 @@
+# NotesHub
+
+## What it is
+
+NotesHub is a cross-platform markdown note app that markets itself on "the
+power of markdown and GitHub together." It is the single closest head-to-head
+with noteser: browser-first, git-as-storage, no subscription.
+
+## Storage model
+
+Users link a GitHub account and clone one or more repositories as
+"notebooks." Local edits sync automatically to the remote. Generic remote
+Git (self-hosted GitLab, Gitea, Bitbucket) is also supported, plus local
+file system and iCloud Drive. The user owns the storage; NotesHub holds no
+server-side copy of note content.
+
+## Killer features
+
+- Native apps on every major platform: Web, iOS, Android, Windows, macOS,
+  Linux, with presence in the relevant app stores.
+- Offline mode in the native apps. The PWA also caches for short sessions.
+- Kanban boards as a first-class note type.
+- Whiteboarding / freeform canvas surface.
+- Mermaid diagrams, LaTeX math, callouts, YouTube and tweet embeds.
+- Automatic conflict resolution on sync. The mechanism is not exposed to
+  the user.
+- Real-time collaboration with invite-based access control.
+- One-time price of $3.99 for the native apps. Browser is free. The brand
+  is explicitly anti-subscription.
+
+## What noteser cannot do that they can
+
+- Native binaries in every app store. noteser is browser-only today.
+- Offline-first usage. NotesHub keeps working with no network; noteser
+  degrades without GitHub reachability.
+- Kanban as a built-in note type. noteser only has Obsidian-Tasks lists.
+- Whiteboard / freeform canvas.
+- Tweet, YouTube, and richer embeds out of the box.
+- Real-time multi-user collaboration with first-party invite flow.
+- Established presence in the iOS, Android, Mac, and Windows stores, which
+  is a discovery and trust advantage that a web app cannot match without
+  effort.
+
+## What they cannot do that noteser can
+
+- Transparent per-hunk three-way merge. NotesHub resolves conflicts
+  "automatically" without surfacing the diff or letting the user pick
+  hunks. Power users who care about losing keystrokes do not trust this.
+- Obsidian Tasks compatibility (`- [ ]` plus `done` emoji plus `YYYY-MM-DD`)
+  with live `tasks` query blocks. NotesHub does not ride that ecosystem.
+- File-compatibility with an Obsidian vault that is also stored in Git.
+
+## Lessons for noteser
+
+- Lean into the merge UX as the wedge. NotesHub's "automatic" resolution
+  is the exact reason a transparent per-hunk diff is defensible. See
+  competitive-analysis.md priority 5 and Vinzent03/obsidian-git #803.
+- Offline-first is table stakes against this rival. Land #68 (IndexedDB
+  cache plus installable PWA) before claiming "browser anywhere."
+- Steal the one-time-price anti-subscription stance for positioning copy
+  (#75). It works against Notion, Obsidian Sync, and HackMD Prime.
+- Kanban can be derived from existing task syntax. A `kanban` view over
+  `- [ ]` lines with status tags is a cheap parity move; do not build a
+  separate Kanban data model.
+
+## Sources
+
+- https://about.noteshub.app/ - visited 2026-06-06.
+- https://github.com/NotesHubApp - visited 2026-06-06.
+- https://productivity.directory/noteshub - referenced from issue #82.
+- https://github.com/Vinzent03/obsidian-git/issues/803 - referenced for
+  the merge-UX demand signal.

--- a/docs/research/competitors/notion-alternatives.md
+++ b/docs/research/competitors/notion-alternatives.md
@@ -1,0 +1,91 @@
+# Self-hosted Notion alternatives: AFFiNE, SiYuan, Trilium
+
+This cluster defines the "databases-in-notes plus blocks plus graph"
+pole. It is the right reference set for noteser's properties / DB views
+(#72), graph and backlinks (#71), and the eventual large-vault
+performance pass (#79).
+
+## What they are
+
+- **AFFiNE.** Open-source workspace that combines docs, Kanban, and an
+  infinite "edgeless" whiteboard. Self-host or managed cloud. Active
+  development; still beta-rough on some flows.
+- **SiYuan.** Block-WYSIWYG markdown editor with block references and
+  embeds, database views, a graph, AI integrations, and flashcards.
+  Local files plus optional paid cloud sync. Markets itself
+  explicitly on handling thousands of notes efficiently.
+- **Trilium.** Hierarchical note tree with end-to-end encryption, an
+  in-app scripting layer, and a focus on handling thousands of notes.
+  Active fork is now Trilium Notes Next.
+
+## Storage model
+
+- **AFFiNE.** Local-first via a CRDT (Yjs-based) document store, with
+  sync via AFFiNE Cloud or self-host. Export to markdown is supported
+  but not the live format.
+- **SiYuan.** Local markdown-ish files on disk in a workspace
+  directory, with extra metadata sidecars for block IDs and database
+  rows. Cloud sync is a paid add-on.
+- **Trilium.** A single SQLite database file as the canonical store.
+  Markdown export exists; the live model is database rows.
+
+## Killer features
+
+- **AFFiNE:** the infinite-canvas whiteboard that lives next to docs in
+  the same workspace, with block-level transclusion between them.
+- **SiYuan:** block-level addressing across the whole workspace, with
+  embeds, queries, and table views. Vault performance is a stated
+  design goal; users report tens of thousands of notes working well.
+- **Trilium:** the in-app scripting and "code notes" surface, plus
+  attribute-based note relationships that act as a lightweight graph.
+
+## What noteser cannot do that they can
+
+- Block-level addressing and embeds (SiYuan).
+- Database / table views over typed properties (SiYuan, AFFiNE).
+- An infinite whiteboard / canvas (AFFiNE).
+- Performance at thousands-of-notes scale (SiYuan, Trilium). noteser's
+  current Fuse.js index plus full-tree GitHub fetch will degrade well
+  before that scale.
+- In-app scripting and code execution (Trilium).
+- A graph view (all three have some form).
+
+## What they cannot do that noteser can
+
+- Run in a browser with no install and no server. AFFiNE has a web
+  build but it is the same heavy app; SiYuan and Trilium are desktop
+  or self-host.
+- Use GitHub as the source of truth with a real merge UI. None of
+  these treat git as the storage primitive.
+- Round-trip cleanly to vanilla markdown that any other editor can
+  open. SiYuan comes closest but still carries sidecar metadata; the
+  others are database-shaped.
+- Zero-infrastructure onboarding. AFFiNE Cloud and SiYuan Cloud are
+  paid; Trilium is self-host.
+
+## Lessons for noteser
+
+- Reference SiYuan when scoping #72 (properties UI plus Bases-style
+  table views). The bar is: typed frontmatter, filter, sort, save the
+  view, render in the editor. Stay file-compatible; do not adopt block
+  IDs as a storage primitive.
+- The "thousands of notes" performance claim sets a bar for #79.
+  Concrete acceptance: 5,000 notes load under a second, search returns
+  in under 200 ms, sync does not refetch the whole tree on each pull.
+  Use ETag conditional requests (already in #69) plus incremental
+  search index updates instead of a Fuse.js rebuild.
+- AFFiNE's edgeless canvas is a future bet, not a near-term one. If a
+  canvas surface ships, prefer the JSON Canvas format (Obsidian) for
+  interop rather than a CRDT-shaped one.
+- Trilium's scripting layer is a useful warning: it accumulates
+  user-written code that is hard to migrate. A scoped templater is
+  safer than a programmable runtime.
+- None of these compete on the merge axis. The wedge holds.
+
+## Sources
+
+- https://www.theinfinity.dev/articles/the-3-best-open-source-notion-alternatives
+  - referenced from #89.
+- https://affine.pro/ - visited 2026-06-06.
+- https://b3log.org/siyuan/en/ - visited 2026-06-06.
+- https://github.com/TriliumNext/Notes - visited 2026-06-06.

--- a/docs/research/competitors/obsidian.md
+++ b/docs/research/competitors/obsidian.md
@@ -1,0 +1,87 @@
+# Obsidian
+
+## What it is
+
+Obsidian is the dominant local-first markdown PKM. It is the gravity
+well in this category: the default thing a power user opens, and the
+file format every other tool tries to be compatible with. noteser
+deliberately stays interoperable: same `.md` files, same Obsidian Tasks
+syntax, the same wikilink shape.
+
+## Storage model
+
+Local markdown files on disk, in a folder the user controls (the
+"vault"). Sync is either paid Obsidian Sync (a hosted, end-to-end
+encrypted service) or a community plugin such as obsidian-git, Syncthing,
+or iCloud. There is no first-party browser version; the desktop and
+mobile apps are the only official clients.
+
+## Killer features
+
+- Plugin ecosystem. Roughly 2,000 community plugins, including
+  Dataview, Templater, Smart Connections (around 786,000 downloads),
+  Obsidian Tasks, and the official Web Clipper.
+- **Bases** (shipped 2025). A vault-as-database feature: typed
+  frontmatter properties surfaced as filterable, sortable table views.
+  Stays file-compatible because properties live in frontmatter.
+- **Canvas** with the JSON Canvas open file format. An infinite
+  whiteboard with cards that can embed notes.
+- Official **Web Clipper** browser extension (2025) with an AI
+  Interpreter that summarizes pages before saving.
+- Claude and AI Skills integrations announced for 2025-26.
+- Graph view and backlinks panel as first-class navigation surfaces.
+- Live preview that toggles between source and rendered seamlessly
+  per-line.
+
+## What noteser cannot do that they can
+
+- A graph view or backlinks panel. noteser has wikilinks but no graph
+  and no unlinked-mentions surface.
+- Frontmatter properties as a typed UI, plus Bases table views.
+- An infinite canvas with the JSON Canvas format.
+- A browser-extension web clipper.
+- A plugin marketplace of any kind.
+- Mobile apps in the relevant app stores.
+- An AI surface integrated into the editor, whether first-party or via
+  the Smart Connections ecosystem.
+
+## What they cannot do that noteser can
+
+- Run in a browser at all. There is no official web build. This is
+  Obsidian's most persistent structural gap and noteser's core wedge.
+- Use GitHub as a first-class storage backend with a real merge UI.
+  obsidian-git exists as a community plugin and its conflict handling
+  is the top-requested improvement (issue #803 on Vinzent03/obsidian-git).
+  noteser's transparent per-hunk three-way merge is exactly that gap
+  closed.
+- Sync without either paying for Obsidian Sync ($5/mo), running a
+  separate sync tool, or accepting the obsidian-git plugin's rough
+  edges.
+
+## Lessons for noteser
+
+- Stay file-compatible with Bases (#72). Frontmatter properties are
+  now a real standard; do not invent a competing schema. A Bases-style
+  table view over the existing tag and frontmatter data is a high-ROI
+  parity move that also opens an import path for Obsidian users.
+- Graph view plus backlinks (#71) is the single most-expected PKM
+  feature. Without it noteser reads as "not a real PKM" to anyone
+  evaluating against Obsidian.
+- A web clipper (#74) pairs naturally with git storage: clip a page,
+  commit a `.md` file. Manifest V3 plus a "send to noteser" endpoint
+  is small surface area for a meaningful capture flow.
+- The merge-UX win against obsidian-git is real and demonstrable.
+  Lead with it in copy (#75): "the obsidian-git conflict story you
+  always wanted." Tie back to obsidian-git #803 in marketing.
+- Do not chase the plugin ecosystem. That is a multi-year project and
+  the wrong axis. Compete on the wedge (#75) and pick off one or two
+  marquee plugin behaviors (Tasks, eventually Dataview-lite).
+
+## Sources
+
+- https://obsidian.md/pricing - visited 2026-06-06.
+- https://obsidian.md/roadmap/ - visited 2026-06-06.
+- https://github.com/Vinzent03/obsidian-git/issues/803 - the merge-UX
+  demand signal, referenced from #86.
+- https://github.com/obsidianmd/obsidian-clipper - official Web Clipper
+  source, referenced from #86.

--- a/docs/research/competitors/privacy-e2e-cluster.md
+++ b/docs/research/competitors/privacy-e2e-cluster.md
@@ -1,0 +1,100 @@
+# Privacy / E2E cluster: Anytype, Standard Notes, Notesnook, Joplin
+
+This cluster defines the encrypted local-first pole of the market. It
+is the axis where noteser is structurally weakest: notes live in a
+GitHub repository, which is a third party, not on-device-first or
+end-to-end-encrypted by default. The strategic conclusion in
+`docs/competitive-analysis.md` is to **not** compete on privacy, but
+the cluster is worth understanding because the Joplin sub-thread
+reinforces noteser's strongest card (trustworthy sync and merge).
+
+## What they are
+
+- **Anytype.** Local-first, end-to-end-encrypted, peer-to-peer sync,
+  with a typed-object data model (not files). Free self-host;
+  managed tier $5/mo with 1 GB of included storage.
+- **Standard Notes.** A long-running encrypted note app whose pitch is
+  "bulletproof E2E and longevity." Plain notes are free; rich editors,
+  themes, and extra features sit behind a subscription.
+- **Notesnook.** Encrypted-by-default, zero-knowledge architecture.
+  Native apps on every platform; free tier covers most personal use.
+- **Joplin.** Free and open-source, with self-hosted sync over Dropbox,
+  WebDAV, OneDrive, Nextcloud, S3, and others. Optional client-side E2E.
+
+## Storage model
+
+- **Anytype.** A typed-object store synced peer-to-peer. Not files.
+  Export to markdown exists but the live model is not on-disk markdown.
+- **Standard Notes.** Encrypted blobs in Standard Notes' hosted
+  service. Self-host is supported via Standard Notes Server.
+- **Notesnook.** Encrypted blobs in Notesnook's hosted service. Local
+  caches exist for offline use.
+- **Joplin.** Plain files in a sync-folder backend (Dropbox, WebDAV,
+  Nextcloud, S3, Joplin Cloud). Optional E2E wraps the files.
+
+## Killer features
+
+- E2E by default in three of the four (Anytype, Standard Notes,
+  Notesnook). The provider cannot read note content.
+- Anytype's typed objects: a note can be a "task" or a "person" or a
+  custom type with a schema, and views are derived from the type.
+- Standard Notes' longevity stance: the project explicitly designs for
+  a decade-plus lifetime of the encrypted data format.
+- Notesnook's polished mobile and desktop parity, plus public
+  third-party audit cadence.
+- Joplin's plugin ecosystem and broad sync-backend list.
+
+## What noteser cannot do that they can
+
+- End-to-end encryption of note content at rest. Anyone with the
+  user's GitHub credentials can read the vault.
+- A typed-object data model with derived views (Anytype).
+- A documented threat model and an audit track record (Standard Notes,
+  Notesnook).
+- A managed sync service that the user does not have to set up.
+
+## What they cannot do that noteser can
+
+- Edit notes as plain markdown files in a git repository the user
+  already trusts and can clone from any other tool. Anytype's data is
+  not files; Standard Notes' and Notesnook's data is encrypted blobs
+  in a vendor service.
+- Hand a user a Git history, a diff, and a per-hunk merge view.
+- Be opened by any other markdown editor in the world. The encrypted
+  backends are deliberately closed-format.
+- In Joplin's specific case: avoid the recurring "sync constantly broke
+  and lost data" complaint pattern. noteser's transparent merge is the
+  positive counterpoint to that.
+
+## Lessons for noteser
+
+- Do not chase the E2E pole. The honest positioning is **ownership +
+  version control + portability**, not privacy (#75). Vault encryption
+  for the GitHub repo is a separate feature track and should be
+  documented as such (the trust model: data lives in your GitHub repo,
+  the same trust model as Obsidian Git plugin, plus the XSS exfil note
+  for the token).
+- The Joplin data-loss thread reinforces #69. Trustworthy sync and
+  merge is a real unmet need at the file-storage tier; noteser's
+  per-hunk merge plus better rate-limit / retry behavior is on the
+  exactly correct axis.
+- Steal Anytype's typed-object framing for the properties UI (#72) at
+  the documentation level only. Do not store typed objects; let
+  frontmatter properties be the type, and let views filter on them.
+- Watch Standard Notes' longevity claims for marketing patterns. The
+  "your data will outlive the app" stance maps cleanly onto noteser's
+  "the files are in your repo and a plain markdown editor can open
+  them" pitch (#75).
+
+## Sources
+
+- https://www.toolworthy.ai/blog/obsidian-alternatives - referenced
+  from #88.
+- https://lock.pub/en/blog/secure-note-taking-apps-comparison -
+  referenced from #88.
+- https://openalternative.co/compare/joplin/vs/notesnook - referenced
+  from #88.
+- https://anytype.io/ - visited 2026-06-06.
+- https://standardnotes.com/ - visited 2026-06-06.
+- https://notesnook.com/ - visited 2026-06-06.
+- https://joplinapp.org/ - visited 2026-06-06.

--- a/docs/research/competitors/silverbullet.md
+++ b/docs/research/competitors/silverbullet.md
@@ -1,0 +1,66 @@
+# SilverBullet
+
+## What it is
+
+SilverBullet is an open-source (MIT) self-hosted "personal productivity
+platform" that combines a live-preview markdown editor with a built-in
+query language and a Lua-based scripting layer called Space Lua. It is
+the reference design for "notes as a programmable database."
+
+## Storage model
+
+Plain markdown files in a folder on the user's own server. The server is
+a single Go binary (or a Docker image). There is no git layer baked in;
+users who want versioning add it on the host. There is no managed cloud
+tier; the project is self-host only.
+
+## Killer features
+
+- Installable PWA. It works fully offline once installed, with a service
+  worker and a local cache.
+- Space Lua. Users embed Lua snippets inside notes to script behavior,
+  templates, and queries.
+- Objects and Queries: notes act as records with frontmatter properties,
+  and a query DSL surfaces them as tables, lists, or task views.
+- Plugin system ("plugs") with a clear extension API.
+- Single-binary deploy. Zero npm or build chain at install time.
+
+## What noteser cannot do that they can
+
+- True PWA offline. noteser today degrades to a stale-data error when
+  GitHub is unreachable.
+- A programmable query language over note metadata. noteser has only
+  Fuse.js search and an Obsidian-Tasks subset.
+- User-authored scripting inside notes. noteser has no in-note runtime.
+- A plugin system with a documented surface area. noteser has none.
+
+## What they cannot do that noteser can
+
+- Zero-infrastructure onboarding. SilverBullet requires a server,
+  Docker, and a reverse proxy with TLS for any non-localhost use.
+  noteser is a browser tab.
+- Git-as-storage with a remote that the user already trusts. Versioning
+  on SilverBullet is whatever the host filesystem provides.
+- Per-hunk merge UX for collaborative edits. There is no concept of a
+  remote-side conflict in SilverBullet's model.
+- Direct file-compatibility with an Obsidian vault hosted in GitHub.
+
+## Lessons for noteser
+
+- Study the Objects/Queries DSL as a reference for the properties UI and
+  the lightweight DB views called for in #72. Stay file-compatible with
+  Obsidian Bases frontmatter; do not invent a parallel schema.
+- The Space Lua direction is too big to copy directly, but the lesson is
+  that power users want one programmable surface. A scoped "templater +
+  query" path is a smaller step in that direction.
+- The PWA story (#68) is non-negotiable. SilverBullet proves that a
+  one-process self-host can deliver a credible offline experience; a
+  browser-only app has fewer excuses.
+- Avoid the self-host trap. noteser's wedge in zero-infra setup is
+  exactly the friction SilverBullet imposes; emphasize that in copy.
+
+## Sources
+
+- https://silverbullet.md/ - visited 2026-06-06.
+- https://github.com/silverbulletmd/silverbullet - visited 2026-06-06.
+- https://lwn.net/Articles/1030941/ - LWN write-up referenced from #83.

--- a/docs/research/competitors/stackedit-hackmd.md
+++ b/docs/research/competitors/stackedit-hackmd.md
@@ -1,0 +1,77 @@
+# StackEdit, HackMD, CodiMD
+
+These three are grouped because they share a "browser-based markdown
+editor with cloud sync" shape. None is a vault-style PKM; each is the
+closest non-PKM precedent for one slice of noteser's UX.
+
+## What they are
+
+- **StackEdit.** An in-browser single-document markdown editor with
+  cloud sync to GitHub, Google Drive, and Dropbox. The closest "browser
+  plus GitHub sync" precedent that predates noteser.
+- **HackMD.** A hosted real-time collaborative markdown workspace aimed
+  at teams. Bidirectional GitHub sync exists as a side feature; the
+  primary store is HackMD's database.
+- **CodiMD.** The free, self-hosted, open-source fork of HackMD's old
+  codebase. Same collaboration model, no managed tier.
+
+## Storage model
+
+- **StackEdit:** files live in the connected provider (GitHub repo or
+  cloud drive). Background sync runs roughly every minute and does a
+  download / merge / upload cycle.
+- **HackMD:** notes live in HackMD's hosted database. GitHub sync is a
+  pull-and-push integration, not the store.
+- **CodiMD:** notes live in the self-hosted server's database (Postgres
+  or sqlite). Same model as HackMD.
+
+## Killer features
+
+- **StackEdit:** zero install; works on a Chromebook; the original
+  "open and start typing markdown in a browser" experience.
+- **HackMD:** live multi-cursor, comments, presentation mode, version
+  history, Mermaid, PlantUML, and a slide mode. Free tier exists; Prime
+  is around $5 per user per month.
+- **CodiMD:** the above, free, self-hosted, with no per-seat fee.
+
+## What noteser cannot do that they can
+
+- **StackEdit:** none meaningful. StackEdit's only edges are name
+  recognition and a slimmer, single-document mental model.
+- **HackMD / CodiMD:** real-time multi-cursor editing as the default,
+  not an opt-in. Comments threaded on a document. Slide mode. A
+  full-featured presentation surface.
+
+## What they cannot do that noteser can
+
+- Function as a vault or PKM. StackEdit is one document at a time. No
+  wikilinks, no backlinks, no tag aggregation, no calendar view.
+- Work offline. StackEdit explicitly requires internet; opening it
+  without network shows an error.
+- Transparent merge UX. StackEdit's "background merge" is opaque and
+  has accumulated complaints (see benweet/stackedit #1176).
+- Treat git as the source of truth. HackMD and CodiMD treat git as a
+  side channel; the real store is their server.
+- Run with no hosting at all. CodiMD needs a server, a database, and an
+  ops surface that a browser-only tool avoids.
+
+## Lessons for noteser
+
+- StackEdit's complaint pattern (opaque sync, no manual control, no
+  offline) is exactly the gap noteser already closes on merge and
+  intends to close on offline (#68). Use it in onboarding copy: "the
+  StackEdit you wanted, with a real vault and a real merge view."
+- HackMD's real-time-collab depth is not a target. noteser already has
+  opt-in collaboration via Yjs (`NEXT_PUBLIC_YJS_WS_URL`). Do not chase
+  presentation mode or threaded comments; they are not the wedge.
+- CodiMD is a useful reference for an eventual self-host story, but
+  only if a hosted SaaS appears. Today the "just a browser tab plus
+  a repo" pitch is stronger than any self-host path.
+
+## Sources
+
+- https://stackedit.io/ - visited 2026-06-06.
+- https://github.com/benweet/stackedit/issues/1176 - long-standing
+  opaque-sync complaint, referenced from #85.
+- https://hackmd.io/ - visited 2026-06-06.
+- https://github.com/hackmdio/codimd - visited 2026-06-06.


### PR DESCRIPTION
## Summary

Eight focused competitor write-ups under `docs/research/competitors/`,
plus a surgical consolidation into `docs/competitive-analysis.md`. All
research notes (not coding). Closes #82, #83, #84, #85, #86, #87, #88, #89.

### Files added

- `docs/research/competitors/noteshub.md` (#82)
- `docs/research/competitors/silverbullet.md` (#83)
- `docs/research/competitors/gitjournal.md` (#84)
- `docs/research/competitors/stackedit-hackmd.md` (#85)
- `docs/research/competitors/obsidian.md` (#86)
- `docs/research/competitors/logseq.md` (#87)
- `docs/research/competitors/privacy-e2e-cluster.md` (#88, Anytype + Standard Notes + Notesnook + Joplin)
- `docs/research/competitors/notion-alternatives.md` (#89, AFFiNE + SiYuan + Trilium)

### Consolidation in `docs/competitive-analysis.md`

1. "Closest competitors" table replaced with a denser 8-row version
   (same column structure), with pointers to the per-cluster files.
2. New section "Lessons surfaced by deeper research" - 10 bullets
   tied to priorities or backlog issues (#68-#79).

"Top recommendations" is unchanged - the research reinforces it.

### Three most valuable findings

1. **NotesHub still resolves conflicts opaquely as of 2026-06-06.**
   No transparent per-hunk merge UI shipped. noteser's merge wedge
   (#75 positioning) is intact; lead marketing copy with it.
2. **Joplin's "sync broke and lost data" complaint pattern is a
   positive signal, not a warning.** It is direct evidence that
   trustworthy sync + merge is an unmet need at the file-storage tier
   - exactly the axis #69 (rate-limit / retry hardening) plus the
   per-hunk merge tab already address.
3. **SiYuan markets explicitly on thousands-of-notes performance,
   which sets a concrete bar for #79.** Acceptance: 5,000 notes load
   under a second, search under 200 ms, sync does not refetch the
   full tree on each pull (ETag from #69 + incremental Fuse.js index
   updates instead of full rebuild).

Closes #82
Closes #83
Closes #84
Closes #85
Closes #86
Closes #87
Closes #88
Closes #89

## Test plan

- [x] `npm run lint` passes (docs-only change; suite still passes).
- [x] `npx tsc --noEmit` zero errors.
- [ ] CI green on PR.