### PR TITLE
Plugin API v1.2 PR A: VNode set extension (foundation)

### DIFF
--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -1,0 +1,97 @@
+# Plugin API v1.2 — implementation notes
+
+Companion doc to `docs/plugins-v1.2-plan.md`. One section per PR in
+the six-PR plan (section 12 of the plan). Each section records the
+deviations from the design plan, the rationale, and the follow-ups
+the next PR in the sequence inherits.
+
+The plan is authoritative; this file is the audit trail. If the two
+disagree, the plan wins until a future PR explicitly updates it.
+
+## PR A — VNode set extension
+
+Lands the seven new shapes (`button`, `input`, `list`, `link`,
+`radio`, `svg`, `box`) and the shared event-handler record. Follows
+the plan section 2 exactly with the following clarifications.
+
+### Sanitisation
+
+The repo had no `escape-html` dependency at the time PR A landed.
+PR A ships an inline escape (`escapeText` in
+`src/plugins/PluginVNode.tsx`) that covers `&`, `<`, `>`, `"`, and
+`'`. Every plugin-supplied string lands in a React children slot, so
+React's default escape handles XSS for the rendered DOM; `escapeText`
+exists as a named contract for future paths that build strings before
+passing them to React (e.g. a debug renderer, a server-side preview).
+No `dangerouslySetInnerHTML` anywhere in the renderer; a unit test
+asserts the rendered HTML never contains the attribute for any v1.2
+shape.
+
+### Link href shape
+
+The plan defines `VNodeLink.href` as a discriminated union
+(`{ kind: 'note'; noteId }` or `{ kind: 'anchor'; fragment }`), and
+PR A implements that union verbatim. The task brief mentioned an
+alternative "wikilink:// or relative string, reject javascript:"
+contract; that contract is enforced too, via `isSafePluginHref`, but
+only as a belt-and-braces guard. The plugin never produces a raw href
+string — the host constructs the real URL from the typed parts. The
+named guard exists so a later opt-in raw-href shape can gate through
+one chokepoint without re-deriving the unsafe-scheme list.
+
+### Event wire
+
+The renderer dispatches `PluginVNodeEvent` records (event name +
+payload). Input and radio events augment the plugin-supplied payload
+with `{ value }`; button and clickable svg events forward the payload
+verbatim. The wire envelope `host:vnodeEvent` in `protocol.ts`
+carries the same shape plus a `source` discriminator
+(`panel` / `codeBlock` / `fullscreen`). PR A includes the
+`fullscreen` variant in the type union so PR B does not need to
+churn the protocol; PR A only ever emits `panel` and `codeBlock` at
+runtime.
+
+The handler-registration API (`ctx.onVNodeEvent`) is intentionally
+NOT in PR A. The renderer's event dispatcher is currently wired only
+in unit tests; the surface adapters (panel, code block) start
+forwarding events to the worker in a later PR that also ships
+`ctx.onVNodeEvent`. PR A ships the shape so PR B and the capability
+PRs do not block on protocol churn.
+
+### SDK exports
+
+The in-repo SDK (`src/plugins/sdk.ts`) re-exports the VNode types
+from `PluginVNode.tsx`. The published SDK
+(`packages/noteser-plugin-sdk/src/sdk.ts`) inlines the type
+declarations — it has no React dependency, so it cannot pull from the
+renderer file. Both lists are kept aligned by review; a future PR may
+extract the shared types into a `vdom.ts` shared between the two.
+
+### List depth cap
+
+`MAX_LIST_DEPTH = 8` per the plan (section 2.4). Both `list` and
+`box` count toward the same depth budget — a nested chain of
+`box → list → box → …` is rejected at depth 9, not depth 17. Simpler
+contract for the renderer and tighter bound on React stack use.
+
+### SVG colour parser
+
+The plan specifies the colour regex
+`/^(#[0-9a-f]{3,8}|rgb\(.*\)|rgba\(.*\)|[a-z]+)$/i` with a 32-char
+cap. PR A tightens the `rgb`/`rgba` alternatives to `[^)]*` instead
+of `.*` to keep the match anchored. Functionally equivalent for safe
+inputs; rejects pathological strings like `rgb()) javascript:` that
+the looser pattern would accept.
+
+### Out-of-scope reminders for downstream PRs
+
+- PR B (fullscreen) consumes the `HostVNodeEvent.source.fullscreen`
+  variant already present in `protocol.ts`. No protocol change should
+  be needed in B.
+- PRs C / D / E / F MUST NOT add new VNode shapes. If a capability
+  needs a new control, the discussion belongs in a v1.3 plan, not in
+  a capability PR.
+- The reference plugin under `public/plugins/noteser-vnode-demo`
+  exercises every new shape but does not yet receive event callbacks
+  (the registration API ships later). Once `ctx.onVNodeEvent` lands,
+  update the plugin to read events and re-render.

--- a/packages/noteser-plugin-sdk/src/index.ts
+++ b/packages/noteser-plugin-sdk/src/index.ts
@@ -7,6 +7,24 @@ export type {
   PluginDefinition,
 } from './sdk'
 
+// v1.2 — VNode shapes plus the shared event-handler record. PR A adds
+// the types only; new SDK methods (event registration, fullscreen,
+// vault, fs) ship in later v1.2 PRs.
+export type {
+  VNode,
+  VNodeText,
+  VNodeCallout,
+  VNodeButton,
+  VNodeInput,
+  VNodeList,
+  VNodeLink,
+  VNodeRadio,
+  VNodeSvg,
+  VNodeBox,
+  VNodeEvent,
+  SvgChild,
+} from './sdk'
+
 export type {
   PluginManifest,
   PluginSurfaces,

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -13,6 +13,120 @@
 
 import type { PluginManifest } from './manifest'
 
+// ─── v1.2 VNode shapes ────────────────────────────────────────────────────
+//
+// These mirror the curated renderer in `src/plugins/PluginVNode.tsx`.
+// The published SDK ships them as pure types so plugin authors can
+// construct VNodes type-safely without depending on noteser's React
+// renderer. The host re-validates every VNode at render time; the
+// types are advisory, not load-bearing for security.
+
+/**
+ * Plugin-declared event intent. Functions cannot survive postMessage,
+ * so plugins emit this record on `onClick` / `onChange` instead of a
+ * callback. The host dispatches the event back through the wire
+ * protocol; the worker matches by `event` name against handlers the
+ * plugin registers via `ctx.onVNodeEvent` (registration ships in a
+ * later v1.2 PR).
+ */
+export interface VNodeEvent {
+  kind: 'emit'
+  /** Plugin-defined event name. Host treats as opaque. */
+  event: string
+  /** Optional payload echoed back on the wire. */
+  payload?: unknown
+}
+
+export interface VNodeText {
+  tag: 'text'
+  value: string
+}
+
+export interface VNodeCallout {
+  tag: 'callout'
+  kind?: 'note' | 'warn' | 'tip' | 'danger' | 'info'
+  title?: string
+  body: string
+}
+
+export interface VNodeButton {
+  tag: 'button'
+  label: string
+  variant?: 'default' | 'primary' | 'danger' | 'ghost'
+  disabled?: boolean
+  onClick?: VNodeEvent
+}
+
+export interface VNodeInput {
+  tag: 'input'
+  type: 'text' | 'number' | 'search' | 'select'
+  options?: ReadonlyArray<{ value: string; label: string }>
+  value?: string | number
+  placeholder?: string
+  disabled?: boolean
+  onChange?: VNodeEvent
+}
+
+export interface VNodeList {
+  tag: 'list'
+  ordered?: boolean
+  items: ReadonlyArray<VNode>
+}
+
+export interface VNodeLink {
+  tag: 'link'
+  label: string
+  /**
+   * Discriminated union — the renderer constructs the real URL
+   * host-side. Plugins cannot produce a raw href string, so
+   * `javascript:`, `data:`, `mailto:`, and external URLs are
+   * structurally impossible.
+   */
+  href:
+    | { kind: 'note'; noteId: string }
+    | { kind: 'anchor'; fragment: string }
+}
+
+export interface VNodeRadio {
+  tag: 'radio'
+  group: string
+  options: ReadonlyArray<{ value: string; label: string }>
+  value?: string
+  onChange?: VNodeEvent
+}
+
+export type SvgChild =
+  | { tag: 'line'; x1: number; y1: number; x2: number; y2: number; stroke?: string; strokeWidth?: number }
+  | { tag: 'circle'; cx: number; cy: number; r: number; fill?: string; stroke?: string; onClick?: VNodeEvent }
+  | { tag: 'rect'; x: number; y: number; width: number; height: number; fill?: string; stroke?: string; onClick?: VNodeEvent }
+  | { tag: 'text'; x: number; y: number; value: string; fontSize?: number; fill?: string }
+  | { tag: 'path'; d: string; stroke?: string; fill?: string; strokeWidth?: number }
+
+export interface VNodeSvg {
+  tag: 'svg'
+  width: number
+  height: number
+  viewBox?: readonly [number, number, number, number]
+  children: ReadonlyArray<SvgChild>
+}
+
+export interface VNodeBox {
+  tag: 'box'
+  children: ReadonlyArray<VNode>
+  gap?: 0 | 1 | 2 | 3 | 4
+}
+
+export type VNode =
+  | VNodeText
+  | VNodeCallout
+  | VNodeButton
+  | VNodeInput
+  | VNodeList
+  | VNodeLink
+  | VNodeRadio
+  | VNodeSvg
+  | VNodeBox
+
 /** Narrow capability surface exposed to plugin handlers. The plugin
  *  never sees `localStorage`, the GitHub token, or the bodies of notes
  *  it is not currently viewing. v1 read scope is intentionally tight:

--- a/public/plugins/noteser-vnode-demo/main.js
+++ b/public/plugins/noteser-vnode-demo/main.js
@@ -1,0 +1,114 @@
+// noteser-vnode-demo v0.1.0
+//
+// Reference plugin for Plugin API v1.2 PR A. Renders one of every new
+// VNode shape (button, input, list, link, radio, svg, box) inside a
+// sidebar panel so a human can confirm the end-to-end wire works.
+//
+// The event-handler wire (ctx.onVNodeEvent) lands in a later PR. This
+// plugin logs to the worker console so the developer can see that the
+// renderer produced the right DOM and the event records made it back
+// across postMessage. Once ctx.onVNodeEvent ships, this plugin will
+// flip the logged values into live state without changing its VNode
+// shapes.
+//
+// Self-contained ES module. Worker dynamic-imports via Blob URL.
+
+function render(state) {
+  return {
+    tag: 'box',
+    gap: 3,
+    children: [
+      { tag: 'text', value: 'Plugin v1.2 VNode demo' },
+
+      {
+        tag: 'callout',
+        kind: 'info',
+        title: 'What this panel is for',
+        body: 'Every new VNode shape in PR A renders here. Click the button, type in the input, pick a radio. The worker logs each event so you can confirm the wire works.',
+      },
+
+      {
+        tag: 'button',
+        label: 'Click me',
+        variant: 'primary',
+        onClick: { kind: 'emit', event: 'demo.click', payload: { from: 'button' } },
+      },
+
+      {
+        tag: 'input',
+        type: 'text',
+        value: state.text,
+        placeholder: 'Type something…',
+        onChange: { kind: 'emit', event: 'demo.text' },
+      },
+
+      {
+        tag: 'radio',
+        group: 'mode',
+        value: state.mode,
+        options: [
+          { value: 'a', label: 'Mode A' },
+          { value: 'b', label: 'Mode B' },
+        ],
+        onChange: { kind: 'emit', event: 'demo.mode' },
+      },
+
+      {
+        tag: 'list',
+        ordered: false,
+        items: [
+          { tag: 'text', value: 'List item one' },
+          { tag: 'text', value: 'List item two' },
+          {
+            tag: 'link',
+            label: 'Open a note by id',
+            href: { kind: 'note', noteId: 'sample-note-id' },
+          },
+        ],
+      },
+
+      {
+        tag: 'svg',
+        width: 200,
+        height: 100,
+        viewBox: [0, 0, 200, 100],
+        children: [
+          { tag: 'rect', x: 0, y: 0, width: 200, height: 100, fill: '#1e293b' },
+          { tag: 'line', x1: 0, y1: 50, x2: 200, y2: 50, stroke: '#475569', strokeWidth: 1 },
+          {
+            tag: 'circle',
+            cx: 100,
+            cy: 50,
+            r: 20,
+            fill: '#4f8',
+            onClick: { kind: 'emit', event: 'demo.circle' },
+          },
+          { tag: 'text', x: 75, y: 90, value: 'svg shapes', fill: '#cbd5e1', fontSize: 12 },
+        ],
+      },
+    ],
+  }
+}
+
+export default {
+  id: 'noteser-vnode-demo',
+  name: 'VNode demo',
+  version: '0.1.0',
+  author: 'Noteser',
+  description:
+    'Reference plugin for v1.2 PR A. Exercises every new VNode shape inside a sidebar panel.',
+  surfaces: {
+    sidebarPanels: [{ id: 'demo', title: 'VNode demo' }],
+  },
+
+  onPanelMount(panelId, ctx) {
+    if (panelId !== 'demo') return
+    const state = { text: '', mode: 'a' }
+    ctx.setPanelContent('demo', render(state))
+    // ctx.onVNodeEvent ships in a later v1.2 PR — for now the worker
+    // simply emits the VNodes and trusts the renderer's event wire.
+    // Once the event registration API lands, this handler will read
+    // the click / change events and re-render the panel with new
+    // state. The shapes themselves do not change.
+  },
+}

--- a/public/plugins/noteser-vnode-demo/manifest.json
+++ b/public/plugins/noteser-vnode-demo/manifest.json
@@ -1,0 +1,13 @@
+{
+  "id": "noteser-vnode-demo",
+  "name": "VNode demo",
+  "version": "0.1.0",
+  "author": "Noteser",
+  "description": "Reference plugin for v1.2 PR A. Exercises every new VNode shape — button, input, list, link, radio, svg, box — inside a sidebar panel.",
+  "main": "./main.js",
+  "surfaces": {
+    "sidebarPanels": [
+      { "id": "demo", "title": "VNode demo" }
+    ]
+  }
+}

--- a/src/plugins/PluginVNode.tsx
+++ b/src/plugins/PluginVNode.tsx
@@ -4,18 +4,36 @@
 //
 // Plugins emit a small set of VNode shapes via ctx.setPanelContent or
 // ctx.renderCodeBlock; the host maps each shape to a real React tree
-// here. This is the v1 component surface — keep it intentionally
-// narrow. Anything richer in v2 lands as a new tag with its own
-// security review.
+// here. v1 shipped two shapes (`text`, `callout`). v1.2 adds seven
+// more (`button`, `input`, `list`, `link`, `radio`, `svg`, `box`) per
+// `docs/plugins-v1.2-plan.md` section 2.
 //
 // Why curated and not raw HTML / React: plugins run in a Worker, the
 // Worker has no DOM, so the only thing it CAN emit is data. Mapping
 // data to React inside this single module means the worker cannot
 // inject script, style, or arbitrary attributes. One audit surface.
 //
+// Sanitisation: every plugin-supplied string renders as React text
+// content via the children slot; the renderer never reaches React's
+// raw-HTML escape hatch. React's default escape handles `<`, `>`,
+// `&`, `"`, `'` in text nodes for us; we add `escapeText` for the
+// rare paths that build a string before handing it to React (e.g.
+// SVG path/attribute coercion comments). Numeric props are coerced
+// via `coerceFinite` and rejected on NaN / Infinity. A static-source
+// guard in `src/__tests__/markdownXssGuard.test.tsx` pins this rule
+// across the whole `src/` tree.
+//
+// Event handlers are NOT functions. Plugins declare event intent as
+// `{ kind: 'emit', event: string, payload?: unknown }`; the renderer
+// turns that into a DOM event listener that posts the event back
+// through the wire protocol via the `onEvent` prop. PR B (fullscreen)
+// and the capability PRs consume the same shape.
+//
 // All shapes carry `tag` as discriminator.
 
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+
+// ─── v1 shapes (unchanged) ────────────────────────────────────────────────
 
 export interface VNodeText {
   tag: 'text'
@@ -32,7 +50,138 @@ export interface VNodeCallout {
   body: string
 }
 
-export type VNode = VNodeText | VNodeCallout
+// ─── v1.2 event shape ─────────────────────────────────────────────────────
+
+/**
+ * Plugin-declared event intent. Functions cannot survive postMessage,
+ * so plugins emit this record on `onClick` / `onChange` instead of a
+ * callback. The renderer dispatches a `PluginVNodeEvent` upstream via
+ * the `onEvent` prop; the worker matches by `event` name against the
+ * handlers the plugin registered via `ctx.onVNodeEvent` (wired in a
+ * later v1.2 PR).
+ */
+export interface VNodeEvent {
+  kind: 'emit'
+  /** Plugin-defined event name. Host treats as opaque. */
+  event: string
+  /** Optional payload echoed back on the wire. */
+  payload?: unknown
+}
+
+/**
+ * Wire-level event message emitted by the renderer when a plugin's
+ * control (button / input / radio / clickable svg shape) fires. This
+ * is the contract every later v1.2 PR consumes — surfaces (panel,
+ * fullscreen, code block) wrap the dispatcher and add their `source`
+ * descriptor before the message hits `host:vnodeEvent` on the wire
+ * (see `protocol.ts`).
+ */
+export interface PluginVNodeEvent {
+  /** Plugin-defined event name, echoed from `VNodeEvent.event`. */
+  event: string
+  /**
+   * Payload posted back to the worker. For inputs and radios the
+   * renderer augments the plugin-supplied `payload` with `{ value }`;
+   * for buttons and clickable svg shapes it is the plugin payload
+   * verbatim (or `undefined`).
+   */
+  payload: unknown
+}
+
+// ─── v1.2 new shapes ──────────────────────────────────────────────────────
+
+export interface VNodeButton {
+  tag: 'button'
+  label: string
+  variant?: 'default' | 'primary' | 'danger' | 'ghost'
+  disabled?: boolean
+  onClick?: VNodeEvent
+}
+
+export interface VNodeInput {
+  tag: 'input'
+  type: 'text' | 'number' | 'search' | 'select'
+  /** Required when `type === 'select'`; ignored otherwise. */
+  options?: ReadonlyArray<{ value: string; label: string }>
+  value?: string | number
+  placeholder?: string
+  disabled?: boolean
+  onChange?: VNodeEvent
+}
+
+export interface VNodeList {
+  tag: 'list'
+  ordered?: boolean
+  /** Depth-capped at MAX_LIST_DEPTH. Deeper trees fall through to the
+   *  JSON dump path in `PluginNode`. */
+  items: ReadonlyArray<VNode>
+}
+
+export interface VNodeLink {
+  tag: 'link'
+  label: string
+  /**
+   * Discriminated union — the renderer constructs the real URL
+   * host-side. Plugins cannot produce a raw href string, so
+   * `javascript:`, `data:`, `mailto:`, and external URLs are
+   * structurally impossible. The `note` variant resolves to a
+   * `wikilink://` URL the editor's link layer already understands;
+   * the `anchor` variant scrolls to a fragment within the active
+   * note.
+   */
+  href:
+    | { kind: 'note'; noteId: string }
+    | { kind: 'anchor'; fragment: string }
+}
+
+export interface VNodeRadio {
+  tag: 'radio'
+  /** Group name shared by all radio inputs in the rendered fieldset. */
+  group: string
+  options: ReadonlyArray<{ value: string; label: string }>
+  value?: string
+  onChange?: VNodeEvent
+}
+
+/**
+ * SVG shape primitives. Only the five named tags are allowed; no
+ * `<foreignObject>`, no `<use>`, no `<script>`. The renderer rejects
+ * any other tag and emits nothing.
+ */
+export type SvgChild =
+  | { tag: 'line'; x1: number; y1: number; x2: number; y2: number; stroke?: string; strokeWidth?: number }
+  | { tag: 'circle'; cx: number; cy: number; r: number; fill?: string; stroke?: string; onClick?: VNodeEvent }
+  | { tag: 'rect'; x: number; y: number; width: number; height: number; fill?: string; stroke?: string; onClick?: VNodeEvent }
+  | { tag: 'text'; x: number; y: number; value: string; fontSize?: number; fill?: string }
+  | { tag: 'path'; d: string; stroke?: string; fill?: string; strokeWidth?: number }
+
+export interface VNodeSvg {
+  tag: 'svg'
+  width: number
+  height: number
+  viewBox?: readonly [number, number, number, number]
+  children: ReadonlyArray<SvgChild>
+}
+
+export interface VNodeBox {
+  tag: 'box'
+  children: ReadonlyArray<VNode>
+  /** Gap between children, mapped to tailwind spacing. */
+  gap?: 0 | 1 | 2 | 3 | 4
+}
+
+export type VNode =
+  | VNodeText
+  | VNodeCallout
+  | VNodeButton
+  | VNodeInput
+  | VNodeList
+  | VNodeLink
+  | VNodeRadio
+  | VNodeSvg
+  | VNodeBox
+
+// ─── Renderer constants ───────────────────────────────────────────────────
 
 const CALLOUT_STYLES: Record<NonNullable<VNodeCallout['kind']>, { container: string; icon: string; label: string }> = {
   note: {
@@ -62,49 +211,469 @@ const CALLOUT_STYLES: Record<NonNullable<VNodeCallout['kind']>, { container: str
   },
 }
 
+const BUTTON_VARIANTS: Record<NonNullable<VNodeButton['variant']>, string> = {
+  default:
+    'border border-obsidianBorder bg-obsidianHighlight/40 text-obsidianText hover:bg-obsidianHighlight/60',
+  primary:
+    'border border-blue-500/60 bg-blue-500/30 text-obsidianText hover:bg-blue-500/40',
+  danger:
+    'border border-red-500/60 bg-red-500/30 text-obsidianText hover:bg-red-500/40',
+  ghost:
+    'border border-transparent text-obsidianText hover:bg-obsidianHighlight/40',
+}
+
+const GAP_CLASSES: Record<NonNullable<VNodeBox['gap']>, string> = {
+  0: 'gap-0',
+  1: 'gap-1',
+  2: 'gap-2',
+  3: 'gap-3',
+  4: 'gap-4',
+}
+
+/** Maximum depth a list (and any nested boxes/lists) is allowed to
+ *  recurse through the renderer. Deeper trees render the JSON
+ *  fallback in `PluginNode`. */
+export const MAX_LIST_DEPTH = 8
+
+/** Cap on the length of an SVG `<path d>` string. Path syntax is
+ *  non-executable in browsers, but the parser still costs CPU. */
+const MAX_PATH_D_LENGTH = 8 * 1024
+
+/** Cap on color-string length before falling back to currentColor. */
+const MAX_COLOR_LENGTH = 32
+
+const COLOR_RE = /^(#[0-9a-f]{3,8}|rgb\([^)]*\)|rgba\([^)]*\)|[a-z]+)$/i
+
+// ─── Sanitisation helpers ─────────────────────────────────────────────────
+
+/**
+ * Escape `<`, `>`, `&`, `"`, `'` in a plugin-supplied string. React
+ * already escapes when a string lands in a children slot; this helper
+ * exists so non-children paths (e.g. assembling a string before
+ * passing to React) stay safe. The renderer never reaches the raw-
+ * HTML escape hatch — see the static-source guard in
+ * `src/__tests__/markdownXssGuard.test.tsx`.
+ */
+export function escapeText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function coerceFinite(value: unknown): number | null {
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+function safeColor(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  if (value.length === 0 || value.length > MAX_COLOR_LENGTH) return null
+  return COLOR_RE.test(value) ? value : null
+}
+
+/**
+ * Translate a `VNodeLink.href` discriminated union into a real string
+ * URL. The plugin never sees this string; the renderer constructs it
+ * host-side from typed parts, so `javascript:` and `data:` are
+ * structurally unreachable.
+ */
+function linkHrefToString(href: VNodeLink['href']): string | null {
+  if (href.kind === 'note') {
+    if (typeof href.noteId !== 'string' || href.noteId.length === 0) return null
+    return `wikilink://${encodeURIComponent(href.noteId)}`
+  }
+  if (href.kind === 'anchor') {
+    if (typeof href.fragment !== 'string' || href.fragment.length === 0) return null
+    return `#${encodeURIComponent(href.fragment)}`
+  }
+  return null
+}
+
+/**
+ * Belt-and-braces guard for raw hrefs. Even though the discriminated
+ * union makes `javascript:` etc. unreachable, the helper exists as a
+ * named contract the tests can assert on — and lets later changes
+ * (e.g. an opt-in raw href shape) gate through one chokepoint.
+ */
+export function isSafePluginHref(href: string): boolean {
+  if (typeof href !== 'string' || href.length === 0) return false
+  if (href.startsWith('wikilink://')) return true
+  if (href.startsWith('#')) return true
+  if (href.startsWith('/') && !href.startsWith('//')) return true
+  return false
+}
+
+// ─── Event dispatch plumbing ──────────────────────────────────────────────
+
+export type PluginVNodeEventDispatcher = (event: PluginVNodeEvent) => void
+
+interface RenderContext {
+  /** Optional. When absent the renderer drops events on the floor; the
+   *  panel surface always wires one, but a JSON-dump fallback path in
+   *  isolation does not need to. */
+  onEvent?: PluginVNodeEventDispatcher
+  /** Current depth into list / box recursion. */
+  depth: number
+}
+
+function dispatchOrDrop(ctx: RenderContext, evt: VNodeEvent | undefined, valueOverride?: { value: string | number }): void {
+  if (!ctx.onEvent) return
+  if (!evt || evt.kind !== 'emit' || typeof evt.event !== 'string' || evt.event.length === 0) return
+  const payload = valueOverride !== undefined
+    ? (typeof evt.payload === 'object' && evt.payload !== null
+        ? { ...(evt.payload as Record<string, unknown>), ...valueOverride }
+        : valueOverride)
+    : evt.payload
+  ctx.onEvent({ event: evt.event, payload })
+}
+
+// ─── Renderer ─────────────────────────────────────────────────────────────
+
 /**
  * Render a single VNode received from a plugin. Returns null when the
  * shape is unrecognised — the caller decides whether to show a
  * fallback (JSON dump for debug, an error pane in prod).
+ *
+ * `onEvent` receives wire-level event messages every time a rendered
+ * control (button click, input change, radio pick, clickable svg
+ * shape) fires. Surfaces (sidebar panel, code block, future
+ * fullscreen view in PR B) wrap this dispatcher.
  */
-export function renderPluginVNode(node: unknown): ReactNode | null {
+export function renderPluginVNode(node: unknown, onEvent?: PluginVNodeEventDispatcher): ReactNode | null {
+  return renderWithContext(node, { onEvent, depth: 0 })
+}
+
+function renderWithContext(node: unknown, ctx: RenderContext): ReactNode | null {
   if (typeof node === 'string') return node
   if (typeof node !== 'object' || node === null || !('tag' in node)) return null
 
   const tag = (node as { tag: unknown }).tag
 
-  if (tag === 'text') {
-    const v = node as VNodeText
-    if (typeof v.value !== 'string') return null
-    return <span>{v.value}</span>
-  }
+  if (tag === 'text') return renderText(node as VNodeText)
+  if (tag === 'callout') return renderCallout(node as VNodeCallout)
+  if (tag === 'button') return renderButton(node as VNodeButton, ctx)
+  if (tag === 'input') return renderInput(node as VNodeInput, ctx)
+  if (tag === 'list') return renderList(node as VNodeList, ctx)
+  if (tag === 'link') return renderLink(node as VNodeLink)
+  if (tag === 'radio') return renderRadio(node as VNodeRadio, ctx)
+  if (tag === 'svg') return renderSvg(node as VNodeSvg, ctx)
+  if (tag === 'box') return renderBox(node as VNodeBox, ctx)
 
-  if (tag === 'callout') {
-    const v = node as VNodeCallout
-    if (typeof v.body !== 'string') return null
-    const kind = v.kind && v.kind in CALLOUT_STYLES ? v.kind : 'note'
-    const style = CALLOUT_STYLES[kind]
-    return (
-      <div className={`rounded-md border px-3 py-2 ${style.container}`}>
-        <div className="text-xs uppercase tracking-wide text-obsidianText/80 mb-1">
-          <span className="mr-1.5">{style.icon}</span>
-          {v.title && v.title.length > 0 ? v.title : style.label}
-        </div>
-        <div className="text-sm text-obsidianText whitespace-pre-wrap">{v.body}</div>
+  return null
+}
+
+function renderText(v: VNodeText): ReactNode | null {
+  if (typeof v.value !== 'string') return null
+  // React escapes the children slot; the string lands as text content.
+  return <span>{v.value}</span>
+}
+
+function renderCallout(v: VNodeCallout): ReactNode | null {
+  if (typeof v.body !== 'string') return null
+  const kind = v.kind && v.kind in CALLOUT_STYLES ? v.kind : 'note'
+  const style = CALLOUT_STYLES[kind]
+  return (
+    <div className={`rounded-md border px-3 py-2 ${style.container}`}>
+      <div className="text-xs uppercase tracking-wide text-obsidianText/80 mb-1">
+        <span className="mr-1.5">{style.icon}</span>
+        {v.title && v.title.length > 0 ? v.title : style.label}
       </div>
+      <div className="text-sm text-obsidianText whitespace-pre-wrap">{v.body}</div>
+    </div>
+  )
+}
+
+function renderButton(v: VNodeButton, ctx: RenderContext): ReactNode | null {
+  if (typeof v.label !== 'string') return null
+  const variant = v.variant && v.variant in BUTTON_VARIANTS ? v.variant : 'default'
+  const disabled = v.disabled === true
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      className={`inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${BUTTON_VARIANTS[variant]} disabled:cursor-not-allowed disabled:opacity-50`}
+      onClick={
+        disabled
+          ? undefined
+          : () => dispatchOrDrop(ctx, v.onClick)
+      }
+    >
+      {v.label}
+    </button>
+  )
+}
+
+function renderInput(v: VNodeInput, ctx: RenderContext): ReactNode | null {
+  if (v.type !== 'text' && v.type !== 'number' && v.type !== 'search' && v.type !== 'select') {
+    return null
+  }
+  const disabled = v.disabled === true
+  const baseClass =
+    'rounded-md border border-obsidianBorder bg-obsidianHighlight/30 px-2 py-1 text-sm text-obsidianText placeholder:text-obsidianSecondaryText focus:outline-none focus:ring-2 focus:ring-blue-500/40 disabled:cursor-not-allowed disabled:opacity-50'
+
+  if (v.type === 'select') {
+    const options = Array.isArray(v.options) ? v.options : []
+    return (
+      <select
+        className={baseClass}
+        disabled={disabled}
+        value={typeof v.value === 'string' || typeof v.value === 'number' ? String(v.value) : ''}
+        onChange={
+          disabled
+            ? undefined
+            : (e) => dispatchOrDrop(ctx, v.onChange, { value: e.target.value })
+        }
+      >
+        {options.map((opt, idx) => {
+          if (typeof opt?.value !== 'string' || typeof opt?.label !== 'string') return null
+          return (
+            <option key={`${opt.value}:${idx}`} value={opt.value}>
+              {opt.label}
+            </option>
+          )
+        })}
+      </select>
     )
   }
 
+  const value =
+    typeof v.value === 'string' || typeof v.value === 'number' ? String(v.value) : ''
+  return (
+    <input
+      type={v.type}
+      className={baseClass}
+      disabled={disabled}
+      placeholder={typeof v.placeholder === 'string' ? v.placeholder : undefined}
+      value={value}
+      onChange={
+        disabled
+          ? undefined
+          : (e) => {
+              const next = v.type === 'number' ? Number(e.target.value) : e.target.value
+              dispatchOrDrop(ctx, v.onChange, { value: next })
+            }
+      }
+    />
+  )
+}
+
+function renderList(v: VNodeList, ctx: RenderContext): ReactNode | null {
+  if (!Array.isArray(v.items)) return null
+  if (ctx.depth + 1 > MAX_LIST_DEPTH) return null
+  const childCtx: RenderContext = { onEvent: ctx.onEvent, depth: ctx.depth + 1 }
+  const ordered = v.ordered === true
+  const Tag = ordered ? 'ol' : 'ul'
+  return (
+    <Tag className={`${ordered ? 'list-decimal' : 'list-disc'} pl-5 text-sm text-obsidianText space-y-1`}>
+      {v.items.map((item, idx) => {
+        const rendered = renderWithContext(item, childCtx)
+        if (rendered === null) return null
+        return <li key={idx}>{rendered}</li>
+      })}
+    </Tag>
+  )
+}
+
+function renderLink(v: VNodeLink): ReactNode | null {
+  if (typeof v.label !== 'string' || v.label.length === 0) return null
+  if (typeof v.href !== 'object' || v.href === null || !('kind' in v.href)) return null
+  const href = linkHrefToString(v.href as VNodeLink['href'])
+  if (href === null) return null
+  // Belt-and-braces — the helper above already restricts to wikilink://
+  // and #fragment, but the named guard keeps the security contract
+  // explicit at the render site.
+  if (!isSafePluginHref(href)) return null
+  return (
+    <a
+      href={href}
+      className="text-blue-500 underline hover:text-blue-400"
+      rel="noopener noreferrer"
+    >
+      {v.label}
+    </a>
+  )
+}
+
+function renderRadio(v: VNodeRadio, ctx: RenderContext): ReactNode | null {
+  if (typeof v.group !== 'string' || v.group.length === 0) return null
+  if (!Array.isArray(v.options)) return null
+  const current = typeof v.value === 'string' ? v.value : undefined
+  return (
+    <fieldset className="flex flex-col gap-1">
+      {v.options.map((opt, idx) => {
+        if (typeof opt?.value !== 'string' || typeof opt?.label !== 'string') return null
+        const checked = current === opt.value
+        const id = `plugin-radio-${v.group}-${idx}`
+        return (
+          <label key={`${opt.value}:${idx}`} htmlFor={id} className="flex items-center gap-2 text-sm text-obsidianText">
+            <input
+              id={id}
+              type="radio"
+              name={`plugin-radio-${v.group}`}
+              value={opt.value}
+              checked={checked}
+              onChange={() => dispatchOrDrop(ctx, v.onChange, { value: opt.value })}
+              className="accent-blue-500"
+            />
+            <span>{opt.label}</span>
+          </label>
+        )
+      })}
+    </fieldset>
+  )
+}
+
+function renderSvg(v: VNodeSvg, ctx: RenderContext): ReactNode | null {
+  const width = coerceFinite(v.width)
+  const height = coerceFinite(v.height)
+  if (width === null || height === null) return null
+  if (!Array.isArray(v.children)) return null
+  let viewBox: string | undefined
+  if (Array.isArray(v.viewBox) && v.viewBox.length === 4) {
+    const parts = v.viewBox.map((n) => coerceFinite(n))
+    if (parts.every((n): n is number => n !== null)) {
+      viewBox = parts.join(' ')
+    }
+  }
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={viewBox}
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {v.children.map((child, idx) => renderSvgChild(child, idx, ctx))}
+    </svg>
+  )
+}
+
+function renderSvgChild(child: SvgChild | unknown, key: number, ctx: RenderContext): ReactNode | null {
+  if (typeof child !== 'object' || child === null || !('tag' in child)) return null
+  const tag = (child as { tag: unknown }).tag
+
+  if (tag === 'line') {
+    const c = child as Extract<SvgChild, { tag: 'line' }>
+    const x1 = coerceFinite(c.x1)
+    const y1 = coerceFinite(c.y1)
+    const x2 = coerceFinite(c.x2)
+    const y2 = coerceFinite(c.y2)
+    if (x1 === null || y1 === null || x2 === null || y2 === null) return null
+    const stroke = safeColor(c.stroke) ?? 'currentColor'
+    const strokeWidth = coerceFinite(c.strokeWidth) ?? 1
+    return <line key={key} x1={x1} y1={y1} x2={x2} y2={y2} stroke={stroke} strokeWidth={strokeWidth} />
+  }
+
+  if (tag === 'circle') {
+    const c = child as Extract<SvgChild, { tag: 'circle' }>
+    const cx = coerceFinite(c.cx)
+    const cy = coerceFinite(c.cy)
+    const r = coerceFinite(c.r)
+    if (cx === null || cy === null || r === null) return null
+    const fill = safeColor(c.fill) ?? 'currentColor'
+    const stroke = safeColor(c.stroke) ?? 'none'
+    return (
+      <circle
+        key={key}
+        cx={cx}
+        cy={cy}
+        r={r}
+        fill={fill}
+        stroke={stroke}
+        onClick={c.onClick ? () => dispatchOrDrop(ctx, c.onClick) : undefined}
+        style={c.onClick ? ({ cursor: 'pointer' } satisfies CSSProperties) : undefined}
+      />
+    )
+  }
+
+  if (tag === 'rect') {
+    const c = child as Extract<SvgChild, { tag: 'rect' }>
+    const x = coerceFinite(c.x)
+    const y = coerceFinite(c.y)
+    const width = coerceFinite(c.width)
+    const height = coerceFinite(c.height)
+    if (x === null || y === null || width === null || height === null) return null
+    const fill = safeColor(c.fill) ?? 'currentColor'
+    const stroke = safeColor(c.stroke) ?? 'none'
+    return (
+      <rect
+        key={key}
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill={fill}
+        stroke={stroke}
+        onClick={c.onClick ? () => dispatchOrDrop(ctx, c.onClick) : undefined}
+        style={c.onClick ? ({ cursor: 'pointer' } satisfies CSSProperties) : undefined}
+      />
+    )
+  }
+
+  if (tag === 'text') {
+    const c = child as Extract<SvgChild, { tag: 'text' }>
+    const x = coerceFinite(c.x)
+    const y = coerceFinite(c.y)
+    if (x === null || y === null) return null
+    if (typeof c.value !== 'string') return null
+    const fontSize = coerceFinite(c.fontSize) ?? 12
+    const fill = safeColor(c.fill) ?? 'currentColor'
+    return (
+      <text key={key} x={x} y={y} fontSize={fontSize} fill={fill}>
+        {c.value}
+      </text>
+    )
+  }
+
+  if (tag === 'path') {
+    const c = child as Extract<SvgChild, { tag: 'path' }>
+    if (typeof c.d !== 'string' || c.d.length === 0) return null
+    if (c.d.length > MAX_PATH_D_LENGTH) return null
+    const stroke = safeColor(c.stroke) ?? 'currentColor'
+    const fill = safeColor(c.fill) ?? 'none'
+    const strokeWidth = coerceFinite(c.strokeWidth) ?? 1
+    return <path key={key} d={c.d} stroke={stroke} fill={fill} strokeWidth={strokeWidth} />
+  }
+
   return null
+}
+
+function renderBox(v: VNodeBox, ctx: RenderContext): ReactNode | null {
+  if (!Array.isArray(v.children)) return null
+  if (ctx.depth + 1 > MAX_LIST_DEPTH) return null
+  const childCtx: RenderContext = { onEvent: ctx.onEvent, depth: ctx.depth + 1 }
+  const gap = v.gap !== undefined && v.gap in GAP_CLASSES ? GAP_CLASSES[v.gap] : 'gap-2'
+  return (
+    <div className={`flex flex-col ${gap}`}>
+      {v.children.map((child, idx) => {
+        const rendered = renderWithContext(child, childCtx)
+        if (rendered === null) return null
+        return <div key={idx}>{rendered}</div>
+      })}
+    </div>
+  )
 }
 
 /**
  * Render-or-fallback. Unrecognised shapes show a JSON dump in dev so
  * plugin authors can spot a typo, and the same dump in prod (we do
  * not strip it — the surface area is too small to bother gating).
+ *
+ * Pass `onEvent` to wire VNode events back into the host. Surfaces
+ * that need event delivery (the sidebar plugin panel, the code-block
+ * renderer, the future fullscreen view in PR B) all wrap this prop.
  */
-export function PluginNode({ node }: { node: unknown }) {
-  const rendered = renderPluginVNode(node)
+export function PluginNode({
+  node,
+  onEvent,
+}: {
+  node: unknown
+  onEvent?: PluginVNodeEventDispatcher
+}) {
+  const rendered = renderPluginVNode(node, onEvent)
   if (rendered !== null) return <>{rendered}</>
   return (
     <pre className="text-xs font-mono text-obsidianSecondaryText whitespace-pre-wrap">

--- a/src/plugins/__tests__/PluginVNode.test.tsx
+++ b/src/plugins/__tests__/PluginVNode.test.tsx
@@ -1,0 +1,537 @@
+/**
+ * PluginVNode.test.tsx
+ *
+ * Plugin API v1.2 PR A — exercise the extended VNode set:
+ *   button / input / list / link / radio / svg / box
+ *
+ * Each test asserts the rendered DOM is structurally what the plan in
+ * `docs/plugins-v1.2-plan.md` (section 2) describes, plus the host
+ * never reaches dangerouslySetInnerHTML, the sanitiser escapes script
+ * tags in plugin text, unsafe link hrefs are rejected, and the event
+ * shape round-trips through the dispatcher.
+ */
+
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import {
+  PluginNode,
+  renderPluginVNode,
+  escapeText,
+  isSafePluginHref,
+  MAX_LIST_DEPTH,
+  type PluginVNodeEvent,
+  type VNode,
+} from '../PluginVNode'
+
+describe('PluginVNode — v1 shapes still work', () => {
+  test('text renders its value as a span', () => {
+    render(<PluginNode node={{ tag: 'text', value: 'hello world' }} />)
+    expect(screen.getByText('hello world').tagName).toBe('SPAN')
+  })
+
+  test('callout renders the body and falls back to "note" kind', () => {
+    render(<PluginNode node={{ tag: 'callout', body: 'body text' }} />)
+    expect(screen.getByText('body text')).toBeInTheDocument()
+    expect(screen.getByText('Note')).toBeInTheDocument()
+  })
+})
+
+describe('PluginVNode — button', () => {
+  test('renders the label and fires onClick with payload', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'button',
+          label: 'Save',
+          variant: 'primary',
+          onClick: { kind: 'emit', event: 'save', payload: { id: 1 } },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: 'Save' })
+    expect(btn).not.toBeDisabled()
+    fireEvent.click(btn)
+    expect(events).toEqual([{ event: 'save', payload: { id: 1 } }])
+  })
+
+  test('disabled buttons render disabled and never fire events', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'button',
+          label: 'Save',
+          disabled: true,
+          onClick: { kind: 'emit', event: 'save' },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: 'Save' })
+    expect(btn).toBeDisabled()
+    fireEvent.click(btn)
+    expect(events).toEqual([])
+  })
+
+  test('non-string label rejects the node', () => {
+    const out = renderPluginVNode({ tag: 'button', label: 42 } as unknown)
+    expect(out).toBeNull()
+  })
+})
+
+describe('PluginVNode — input', () => {
+  test('text input forwards typed value through the dispatcher', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'input',
+          type: 'text',
+          value: '',
+          placeholder: 'Search…',
+          onChange: { kind: 'emit', event: 'q' },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const input = screen.getByPlaceholderText('Search…') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'abc' } })
+    expect(events).toEqual([{ event: 'q', payload: { value: 'abc' } }])
+  })
+
+  test('number input coerces value to a number in the payload', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'input',
+          type: 'number',
+          value: 0,
+          onChange: { kind: 'emit', event: 'n' },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const input = screen.getByRole('spinbutton') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '7' } })
+    expect(events).toEqual([{ event: 'n', payload: { value: 7 } }])
+  })
+
+  test('select input renders options and emits the picked value', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'input',
+          type: 'select',
+          value: 'a',
+          options: [
+            { value: 'a', label: 'Alpha' },
+            { value: 'b', label: 'Bravo' },
+          ],
+          onChange: { kind: 'emit', event: 'pick' },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const select = screen.getByRole('combobox') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'b' } })
+    expect(events).toEqual([{ event: 'pick', payload: { value: 'b' } }])
+  })
+
+  test('unknown input type rejects the node', () => {
+    const out = renderPluginVNode({ tag: 'input', type: 'password' } as unknown)
+    expect(out).toBeNull()
+  })
+})
+
+describe('PluginVNode — list', () => {
+  test('unordered list renders <ul> with child VNodes', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'list',
+          ordered: false,
+          items: [
+            { tag: 'text', value: 'one' },
+            { tag: 'text', value: 'two' },
+          ],
+        }}
+      />,
+    )
+    const ul = screen.getByText('one').closest('ul')
+    expect(ul).not.toBeNull()
+    expect(screen.getByText('two')).toBeInTheDocument()
+  })
+
+  test('ordered list renders <ol>', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'list',
+          ordered: true,
+          items: [{ tag: 'text', value: 'first' }],
+        }}
+      />,
+    )
+    expect(screen.getByText('first').closest('ol')).not.toBeNull()
+  })
+
+  test('list nested beyond MAX_LIST_DEPTH drops the leaf, does not blow the stack', () => {
+    // Build a list nested deeper than MAX_LIST_DEPTH levels with a
+    // text leaf at the bottom. The outer lists render fine, but the
+    // recursion stops once depth exceeds the cap — so the leaf text
+    // never reaches the DOM. The bound exists to keep a malicious
+    // plugin from blowing the React stack, not to error noisily.
+    let node: VNode = { tag: 'text', value: 'leaf-too-deep' }
+    for (let i = 0; i < MAX_LIST_DEPTH + 2; i++) {
+      node = { tag: 'list', items: [node] }
+    }
+    const { container } = render(<PluginNode node={node} />)
+    expect(container.textContent).not.toContain('leaf-too-deep')
+  })
+})
+
+describe('PluginVNode — link', () => {
+  test('note href renders an anchor with a wikilink:// URL', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'link',
+          label: 'Open',
+          href: { kind: 'note', noteId: 'abc' },
+        }}
+      />,
+    )
+    const a = screen.getByRole('link', { name: 'Open' }) as HTMLAnchorElement
+    expect(a.getAttribute('href')).toBe('wikilink://abc')
+  })
+
+  test('anchor href renders a fragment link', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'link',
+          label: 'Jump',
+          href: { kind: 'anchor', fragment: 'section-1' },
+        }}
+      />,
+    )
+    const a = screen.getByRole('link', { name: 'Jump' }) as HTMLAnchorElement
+    expect(a.getAttribute('href')).toBe('#section-1')
+  })
+
+  test('javascript: cannot be expressed — discriminated union rejects raw hrefs', () => {
+    // Try to slip a raw href through. The renderer reads `href.kind` —
+    // a plain string fails the type guard, the node renders to null,
+    // and `PluginNode` shows the JSON fallback.
+    const out = renderPluginVNode({
+      tag: 'link',
+      label: 'click',
+      href: 'javascript:alert(1)' as unknown,
+    } as unknown)
+    expect(out).toBeNull()
+  })
+
+  test('isSafePluginHref rejects javascript: and data:', () => {
+    expect(isSafePluginHref('javascript:alert(1)')).toBe(false)
+    expect(isSafePluginHref('data:text/html,<script>')).toBe(false)
+    expect(isSafePluginHref('http://evil.example')).toBe(false)
+    expect(isSafePluginHref('mailto:a@b.c')).toBe(false)
+    expect(isSafePluginHref('//evil.example/path')).toBe(false)
+    expect(isSafePluginHref('wikilink://abc')).toBe(true)
+    expect(isSafePluginHref('#fragment')).toBe(true)
+    expect(isSafePluginHref('/local/path')).toBe(true)
+  })
+})
+
+describe('PluginVNode — radio', () => {
+  test('renders one radio per option and emits the picked value', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'radio',
+          group: 'format',
+          value: 'obsidian',
+          options: [
+            { value: 'obsidian', label: 'Obsidian' },
+            { value: 'notion', label: 'Notion' },
+          ],
+          onChange: { kind: 'emit', event: 'pickFormat' },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const notion = screen.getByLabelText('Notion') as HTMLInputElement
+    expect(notion.checked).toBe(false)
+    fireEvent.click(notion)
+    expect(events).toEqual([{ event: 'pickFormat', payload: { value: 'notion' } }])
+  })
+})
+
+describe('PluginVNode — svg', () => {
+  test('renders the five permitted shape primitives', () => {
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 100,
+          height: 100,
+          viewBox: [0, 0, 100, 100],
+          children: [
+            { tag: 'line', x1: 0, y1: 0, x2: 10, y2: 10 },
+            { tag: 'circle', cx: 50, cy: 50, r: 5, fill: '#f00' },
+            { tag: 'rect', x: 1, y: 2, width: 3, height: 4 },
+            { tag: 'text', x: 10, y: 10, value: 'hi' },
+            { tag: 'path', d: 'M0 0 L10 10' },
+          ],
+        }}
+      />,
+    )
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 100 100')
+    expect(container.querySelector('line')).not.toBeNull()
+    expect(container.querySelector('circle')).not.toBeNull()
+    expect(container.querySelector('rect')).not.toBeNull()
+    expect(container.querySelector('text')?.textContent).toBe('hi')
+    expect(container.querySelector('path')).not.toBeNull()
+  })
+
+  test('non-finite numeric props reject the affected child', () => {
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 100,
+          height: 100,
+          children: [
+            { tag: 'circle', cx: Number.NaN, cy: 0, r: 5 },
+            { tag: 'circle', cx: 1, cy: 2, r: 3 },
+          ],
+        }}
+      />,
+    )
+    // Only the second circle survives the coerceFinite guard.
+    const circles = container.querySelectorAll('circle')
+    expect(circles.length).toBe(1)
+    expect(circles[0].getAttribute('cx')).toBe('1')
+  })
+
+  test('clickable circle dispatches onClick event', () => {
+    const events: PluginVNodeEvent[] = []
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 100,
+          height: 100,
+          children: [
+            {
+              tag: 'circle',
+              cx: 50,
+              cy: 50,
+              r: 5,
+              onClick: { kind: 'emit', event: 'pickNode', payload: { id: 'n1' } },
+            },
+          ],
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const circle = container.querySelector('circle')
+    expect(circle).not.toBeNull()
+    fireEvent.click(circle!)
+    expect(events).toEqual([{ event: 'pickNode', payload: { id: 'n1' } }])
+  })
+
+  test('unknown svg child tags are dropped', () => {
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 10,
+          height: 10,
+          children: [{ tag: 'script', value: 'alert(1)' }],
+        } as unknown}
+      />,
+    )
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  test('unsafe color string falls back to currentColor', () => {
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 10,
+          height: 10,
+          children: [
+            { tag: 'line', x1: 0, y1: 0, x2: 1, y2: 1, stroke: 'url(javascript:alert(1))' },
+          ],
+        }}
+      />,
+    )
+    const line = container.querySelector('line')
+    expect(line?.getAttribute('stroke')).toBe('currentColor')
+  })
+})
+
+describe('PluginVNode — box', () => {
+  test('renders each child of a box', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'box',
+          gap: 2,
+          children: [
+            { tag: 'text', value: 'header' },
+            { tag: 'text', value: 'body' },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getByText('header')).toBeInTheDocument()
+    expect(screen.getByText('body')).toBeInTheDocument()
+  })
+})
+
+describe('PluginVNode — sanitisation', () => {
+  test('script-tag strings render as text content, never as DOM nodes', () => {
+    const evil = '<script>alert("x")</script>'
+    const { container } = render(<PluginNode node={{ tag: 'text', value: evil }} />)
+    // React renders the string as text content — no <script> element.
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.textContent).toContain(evil)
+  })
+
+  test('escapeText escapes &, <, >, ", and \'', () => {
+    expect(escapeText('<script>alert("x")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;',
+    )
+    expect(escapeText("A & B's <tag>")).toBe('A &amp; B&#39;s &lt;tag&gt;')
+  })
+
+  test('svg text value renders as text content, not markup', () => {
+    const evil = '<script>alert(1)</script>'
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 10,
+          height: 10,
+          children: [{ tag: 'text', x: 0, y: 0, value: evil }],
+        }}
+      />,
+    )
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('text')?.textContent).toBe(evil)
+  })
+
+  test('renderer never reaches dangerouslySetInnerHTML for any v1.2 shape', () => {
+    // Spy on React's warning channel — dangerouslySetInnerHTML on a
+    // mismatched element would log. We just confirm no element in any
+    // rendered v1.2 shape carries the attribute.
+    const shapes: VNode[] = [
+      { tag: 'button', label: 'b' },
+      { tag: 'input', type: 'text' },
+      { tag: 'list', items: [{ tag: 'text', value: 'x' }] },
+      { tag: 'link', label: 'l', href: { kind: 'note', noteId: 'a' } },
+      { tag: 'radio', group: 'g', options: [{ value: 'a', label: 'A' }] },
+      {
+        tag: 'svg',
+        width: 10,
+        height: 10,
+        children: [{ tag: 'text', x: 0, y: 0, value: 'x' }],
+      },
+      { tag: 'box', children: [{ tag: 'text', value: 'x' }] },
+    ]
+    for (const shape of shapes) {
+      const { container, unmount } = render(<PluginNode node={shape} />)
+      const html = container.innerHTML
+      expect(html).not.toContain('dangerouslySetInnerHTML')
+      unmount()
+    }
+  })
+})
+
+describe('PluginVNode — event shape round-trip', () => {
+  test('VNodeEvent + dispatcher preserve event name and payload verbatim', () => {
+    const events: PluginVNodeEvent[] = []
+    const payload = { complex: { nested: [1, 2, 3] }, str: 'hello' }
+    render(
+      <PluginNode
+        node={{
+          tag: 'button',
+          label: 'fire',
+          onClick: { kind: 'emit', event: 'fire', payload },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'fire' }))
+    expect(events).toHaveLength(1)
+    expect(events[0].event).toBe('fire')
+    expect(events[0].payload).toEqual(payload)
+  })
+
+  test('input change merges value into the plugin-supplied payload', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'input',
+          type: 'text',
+          value: '',
+          onChange: { kind: 'emit', event: 'edit', payload: { fieldId: 'name' } },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Jon' } })
+    expect(events).toEqual([
+      { event: 'edit', payload: { fieldId: 'name', value: 'Jon' } },
+    ])
+  })
+
+  test('missing onEvent dispatcher silently drops the event', () => {
+    // Component must not throw when a surface forgets to wire onEvent.
+    render(
+      <PluginNode
+        node={{
+          tag: 'button',
+          label: 'orphan',
+          onClick: { kind: 'emit', event: 'fire' },
+        }}
+      />,
+    )
+    expect(() => fireEvent.click(screen.getByRole('button'))).not.toThrow()
+  })
+
+  test('missing or malformed VNodeEvent does not call the dispatcher', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{ tag: 'button', label: 'noop' } as VNode}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(events).toEqual([])
+  })
+})
+
+describe('PluginVNode — unrecognised node fallback', () => {
+  test('PluginNode dumps JSON for an unknown tag', () => {
+    const { container } = render(
+      <PluginNode node={{ tag: 'totally-made-up', x: 1 }} />,
+    )
+    const pre = container.querySelector('pre')
+    expect(pre).not.toBeNull()
+    expect(pre?.textContent).toContain('totally-made-up')
+  })
+})

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -33,6 +33,7 @@ export type HostToWorker =
   | HostActiveNoteChanged
   | HostFileSaveResult
   | HostFileOpenResult
+  | HostVNodeEvent
 
 /** First message the host sends. Worker initialises the plugin module
  *  and replies with WorkerReady on success or WorkerBootError on failure. */
@@ -117,6 +118,38 @@ export interface HostFileOpenResult {
   bytesBase64?: string
   filename?: string
   error?: string
+}
+
+/** v1.2 — VNode event delivery. The renderer dispatches one of these
+ *  every time a plugin-rendered control fires (button click, input
+ *  change, radio pick, clickable svg shape). The worker matches
+ *  `event` against handlers the plugin registered via
+ *  `ctx.onVNodeEvent` (registration API ships in a later v1.2 PR;
+ *  this envelope is the wire contract every later PR builds on).
+ *
+ *  `source` tells the worker which surface produced the event so the
+ *  plugin can disambiguate when the same `event` name is used in two
+ *  surfaces. PR B fills `kind: 'fullscreen'`; this PR (A) only emits
+ *  `kind: 'panel'` / `kind: 'codeBlock'`.
+ *
+ *  Per the v1.2 plan section 2.1, the host curates which event types
+ *  are wireable (`onClick`, `onChange`, `onSubmit`, `onKeyDown`). For
+ *  inputs and radios the host augments `payload` with `{ value }`
+ *  before posting, so the worker reads the user's selection without
+ *  guessing the DOM event shape. */
+export interface HostVNodeEvent {
+  type: 'host:vnodeEvent'
+  seq: number
+  /** Plugin-defined event name. Host treats as opaque. */
+  event: string
+  /** Plugin-supplied payload, possibly augmented with `{ value }` for
+   *  inputs and radios. */
+  payload: unknown
+  /** Which rendered surface produced the event. */
+  source:
+    | { kind: 'panel'; panelId: string }
+    | { kind: 'codeBlock'; blockId: string }
+    | { kind: 'fullscreen'; viewId: string }
 }
 
 // ─── Worker → Host ─────────────────────────────────────────────────────────
@@ -238,6 +271,7 @@ export function isHostToWorker(msg: unknown): msg is HostToWorker {
     'host:activeNoteChanged',
     'host:fileSaveResult',
     'host:fileOpenResult',
+    'host:vnodeEvent',
   ])
 }
 

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -13,6 +13,25 @@
 
 import type { PluginManifest } from './manifest'
 
+// Re-export the v1.2 VNode types so plugin authors importing from the
+// SDK can construct VNodes type-safely. PR A only adds the types —
+// new SDK methods (event registration, fullscreen, vault, fs) ship in
+// later v1.2 PRs.
+export type {
+  VNode,
+  VNodeText,
+  VNodeCallout,
+  VNodeButton,
+  VNodeInput,
+  VNodeList,
+  VNodeLink,
+  VNodeRadio,
+  VNodeSvg,
+  VNodeBox,
+  VNodeEvent,
+  SvgChild,
+} from './PluginVNode'
+
 /** Narrow capability surface exposed to plugin handlers. The plugin
  *  never sees `localStorage`, the GitHub token, or the bodies of notes
  *  it is not currently viewing. v1 read scope is intentionally tight:


### PR DESCRIPTION
References [`docs/plugins-v1.2-plan.md`](docs/plugins-v1.2-plan.md) section 2. Foundation PR for the v1.2 six-PR sequence — every later PR (B fullscreen, C-F capabilities) assumes this lands first.

## Summary

Extends the curated VNode renderer (`src/plugins/PluginVNode.tsx`) from the v1 two-shape set (`text`, `callout`) to the v1.2 nine-shape set. Adds the shared event-handler record (`VNodeEvent`) and the wire envelope (`host:vnodeEvent`) that PR B and the capability PRs consume without further protocol churn.

## New VNodes (per plan section 2.2)

| Tag      | Shape                                              | Security stance                                                                                                                       |
|----------|----------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
| `button` | label + variant + disabled + `onClick` event       | Disabled buttons skip the event listener entirely; non-string `label` rejects the node.                                                |
| `input`  | type (text/number/search/select) + value + change  | Unknown `type` rejects the node. Number inputs coerce the emitted value via `Number()`. Disabled inputs skip the listener.             |
| `list`   | ordered/unordered + child VNodes                   | Depth-capped at `MAX_LIST_DEPTH = 8` (shared budget with `box`). Bound to keep a runaway plugin from blowing the React stack.           |
| `link`   | label + discriminated `href` (note id or anchor)    | Plugins cannot produce a raw href string — `javascript:`, `data:`, `mailto:`, external URLs are structurally impossible. `isSafePluginHref` belt-and-braces guards the assembled URL. |
| `radio`  | group + options + value + change event              | Each option's `value` and `label` must be a string; malformed options drop silently.                                                   |
| `svg`    | width/height/viewBox + 5 shape primitives           | Only `line` / `circle` / `rect` / `text` / `path` permitted. Unknown svg child tags drop. Non-finite numeric props reject the affected child. Colour strings match a strict regex (32-char cap) and fall back to `currentColor`. `path d` capped at 8 KB. |
| `box`    | layout container + gap                              | Shares the `MAX_LIST_DEPTH = 8` recursion budget with `list`.                                                                          |

## Sanitisation

Every plugin-supplied string renders as React text content — the renderer never reaches React's raw-HTML escape hatch. The static-source guard at `src/__tests__/markdownXssGuard.test.tsx` already pins this rule across the whole `src/` tree. An `escapeText` helper covers the rare paths that need to assemble a string before handing it to React.

## Event shape

```ts
type VNodeEvent = { kind: 'emit'; event: string; payload?: unknown }
type PluginVNodeEvent = { event: string; payload: unknown }
```

The wire envelope `host:vnodeEvent` in `protocol.ts` carries the same shape plus a `source` discriminator (`panel` / `codeBlock` / `fullscreen`). PR A only emits `panel` / `codeBlock` at runtime; the `fullscreen` variant is pre-shipped in the type union so PR B does not need to churn the protocol. Input and radio events augment the plugin-supplied payload with `{ value }`.

The handler-registration API (`ctx.onVNodeEvent`) is intentionally NOT in PR A — the surface adapters (panel, code block) start forwarding events to the worker in a later PR that also ships the registration API. The renderer's dispatcher is currently wired only in unit tests; this PR ships the shape so the rest of v1.2 does not block on protocol churn.

## SDK additions

- `src/plugins/sdk.ts` re-exports the VNode types from `PluginVNode.tsx`.
- `packages/noteser-plugin-sdk/src/{sdk.ts,index.ts}` inlines the type declarations (the published SDK has no React dependency, so it cannot pull from the renderer file). Both lists are aligned by review; a future PR may extract them into a shared `vdom.ts`.

## Reference plugin

`public/plugins/noteser-vnode-demo/` renders one of every new shape inside a sidebar panel for manual smoke. The plugin loads via the existing vault-scan / URL install paths.

## Test plan

- [x] `npm run lint` clean on touched files.
- [x] `npx tsc --noEmit` zero errors.
- [x] `npm test -- --ci` green (197 suites, 2437 tests passing, 17 skipped — only existing-suite skips, no new ones).
- [x] 32 new unit tests in `src/plugins/__tests__/PluginVNode.test.tsx` cover every new shape, the sanitiser path, `javascript:` link rejection, the depth cap, and the event-shape round-trip.
- [x] Manual: the demo plugin's `onPanelMount` produces a root `box` with seven children (`text`, `callout`, `button`, `input`, `radio`, `list`, `svg`); each maps through the new renderer cleanly.

Deviations from the plan are tracked in [`docs/plugins-v1.2-impl-notes.md`](docs/plugins-v1.2-impl-notes.md), section "PR A".