### PR TITLE
Plugin API v1.2 PR C: vault.read.all capability

### DIFF
--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -95,3 +95,80 @@ the looser pattern would accept.
   exercises every new shape but does not yet receive event callbacks
   (the registration API ships later). Once `ctx.onVNodeEvent` lands,
   update the plugin to read events and re-render.
+
+## PR C — `vault.read.all` capability
+
+Branch: `feat/plugins-v1.2-C-vault-read`. Lands the first v1.2 capability
+(`vault.read.all`) under the plan's §4.1.
+
+### As-built vs. plan
+
+- **SDK return type for `getAllNotes` / `getNote`.** The plan signature is
+  `Promise<ReadonlyArray<NoteWithBody>>` / `Promise<NoteWithBody | null>`.
+  Shipped as written. The wire layer carries the same shape under
+  `NoteWithBodyWire` for clarity at the protocol boundary; the SDK
+  type alias collapses to `NoteWithBody` because the host-side parsed
+  frontmatter is already a plain object.
+- **`stream()` default chunk size.** Plan §5.1 documents the wire-level
+  default as 200 and the cap as 500. PR C ships **default 100** (the
+  scope spec called out 100 explicitly: "chunked 100 notes per chunk").
+  Cap stays at 500 to match the plan's 256 KB envelope guard. Plugins
+  can still request any size; the host clamps.
+- **`getAllNotes` size guard.** Plan: reject when projected payload
+  exceeds 4 MiB. Implemented as `MAX_GET_ALL_BYTES = 4 * 1024 * 1024`
+  in `src/plugins/vaultSnapshot.ts`. `stream()` is always the
+  recommended path for vault-wide reads.
+- **Host snapshot cache.** Plan §3 (perf): "cache by vault-snapshot SHA
+  so a second `getAllNotes()` call within the same SHA returns
+  instantly." Implemented in `vaultSnapshot.ts` with an FNV-1a rolling
+  hash over `(id, updatedAt)` pairs + folder ids. Not cryptographic —
+  it's an identity key, not a security boundary.
+- **Stream chunking + main-thread yield.** Plan §9: "must NOT block the
+  main thread for >50ms even on 5000-note vaults." `streamVaultSnapshot`
+  awaits a `queueMicrotask` between chunks, so a 5000-note walk at
+  chunkSize=100 yields 50 times. The dominant cost (frontmatter parsing)
+  happens once on the cache-cold call; subsequent calls reuse the cache.
+- **Permission revocation persistence.** Plan §4 (each capability is
+  revocable from Settings → Plugins). Implemented as a per-record
+  `revokedPermissions` array on `InstalledPluginRecord`; the host
+  re-applies it on each boot AND on each `confirmAndInstallPlugin`
+  reload. In-memory revocation also writes through to the host so the
+  next call rejects without waiting for a reload.
+- **Mid-stream revocation.** Plan §5.3: "host emits a terminal chunk
+  with `notes: []` and a non-empty `error`; worker rejects the
+  AsyncIterable." Implemented in `pluginHostSingleton.handleVaultReadRequest`
+  via `streamVaultSnapshot`'s `isAborted` polling — checked before
+  every chunk emission.
+
+### What this PR did NOT touch
+
+Per the explicit scope guard rails:
+- No `vault.write` (PR D).
+- No `vault.events` (PR F).
+- No `fs.openDirectory` (PR E).
+- No new VNode set (PR A).
+- The `ctx.vault.write`, `ctx.vault.events`, and `ctx.fs` namespaces are
+  NOT populated by this PR — adding them here would split type defs
+  across two PRs. The SDK `PluginCtx` type only gains `vault: { read: …}`;
+  the sibling slots land with their respective PRs.
+
+### Conflict expectations
+
+- `src/plugins/protocol.ts`, `src/plugins/sdk.ts`, and
+  `packages/noteser-plugin-sdk/src/sdk.ts` will conflict with PR A
+  (VNode set) and PR D / E / F (other capabilities). Resolution rule:
+  union types extend by line, so concatenate; the SDK `vault.read.*`
+  methods are independent of `vault.write` and `vault.events` and can
+  coexist on the `vault` namespace.
+- `src/components/modals/PluginsSettingsPanel.tsx` grew a per-plugin
+  permissions block. PR D will reuse the same block when it lands
+  `vault.write` revocation; no schema change needed.
+
+### Manual verification
+
+The reference plugin at `public/plugins/noteser-vault-read-demo/`
+exercises both `getAllNotes()` and `stream({ chunkSize: 50 })`. The
+test plan: install from a local manifest URL, run "Vault read demo:
+count notes" from the palette, confirm the toast reports the right
+note count; revoke `vault.read.all` from Settings → Plugins, re-run,
+confirm the toast reports the rejection.

--- a/packages/noteser-plugin-sdk/src/index.ts
+++ b/packages/noteser-plugin-sdk/src/index.ts
@@ -5,6 +5,7 @@ export type {
   PluginCtx,
   PluginHandlers,
   PluginDefinition,
+  NoteWithBody,
 } from './sdk'
 
 // v1.2 — VNode shapes plus the shared event-handler record. PR A adds

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -127,6 +127,19 @@ export type VNode =
   | VNodeSvg
   | VNodeBox
 
+/** A note's body + frontmatter as the host renders them. Returned by
+ *  the v1.2 `ctx.vault.read.*` family. Strings only — the host never
+ *  hands the worker raw bytes or a YAML string. */
+export interface NoteWithBody {
+  id: string
+  title: string
+  folderPath: string
+  body: string
+  /** Parsed by the host. `null` when the note has no frontmatter. */
+  frontmatter: Readonly<Record<string, unknown>> | null
+  updatedAt: number
+}
+
 /** Narrow capability surface exposed to plugin handlers. The plugin
  *  never sees `localStorage`, the GitHub token, or the bodies of notes
  *  it is not currently viewing. v1 read scope is intentionally tight:
@@ -157,6 +170,38 @@ export interface PluginCtx {
    *  cannot read another plugin's settings. */
   getSetting<T = unknown>(key: string): T | undefined
   setSetting<T = unknown>(key: string, value: T): void
+
+  /**
+   * v1.2 vault namespace. Always populated; methods reject when the
+   * matching permission was not granted or has been revoked. Plugins
+   * can catch and degrade. PR C wires the `read` sub-namespace.
+   *
+   * Spec reference: docs/plugins-v1.2-plan.md §4.1.
+   */
+  vault: {
+    read: {
+      /** Snapshot every non-deleted note in the vault. Resolves with a
+       *  plain array of `NoteWithBody`. For very large vaults the host
+       *  rejects with `'Vault too large; use stream().'`; plugins MUST
+       *  fall back to `stream()` in that case.
+       *
+       *  Requires `vault.read.all` permission. */
+      getAllNotes(): Promise<ReadonlyArray<NoteWithBody>>
+
+      /** Resolve a single note by id. Returns null when the id is
+       *  unknown or the note has been soft-deleted. Requires
+       *  `vault.read.all` permission. */
+      getNote(id: string): Promise<NoteWithBody | null>
+
+      /** Paginate over the vault. Each iteration yields up to
+       *  `chunkSize` notes (default 100, max 500). The iterator
+       *  completes naturally when the vault is exhausted; it throws
+       *  when the permission is revoked mid-stream.
+       *
+       *  Requires `vault.read.all` permission. */
+      stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
+    }
+  }
 }
 
 export interface PluginHandlers {

--- a/public/plugins/noteser-vault-read-demo/main.js
+++ b/public/plugins/noteser-vault-read-demo/main.js
@@ -1,0 +1,56 @@
+// noteser-vault-read-demo v0.1.0
+//
+// Reference plugin for the v1.2 `vault.read.all` capability (PR C).
+// Two commands:
+//   - count   : ctx.vault.read.getAllNotes() → notify with count.
+//   - stream  : ctx.vault.read.stream({ chunkSize: 50 }) → notify per
+//               chunk, then totals at end-of-stream.
+//
+// Both flows print to the worker console via ctx.notify so an
+// end-to-end manual test confirms the wire works without UI surface.
+
+export default {
+  id: 'noteser-vault-read-demo',
+  name: 'Vault read demo',
+  version: '0.1.0',
+  author: 'Noteser',
+  description:
+    'Reference plugin for the v1.2 vault.read.all capability. Prints a count of the notes in the vault to the worker console.',
+  permissions: ['vault.read.all'],
+  surfaces: {
+    commands: [
+      { id: 'count', title: 'Vault read demo: count notes' },
+      { id: 'stream', title: 'Vault read demo: stream notes' },
+    ],
+  },
+
+  async onCommand(id, ctx) {
+    if (id === 'count') {
+      try {
+        const notes = await ctx.vault.read.getAllNotes()
+        ctx.notify(`Vault read demo: getAllNotes returned ${notes.length} notes.`)
+      } catch (err) {
+        ctx.notify(
+          `Vault read demo: getAllNotes rejected — ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+      return
+    }
+    if (id === 'stream') {
+      let total = 0
+      let chunks = 0
+      try {
+        for await (const chunk of ctx.vault.read.stream({ chunkSize: 50 })) {
+          chunks++
+          total += chunk.length
+        }
+        ctx.notify(`Vault read demo: stream returned ${total} notes across ${chunks} chunks.`)
+      } catch (err) {
+        ctx.notify(
+          `Vault read demo: stream rejected after ${chunks} chunks — ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+      return
+    }
+  },
+}

--- a/public/plugins/noteser-vault-read-demo/manifest.json
+++ b/public/plugins/noteser-vault-read-demo/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "noteser-vault-read-demo",
+  "name": "Vault read demo",
+  "version": "0.1.0",
+  "author": "Noteser",
+  "description": "Reference plugin for the v1.2 vault.read.all capability. Prints a count of the notes in the vault to the worker console.",
+  "main": "./main.js",
+  "permissions": ["vault.read.all"],
+  "surfaces": {
+    "commands": [
+      { "id": "count", "title": "Vault read demo: count notes" },
+      { "id": "stream", "title": "Vault read demo: stream notes" }
+    ]
+  }
+}

--- a/src/components/modals/PluginsSettingsPanel.tsx
+++ b/src/components/modals/PluginsSettingsPanel.tsx
@@ -17,9 +17,11 @@ import { useFolderStore } from '@/stores/folderStore'
 import { useUIStore } from '@/stores'
 import {
   fetchPluginForInstallFromVault,
+  setPluginPermissionRevoked,
   uninstallPlugin,
 } from '@/plugins/pluginHostSingleton'
 import { scanVaultForManifests, type VaultManifestCandidate } from '@/plugins/vaultScan'
+import { PERMISSION_DESCRIPTIONS, type PluginPermission } from '@/plugins/manifest'
 
 export const PluginsSettingsPanel = () => {
   const records = usePluginInstallStore((s) => s.records)
@@ -209,60 +211,101 @@ export const PluginsSettingsPanel = () => {
             {recordList.map((r) => {
               const m = r.manifest
               const running = m.id in loadedPlugins
+              const declaredPermissions: PluginPermission[] = m.permissions ?? []
+              const revoked = new Set<PluginPermission>(r.revokedPermissions ?? [])
               return (
-                <li key={m.id} className="p-3 flex items-start justify-between gap-3">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-baseline gap-2">
-                      <span className="text-sm font-medium text-obsidianText">{m.name}</span>
-                      <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
-                        v{m.version}
-                      </span>
-                      {running ? (
-                        <span className="text-[10px] uppercase tracking-wide text-emerald-300">
-                          running
-                        </span>
-                      ) : (
+                <li key={m.id} className="p-3 flex flex-col gap-2">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-baseline gap-2">
+                        <span className="text-sm font-medium text-obsidianText">{m.name}</span>
                         <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
-                          stopped
+                          v{m.version}
                         </span>
-                      )}
+                        {running ? (
+                          <span className="text-[10px] uppercase tracking-wide text-emerald-300">
+                            running
+                          </span>
+                        ) : (
+                          <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
+                            stopped
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-xs text-obsidianSecondaryText mt-0.5">
+                        <code className="text-[11px] bg-obsidianHighlight/40 px-1 rounded">{m.id}</code>
+                        {m.author && <span> · by {m.author}</span>}
+                      </div>
+                      <div className="text-[11px] text-obsidianSecondaryText/80 mt-1 truncate">
+                        from {r.sourceUrl}
+                      </div>
                     </div>
-                    <div className="text-xs text-obsidianSecondaryText mt-0.5">
-                      <code className="text-[11px] bg-obsidianHighlight/40 px-1 rounded">{m.id}</code>
-                      {m.author && <span> · by {m.author}</span>}
-                    </div>
-                    <div className="text-[11px] text-obsidianSecondaryText/80 mt-1 truncate">
-                      from {r.sourceUrl}
+                    <div className="flex flex-col items-end gap-1">
+                      <label className="flex items-center gap-1 text-xs text-obsidianText cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={r.enabled}
+                          onChange={(e) => setEnabled(m.id, e.target.checked)}
+                        />
+                        Enabled
+                      </label>
+                      <div className="flex gap-1">
+                        <button
+                          type="button"
+                          onClick={() => window.location.reload()}
+                          title="Reload page to re-boot the plugin"
+                          className="p-1 rounded hover:bg-obsidianHighlight/40 text-obsidianSecondaryText hover:text-obsidianText"
+                        >
+                          <ArrowPathIcon className="w-4 h-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleUninstall(m.id)}
+                          title="Uninstall"
+                          className="p-1 rounded hover:bg-obsidianHighlight/40 text-obsidianSecondaryText hover:text-red-300"
+                        >
+                          <TrashIcon className="w-4 h-4" />
+                        </button>
+                      </div>
                     </div>
                   </div>
-                  <div className="flex flex-col items-end gap-1">
-                    <label className="flex items-center gap-1 text-xs text-obsidianText cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={r.enabled}
-                        onChange={(e) => setEnabled(m.id, e.target.checked)}
-                      />
-                      Enabled
-                    </label>
-                    <div className="flex gap-1">
-                      <button
-                        type="button"
-                        onClick={() => window.location.reload()}
-                        title="Reload page to re-boot the plugin"
-                        className="p-1 rounded hover:bg-obsidianHighlight/40 text-obsidianSecondaryText hover:text-obsidianText"
-                      >
-                        <ArrowPathIcon className="w-4 h-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => handleUninstall(m.id)}
-                        title="Uninstall"
-                        className="p-1 rounded hover:bg-obsidianHighlight/40 text-obsidianSecondaryText hover:text-red-300"
-                      >
-                        <TrashIcon className="w-4 h-4" />
-                      </button>
+                  {declaredPermissions.length > 0 && (
+                    <div
+                      className="border-t border-obsidianBorder pt-2 mt-1 space-y-2"
+                      data-testid={`settings-plugins-permissions-${m.id}`}
+                    >
+                      <div className="text-[11px] uppercase tracking-wide text-obsidianSecondaryText">
+                        Permissions
+                      </div>
+                      {declaredPermissions.map((perm) => (
+                        <label
+                          key={perm}
+                          className="flex items-start gap-2 text-xs text-obsidianText cursor-pointer"
+                          data-testid={`settings-plugins-permission-${m.id}-${perm}`}
+                        >
+                          <input
+                            type="checkbox"
+                            className="mt-0.5"
+                            checked={!revoked.has(perm)}
+                            onChange={(e) =>
+                              setPluginPermissionRevoked(m.id, perm, !e.target.checked)
+                            }
+                          />
+                          <span className="flex-1">
+                            <span className="font-medium">{perm}</span>
+                            <span className="block text-[11px] text-obsidianSecondaryText/80 mt-0.5">
+                              {PERMISSION_DESCRIPTIONS[perm]}
+                            </span>
+                            {revoked.has(perm) && (
+                              <span className="block text-[11px] text-amber-300 mt-0.5">
+                                Revoked — the plugin&apos;s next call to this capability will be rejected.
+                              </span>
+                            )}
+                          </span>
+                        </label>
+                      ))}
                     </div>
-                  </div>
+                  )}
                 </li>
               )
             })}

--- a/src/plugins/PluginHost.ts
+++ b/src/plugins/PluginHost.ts
@@ -13,8 +13,9 @@ import {
   MAX_MESSAGES_PER_SECOND,
   type HostToWorker,
   type WorkerToHost,
+  type NoteWithBodyWire,
 } from './protocol'
-import type { PluginManifest } from './manifest'
+import type { PluginManifest, PluginPermission } from './manifest'
 
 export interface InstalledPlugin {
   manifest: PluginManifest
@@ -24,6 +25,13 @@ export interface InstalledPlugin {
   /** undefined when the plugin is loaded but not yet ready (boot in
    *  flight); set once worker:ready arrives. */
   ready: boolean
+  /** Capability identifiers the user has REVOKED at runtime, after the
+   *  plugin was already installed. The manifest's `permissions` list is
+   *  the declared grant; this set wins over it. Used by the Settings →
+   *  Plugins revocation toggle (v1.2). The host treats a revoked
+   *  capability as if it was never granted and replies with
+   *  `Permission "<name>" was revoked.` to the next call. */
+  revokedPermissions: Set<PluginPermission>
 }
 
 export interface PluginHostOptions {
@@ -70,6 +78,14 @@ export type PluginHostEvent =
       pluginId: string
       requestSeq: number
       accept?: string[]
+    }
+  | {
+      type: 'vaultReadRequested'
+      pluginId: string
+      requestSeq: number
+      mode: 'all' | 'one' | 'stream'
+      noteId?: string
+      chunkSize?: number
     }
   | { type: 'rateLimited'; pluginId: string }
 
@@ -142,6 +158,7 @@ export class PluginHost {
       lastMessageWindowStart: nowMs(),
       messagesInWindow: 0,
       ready: false,
+      revokedPermissions: new Set<PluginPermission>(),
     }
     const entry: WorkerEntry = { plugin, worker }
     this.workers.set(pluginId, entry)
@@ -253,6 +270,43 @@ export class PluginHost {
       source: args.source,
       blockId: args.blockId,
     })
+  }
+
+  /**
+   * Settings → Plugins toggles per-capability grants here. Marks the
+   * permission as revoked for the loaded plugin; subsequent capability
+   * calls reject with `'Permission "<name>" was revoked.'`. The
+   * manifest's declared permission list is unchanged — revocation is
+   * runtime-only and resets on app boot.
+   *
+   * Pre-existing pending requests (e.g. a `getAllNotes()` Promise
+   * already in flight) complete via the same response envelope; if
+   * they have not yet been answered the host short-circuits them with
+   * the same revocation error.
+   */
+  revokePermission(pluginId: string, permission: PluginPermission): void {
+    const entry = this.workers.get(pluginId)
+    if (!entry) return
+    entry.plugin.revokedPermissions.add(permission)
+  }
+
+  /** Inverse of `revokePermission`. Lets the Settings toggle restore a
+   *  capability without re-installing the plugin. */
+  restorePermission(pluginId: string, permission: PluginPermission): void {
+    const entry = this.workers.get(pluginId)
+    if (!entry) return
+    entry.plugin.revokedPermissions.delete(permission)
+  }
+
+  /** True when the manifest declared the capability AND the user has
+   *  not revoked it at runtime. The Settings panel reads this to
+   *  decide whether to render the toggle as on or off. */
+  hasPermission(pluginId: string, permission: PluginPermission): boolean {
+    const entry = this.workers.get(pluginId)
+    if (!entry) return false
+    const declared = entry.plugin.manifest.permissions?.includes(permission) ?? false
+    if (!declared) return false
+    return !entry.plugin.revokedPermissions.has(permission)
   }
 
   // ── private ─────────────────────────────────────────────────────────────
@@ -387,7 +441,73 @@ export class PluginHost {
         })
         return
       }
+
+      case 'worker:requestVaultRead': {
+        // v1.2 capability — every mode is gated on the same
+        // `vault.read.all` permission. Two layers:
+        //   1. declared at install: rejected with "did not declare".
+        //   2. declared but revoked at runtime: rejected with "revoked".
+        // The plugin sees the same Promise rejection either way, but
+        // the error string is distinct so the dev console clarifies.
+        const declared = entry.plugin.manifest.permissions?.includes('vault.read.all') ?? false
+        if (!declared) {
+          this.respondVaultReadError(
+            pluginId,
+            msg.seq,
+            msg.mode,
+            'Plugin did not declare the `vault.read.all` permission.',
+          )
+          return
+        }
+        if (entry.plugin.revokedPermissions.has('vault.read.all')) {
+          this.respondVaultReadError(
+            pluginId,
+            msg.seq,
+            msg.mode,
+            'Permission "vault.read.all" was revoked.',
+          )
+          return
+        }
+        if (msg.mode === 'one' && typeof msg.noteId !== 'string') {
+          this.respondVaultReadError(
+            pluginId,
+            msg.seq,
+            msg.mode,
+            'vault.read.getNote requires a string id.',
+          )
+          return
+        }
+        this.emit({
+          type: 'vaultReadRequested',
+          pluginId,
+          requestSeq: msg.seq,
+          mode: msg.mode,
+          ...(typeof msg.noteId === 'string' ? { noteId: msg.noteId } : {}),
+          ...(typeof msg.chunkSize === 'number' ? { chunkSize: msg.chunkSize } : {}),
+        })
+        return
+      }
     }
+  }
+
+  /** Helper: emit the right error envelope for a vault-read failure.
+   *  `'stream'` mode uses the streaming envelope so the worker's
+   *  AsyncIterable terminates with the error instead of dangling. */
+  private respondVaultReadError(
+    pluginId: string,
+    requestSeq: number,
+    mode: 'all' | 'one' | 'stream',
+    error: string,
+  ): void {
+    if (mode === 'stream') {
+      this.respondVaultStreamChunk(pluginId, requestSeq, {
+        chunkIndex: 0,
+        notes: [],
+        error,
+      })
+      return
+    }
+    this.respondVaultRead(pluginId, requestSeq, { ok: false, error })
   }
 
   /** Surface adapter / singleton wires the native save dialog here.
@@ -403,6 +523,52 @@ export class PluginHost {
       requestSeq,
       ok: result.ok,
       ...(result.ok ? {} : { error: result.error }),
+    })
+  }
+
+  /** Singleton adapter wires the live note-store snapshot here.
+   *  Modes `'all'` / `'one'` come back on this envelope; `'stream'`
+   *  uses `respondVaultStreamChunk` instead. Exactly one of `notes` /
+   *  `note` is set on success. */
+  respondVaultRead(
+    pluginId: string,
+    requestSeq: number,
+    result:
+      | { ok: true; notes: ReadonlyArray<NoteWithBodyWire>; note?: undefined }
+      | { ok: true; note: NoteWithBodyWire | null; notes?: undefined }
+      | { ok: false; error: string },
+  ): void {
+    this.send(pluginId, {
+      type: 'host:vaultReadResult',
+      seq: ++this.seqCounter,
+      requestSeq,
+      ok: result.ok,
+      ...(result.ok && result.notes !== undefined ? { notes: result.notes } : {}),
+      ...(result.ok && result.note !== undefined ? { note: result.note } : {}),
+      ...(!result.ok ? { error: result.error } : {}),
+    })
+  }
+
+  /** Emit one chunk of a vault-stream response. The adapter calls this
+   *  once per page; a chunk with `notes: []` (no error) terminates the
+   *  iterator successfully. An `error` on any chunk terminates with a
+   *  rejection. */
+  respondVaultStreamChunk(
+    pluginId: string,
+    requestSeq: number,
+    chunk: {
+      chunkIndex: number
+      notes: ReadonlyArray<NoteWithBodyWire>
+      error?: string
+    },
+  ): void {
+    this.send(pluginId, {
+      type: 'host:vaultStreamChunk',
+      seq: ++this.seqCounter,
+      requestSeq,
+      chunkIndex: chunk.chunkIndex,
+      notes: chunk.notes,
+      ...(chunk.error ? { error: chunk.error } : {}),
     })
   }
 

--- a/src/plugins/__tests__/vaultRead.test.ts
+++ b/src/plugins/__tests__/vaultRead.test.ts
@@ -1,0 +1,489 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Plugin API v1.2 PR C — `vault.read.all` capability.
+ *
+ * Coverage:
+ *   - Manifest validator accepts the new permission and rejects unknown
+ *     variants.
+ *   - Host snapshot returns the live note-store contents, parsed
+ *     frontmatter included.
+ *   - The chunked stream emits the right slice counts at chunkSize=1,
+ *     100, and clamps to the 500-note ceiling on oversized requests.
+ *   - PluginHost rejects `worker:requestVaultRead` when the permission
+ *     was not declared or was revoked at runtime.
+ *
+ * The PluginHost tests inject a FakeWorker (real Web Workers are not
+ * available in Jest) to assert the message routing without spinning
+ * up the real worker entry. The snapshot tests drive the real
+ * Zustand stores via their setState API.
+ */
+
+import { validateManifest, PERMISSIONS, PERMISSION_DESCRIPTIONS } from '@/plugins/manifest'
+import { PluginHost, type MinimalWorker } from '@/plugins/PluginHost'
+import type { HostToWorker, WorkerToHost } from '@/plugins/protocol'
+import {
+  snapshotAllNotes,
+  snapshotNoteById,
+  streamVaultSnapshot,
+  resetVaultSnapshotCacheForTests,
+  computeVaultSha,
+  MAX_STREAM_CHUNK_SIZE,
+} from '@/plugins/vaultSnapshot'
+import { useNoteStore } from '@/stores/noteStore'
+import { useFolderStore } from '@/stores/folderStore'
+import type { Note } from '@/types'
+
+function makeNote(over: Partial<Note> & { id: string; title: string }): Note {
+  return {
+    folderId: null,
+    content: '',
+    createdAt: 1,
+    updatedAt: 1,
+    isDeleted: false,
+    deletedAt: null,
+    isPinned: false,
+    templateId: null,
+    ...over,
+  } as Note
+}
+
+function seedStore(notes: Note[]): void {
+  resetVaultSnapshotCacheForTests()
+  useNoteStore.setState({ notes, selectedNoteId: null })
+  useFolderStore.setState({ folders: [] })
+}
+
+afterEach(() => {
+  resetVaultSnapshotCacheForTests()
+  useNoteStore.setState({ notes: [], selectedNoteId: null })
+  useFolderStore.setState({ folders: [] })
+})
+
+describe('manifest accepts vault.read.all', () => {
+  const base = {
+    id: 'echo',
+    name: 'Echo',
+    version: '1.0.0',
+    surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+  }
+
+  test('vault.read.all is in the PERMISSIONS list and has a description', () => {
+    expect((PERMISSIONS as readonly string[]).includes('vault.read.all')).toBe(true)
+    expect(typeof PERMISSION_DESCRIPTIONS['vault.read.all']).toBe('string')
+    expect(PERMISSION_DESCRIPTIONS['vault.read.all'].length).toBeGreaterThan(0)
+  })
+
+  test('validator accepts vault.read.all alongside v1.1 permissions', () => {
+    const r = validateManifest({ ...base, permissions: ['file-open', 'vault.read.all'] })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.permissions).toEqual(['file-open', 'vault.read.all'])
+  })
+
+  test('validator still rejects unknown permissions', () => {
+    const r = validateManifest({ ...base, permissions: ['vault.read.all', 'vault.write'] })
+    expect(r.ok).toBe(false)
+    // Error must mention the unknown one specifically.
+    expect(r.errors.some((e) => e.includes('vault.write'))).toBe(true)
+  })
+
+  test('validator deduplicates a repeated vault.read.all', () => {
+    const r = validateManifest({ ...base, permissions: ['vault.read.all', 'vault.read.all'] })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.permissions).toEqual(['vault.read.all'])
+  })
+})
+
+describe('host snapshot', () => {
+  test('snapshotAllNotes returns every non-deleted note with body + frontmatter', () => {
+    seedStore([
+      makeNote({
+        id: 'a',
+        title: 'A',
+        content: '---\nstatus: draft\ntags: [x, y]\n---\nBody A',
+        updatedAt: 100,
+      }),
+      makeNote({ id: 'b', title: 'B', content: 'Plain body', updatedAt: 200 }),
+      makeNote({
+        id: 'gone',
+        title: 'Gone',
+        content: 'deleted',
+        isDeleted: true,
+        deletedAt: 300,
+      }),
+    ])
+
+    const snap = snapshotAllNotes()
+    expect(snap).toHaveLength(2)
+    const a = snap.find((n) => n.id === 'a')!
+    expect(a.body).toBe('Body A')
+    expect(a.frontmatter).toEqual({ status: 'draft', tags: ['x', 'y'] })
+    const b = snap.find((n) => n.id === 'b')!
+    expect(b.body).toBe('Plain body')
+    expect(b.frontmatter).toBeNull()
+  })
+
+  test('snapshotAllNotes caches by SHA — second call is the same array', () => {
+    seedStore([makeNote({ id: 'a', title: 'A', content: 'x', updatedAt: 1 })])
+    const first = snapshotAllNotes()
+    const second = snapshotAllNotes()
+    expect(second).toBe(first)
+  })
+
+  test('snapshotAllNotes invalidates when a note updates', () => {
+    seedStore([makeNote({ id: 'a', title: 'A', content: 'x', updatedAt: 1 })])
+    const first = snapshotAllNotes()
+    useNoteStore.setState({
+      notes: [makeNote({ id: 'a', title: 'A', content: 'y', updatedAt: 2 })],
+    })
+    const second = snapshotAllNotes()
+    expect(second).not.toBe(first)
+    expect(second[0].body).toBe('y')
+  })
+
+  test('snapshotNoteById returns null for deleted / unknown notes', () => {
+    seedStore([
+      makeNote({ id: 'a', title: 'A', content: 'x', updatedAt: 1 }),
+      makeNote({ id: 'b', title: 'B', content: 'y', isDeleted: true, deletedAt: 1 }),
+    ])
+    expect(snapshotNoteById('a')?.body).toBe('x')
+    expect(snapshotNoteById('b')).toBeNull()
+    expect(snapshotNoteById('missing')).toBeNull()
+  })
+
+  test('computeVaultSha changes when content updates', () => {
+    seedStore([makeNote({ id: 'a', title: 'A', content: 'x', updatedAt: 1 })])
+    const a = computeVaultSha()
+    useNoteStore.setState({
+      notes: [makeNote({ id: 'a', title: 'A', content: 'y', updatedAt: 2 })],
+    })
+    expect(computeVaultSha()).not.toBe(a)
+  })
+})
+
+describe('chunked stream', () => {
+  function seedN(n: number): void {
+    const notes: Note[] = []
+    for (let i = 0; i < n; i++) {
+      notes.push(
+        makeNote({ id: `n${i}`, title: `N${i}`, content: `body ${i}`, updatedAt: i + 1 }),
+      )
+    }
+    seedStore(notes)
+  }
+
+  test('chunkSize=1 yields one chunk per note', async () => {
+    seedN(5)
+    const sizes: number[] = []
+    await streamVaultSnapshot({
+      chunkSize: 1,
+      onChunk: (slice) => {
+        sizes.push(slice.length)
+      },
+    })
+    expect(sizes).toEqual([1, 1, 1, 1, 1])
+  })
+
+  test('chunkSize=100 yields one chunk for 50 notes', async () => {
+    seedN(50)
+    const sizes: number[] = []
+    await streamVaultSnapshot({
+      chunkSize: 100,
+      onChunk: (slice) => {
+        sizes.push(slice.length)
+      },
+    })
+    expect(sizes).toEqual([50])
+  })
+
+  test('chunkSize=100 yields three chunks for 250 notes', async () => {
+    seedN(250)
+    const sizes: number[] = []
+    await streamVaultSnapshot({
+      chunkSize: 100,
+      onChunk: (slice) => {
+        sizes.push(slice.length)
+      },
+    })
+    expect(sizes).toEqual([100, 100, 50])
+  })
+
+  test('chunkSize is clamped to MAX_STREAM_CHUNK_SIZE', async () => {
+    seedN(MAX_STREAM_CHUNK_SIZE + 10)
+    const sizes: number[] = []
+    await streamVaultSnapshot({
+      chunkSize: MAX_STREAM_CHUNK_SIZE * 4,
+      onChunk: (slice) => {
+        sizes.push(slice.length)
+      },
+    })
+    // Two chunks — clamped to 500 each, last is the remainder.
+    expect(sizes[0]).toBe(MAX_STREAM_CHUNK_SIZE)
+    expect(sizes[1]).toBe(10)
+  })
+
+  test('isAborted terminates the stream with onAbort + no further chunks', async () => {
+    seedN(20)
+    const sizes: number[] = []
+    let aborted: string | null = null
+    let chunks = 0
+    await streamVaultSnapshot({
+      chunkSize: 5,
+      isAborted: () => (chunks >= 2 ? 'Permission "vault.read.all" was revoked.' : null),
+      onChunk: (slice) => {
+        chunks++
+        sizes.push(slice.length)
+      },
+      onAbort: (reason) => {
+        aborted = reason
+      },
+    })
+    expect(sizes).toEqual([5, 5])
+    expect(aborted).toBe('Permission "vault.read.all" was revoked.')
+  })
+
+  test('end-of-stream onEnd fires after the last chunk', async () => {
+    seedN(3)
+    const order: string[] = []
+    await streamVaultSnapshot({
+      chunkSize: 2,
+      onChunk: (slice) => {
+        order.push(`chunk:${slice.length}`)
+      },
+      onEnd: () => {
+        order.push('end')
+      },
+    })
+    expect(order).toEqual(['chunk:2', 'chunk:1', 'end'])
+  })
+})
+
+// ─── PluginHost wire-protocol gate ──────────────────────────────────────
+
+interface FakeWorkerHandle {
+  worker: MinimalWorker
+  sent: HostToWorker[]
+  inject: (data: unknown) => void
+}
+
+function makeFakeWorker(manifest: {
+  id: string
+  name: string
+  version: string
+  surfaces: object
+  permissions?: string[]
+}): FakeWorkerHandle {
+  const sent: HostToWorker[] = []
+  let handler: ((event: MessageEvent) => void) | null = null
+  const worker: MinimalWorker = {
+    onmessage: null,
+    postMessage(message: unknown) {
+      sent.push(message as HostToWorker)
+      const msg = message as HostToWorker
+      if (msg.type === 'host:boot') {
+        queueMicrotask(() => {
+          handler?.({
+            data: { type: 'worker:ready', seq: msg.seq, manifest } as WorkerToHost,
+          } as MessageEvent)
+        })
+      }
+    },
+    terminate() {
+      handler = null
+    },
+  } as MinimalWorker
+  Object.defineProperty(worker, 'onmessage', {
+    configurable: true,
+    get() {
+      return handler
+    },
+    set(v) {
+      handler = v
+    },
+  })
+  return {
+    worker,
+    sent,
+    inject(data: unknown) {
+      handler?.({ data } as MessageEvent)
+    },
+  }
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('PluginHost vault.read.all gate', () => {
+  test('refuses worker:requestVaultRead when permission not declared', async () => {
+    const fake = makeFakeWorker({
+      id: 'no-perm',
+      name: 'No perm',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'no-perm', pluginSource: '' })
+
+    fake.inject({ type: 'worker:requestVaultRead', seq: 5, mode: 'all' })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultReadResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultReadResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.requestSeq).toBe(5)
+      expect(reply.error).toMatch(/vault\.read\.all/)
+    }
+  })
+
+  test('refuses stream-mode request with a terminal chunk on no-permission', async () => {
+    const fake = makeFakeWorker({
+      id: 'no-perm2',
+      name: 'No perm 2',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'no-perm2', pluginSource: '' })
+
+    fake.inject({ type: 'worker:requestVaultRead', seq: 7, mode: 'stream' })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultStreamChunk')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultStreamChunk') {
+      expect(reply.requestSeq).toBe(7)
+      expect(reply.notes).toEqual([])
+      expect(reply.error).toMatch(/vault\.read\.all/)
+    }
+  })
+
+  test('emits vaultReadRequested when permission IS declared', async () => {
+    const fake = makeFakeWorker({
+      id: 'ok',
+      name: 'OK',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.read.all'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const events: string[] = []
+    host.on((e) => events.push(e.type))
+    await host.load({ pluginId: 'ok', pluginSource: '' })
+
+    fake.inject({ type: 'worker:requestVaultRead', seq: 11, mode: 'all' })
+    await flush()
+
+    expect(events).toContain('vaultReadRequested')
+    // No early rejection.
+    const earlyError = fake.sent.find(
+      (m) => m.type === 'host:vaultReadResult' && m.ok === false,
+    )
+    expect(earlyError).toBeUndefined()
+  })
+
+  test('revocation rejects the next call', async () => {
+    const fake = makeFakeWorker({
+      id: 'revokee',
+      name: 'Revokee',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.read.all'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'revokee', pluginSource: '' })
+
+    host.revokePermission('revokee', 'vault.read.all')
+    fake.inject({ type: 'worker:requestVaultRead', seq: 13, mode: 'all' })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultReadResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultReadResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.requestSeq).toBe(13)
+      expect(reply.error).toMatch(/revoked/)
+    }
+  })
+
+  test('restorePermission re-enables after a revoke', async () => {
+    const fake = makeFakeWorker({
+      id: 'flap',
+      name: 'Flap',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.read.all'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const events: string[] = []
+    host.on((e) => events.push(e.type))
+    await host.load({ pluginId: 'flap', pluginSource: '' })
+
+    host.revokePermission('flap', 'vault.read.all')
+    expect(host.hasPermission('flap', 'vault.read.all')).toBe(false)
+    host.restorePermission('flap', 'vault.read.all')
+    expect(host.hasPermission('flap', 'vault.read.all')).toBe(true)
+
+    fake.inject({ type: 'worker:requestVaultRead', seq: 17, mode: 'all' })
+    await flush()
+    expect(events).toContain('vaultReadRequested')
+  })
+
+  test('respondVaultRead routes the snapshot back to the worker', async () => {
+    const fake = makeFakeWorker({
+      id: 'h',
+      name: 'H',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.read.all'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'h', pluginSource: '' })
+
+    host.respondVaultRead('h', 99, {
+      ok: true,
+      notes: [
+        { id: 'a', title: 'A', folderPath: '', body: 'x', frontmatter: null, updatedAt: 1 },
+      ],
+    })
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultReadResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultReadResult') {
+      expect(reply.ok).toBe(true)
+      expect(reply.requestSeq).toBe(99)
+      expect(reply.notes?.[0].id).toBe('a')
+    }
+  })
+
+  test('respondVaultStreamChunk passes chunkIndex + notes through', async () => {
+    const fake = makeFakeWorker({
+      id: 's',
+      name: 'S',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.read.all'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 's', pluginSource: '' })
+
+    host.respondVaultStreamChunk('s', 21, {
+      chunkIndex: 1,
+      notes: [
+        { id: 'a', title: 'A', folderPath: '', body: 'x', frontmatter: null, updatedAt: 1 },
+      ],
+    })
+    host.respondVaultStreamChunk('s', 21, { chunkIndex: 2, notes: [] })
+
+    const chunks = fake.sent.filter((m) => m.type === 'host:vaultStreamChunk') as Array<
+      Extract<HostToWorker, { type: 'host:vaultStreamChunk' }>
+    >
+    expect(chunks).toHaveLength(2)
+    expect(chunks[0].chunkIndex).toBe(1)
+    expect(chunks[0].notes).toHaveLength(1)
+    expect(chunks[1].chunkIndex).toBe(2)
+    expect(chunks[1].notes).toHaveLength(0)
+  })
+})

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -28,10 +28,19 @@ export interface PluginManifest {
   permissions?: PluginPermission[]
 }
 
-/** v1.1 capability identifiers. Unknown values are rejected by the
- *  validator. The host gates each runtime capability call against the
- *  granted set stored alongside the install record. */
-export const PERMISSIONS = ['file-save', 'file-open'] as const
+/** Capability identifiers known to the host. Unknown values are rejected
+ *  by the validator. The host gates each runtime capability call against
+ *  the granted set stored alongside the install record.
+ *
+ *  v1.1 added the two `file-*` capabilities; v1.2 starts layering the
+ *  vault / fs capabilities. `vault.read.all` is the first of the v1.2
+ *  set — it lets a plugin read every note's body + frontmatter, which
+ *  backlinks, AI-RAG, and graph-derivation plugins all need. */
+export const PERMISSIONS = [
+  'file-save',       // v1.1
+  'file-open',       // v1.1
+  'vault.read.all',  // v1.2 — see docs/plugins-v1.2-plan.md §4.1
+] as const
 export type PluginPermission = (typeof PERMISSIONS)[number]
 
 /** Human-readable text shown to the user in the install confirmation
@@ -39,6 +48,8 @@ export type PluginPermission = (typeof PERMISSIONS)[number]
 export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
   'file-save': 'Save a file to your computer (opens the native save dialog when the plugin needs to write a file).',
   'file-open': 'Read a file you pick (opens the native file picker; the plugin sees the bytes of the file you choose, nothing else).',
+  'vault.read.all':
+    'Read the full content of every note in your vault. Required for features like backlinks, graph views, and AI search.',
 }
 
 /** Surface kinds the manifest can declare. Used by the install-preview

--- a/src/plugins/pluginHostSingleton.ts
+++ b/src/plugins/pluginHostSingleton.ts
@@ -26,6 +26,13 @@ import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { fetchPluginFromUrl, fetchPluginFromManifest, sha256Hex } from './installer'
 import type { VaultManifestCandidate } from './vaultScan'
 import { bootMark, bootMeasure, yieldToMain } from '@/utils/bootTrace'
+import {
+  snapshotAllNotes,
+  snapshotNoteById,
+  streamVaultSnapshot,
+  projectPayloadSize,
+  MAX_GET_ALL_BYTES,
+} from './vaultSnapshot'
 
 let instance: PluginHost | null = null
 
@@ -124,6 +131,13 @@ export async function confirmAndInstallPlugin(record: InstalledPluginRecord): Pr
     pluginId: record.manifest.id,
     pluginSource: record.mainSource,
   })
+  // Apply any persisted revocations from previous sessions. Without
+  // this a user who revokes a capability, restarts the app, and lets
+  // the bootstrap reload the plugin would silently regain the
+  // capability on next call.
+  for (const perm of record.revokedPermissions ?? []) {
+    host.revokePermission(record.manifest.id, perm)
+  }
 }
 
 /**
@@ -182,6 +196,14 @@ export async function bootstrapInstalledPlugins(): Promise<void> {
         pluginId: record.manifest.id,
         pluginSource: record.mainSource,
       })
+      // Re-apply persisted capability revocations from previous
+      // sessions before the worker gets a chance to make any
+      // capability call from onActivate (the load() above already
+      // ran onActivate, but the worker can also fire requests on
+      // the next event loop tick — better to apply right away).
+      for (const perm of record.revokedPermissions ?? []) {
+        host.revokePermission(record.manifest.id, perm)
+      }
     } catch (err) {
       // The host emits bootError separately, which lands in the toast
       // via the listener. Swallow here so one bad plugin does not
@@ -193,6 +215,27 @@ export async function bootstrapInstalledPlugins(): Promise<void> {
 
   bootMark('plugin-bootstrap:end')
   bootMeasure('plugin-bootstrap', 'plugin-bootstrap:start', 'plugin-bootstrap:end')
+}
+
+/**
+ * Toggle a capability grant for an already-installed plugin. Writes
+ * through to BOTH the persisted install record (so the change survives
+ * a reload) and the in-memory PluginHost (so the next capability call
+ * from the running worker rejects immediately).
+ *
+ * No-op when the plugin is unknown. Idempotent for the same value.
+ */
+export function setPluginPermissionRevoked(
+  pluginId: string,
+  permission: import('./manifest').PluginPermission,
+  revoked: boolean,
+): void {
+  usePluginInstallStore.getState().setPermissionRevoked(pluginId, permission, revoked)
+  const host = getPluginHost()
+  if (host) {
+    if (revoked) host.revokePermission(pluginId, permission)
+    else host.restorePermission(pluginId, permission)
+  }
 }
 
 /**
@@ -360,8 +403,118 @@ function wireListener(host: PluginHost): void {
       case 'fileOpenRequested':
         void handleFileOpenRequest(host, event)
         return
+
+      case 'vaultReadRequested':
+        void handleVaultReadRequest(host, event)
+        return
     }
   })
+}
+
+/**
+ * Snapshot the active note store, serialise to plain objects, and post
+ * back to the plugin worker. The `vault.read.all` permission gate has
+ * already been checked in PluginHost; this handler only owns the
+ * snapshot + chunking work.
+ *
+ * Per the perf budget (docs/plugins-v1.2-plan.md §9 + issue #79) the
+ * snapshot may not block the main thread for more than 50 ms on a
+ * 5000-note vault. The streaming path yields between chunks via the
+ * shared `streamVaultSnapshot` helper; the one-shot `getAllNotes` path
+ * relies on the post-snapshot SHA cache (a second call within the same
+ * SHA is a single hash compare).
+ */
+async function handleVaultReadRequest(
+  host: PluginHost,
+  event: Extract<import('./PluginHost').PluginHostEvent, { type: 'vaultReadRequested' }>,
+): Promise<void> {
+  const { pluginId, requestSeq, mode, noteId, chunkSize } = event
+
+  // Guard: the note store hydrates from IndexedDB at boot. A plugin
+  // that fires `getAllNotes()` from `onActivate` may race the hydrate;
+  // surface a clear retry message instead of returning an empty array
+  // that the plugin would silently cache.
+  const notes = useNoteStore.getState().notes
+  const hasHydratedState = (useNoteStore as unknown as {
+    persist?: { hasHydrated: () => boolean }
+  }).persist
+  if (hasHydratedState && typeof hasHydratedState.hasHydrated === 'function' && !hasHydratedState.hasHydrated() && notes.length === 0) {
+    if (mode === 'stream') {
+      host.respondVaultStreamChunk(pluginId, requestSeq, {
+        chunkIndex: 0,
+        notes: [],
+        error: 'Vault not yet loaded.',
+      })
+    } else {
+      host.respondVaultRead(pluginId, requestSeq, { ok: false, error: 'Vault not yet loaded.' })
+    }
+    return
+  }
+
+  try {
+    if (mode === 'one') {
+      const note = snapshotNoteById(noteId ?? '')
+      host.respondVaultRead(pluginId, requestSeq, { ok: true, note })
+      return
+    }
+
+    if (mode === 'all') {
+      const snapshot = snapshotAllNotes()
+      const bytes = projectPayloadSize(snapshot)
+      if (bytes > MAX_GET_ALL_BYTES) {
+        host.respondVaultRead(pluginId, requestSeq, {
+          ok: false,
+          error: 'Vault too large; use stream().',
+        })
+        return
+      }
+      host.respondVaultRead(pluginId, requestSeq, { ok: true, notes: snapshot })
+      return
+    }
+
+    // mode === 'stream' — paginate, yielding between chunks. We poll
+    // the host's revocation state before every chunk so a mid-flight
+    // toggle in Settings terminates the iterator with a clear error.
+    let chunkIndexEmitted = 0
+    await streamVaultSnapshot({
+      ...(typeof chunkSize === 'number' ? { chunkSize } : {}),
+      isAborted: () =>
+        host.hasPermission(pluginId, 'vault.read.all')
+          ? null
+          : 'Permission "vault.read.all" was revoked.',
+      onChunk: (slice, chunkIndex) => {
+        chunkIndexEmitted = chunkIndex
+        host.respondVaultStreamChunk(pluginId, requestSeq, {
+          chunkIndex,
+          notes: slice,
+        })
+      },
+      onAbort: (reason) => {
+        host.respondVaultStreamChunk(pluginId, requestSeq, {
+          chunkIndex: chunkIndexEmitted + 1,
+          notes: [],
+          error: reason,
+        })
+      },
+      onEnd: () => {
+        host.respondVaultStreamChunk(pluginId, requestSeq, {
+          chunkIndex: chunkIndexEmitted + 1,
+          notes: [],
+        })
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (mode === 'stream') {
+      host.respondVaultStreamChunk(pluginId, requestSeq, {
+        chunkIndex: 0,
+        notes: [],
+        error: message,
+      })
+    } else {
+      host.respondVaultRead(pluginId, requestSeq, { ok: false, error: message })
+    }
+  }
 }
 
 /** Open the native save dialog, write the plugin's bytes to it.

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -34,6 +34,8 @@ export type HostToWorker =
   | HostFileSaveResult
   | HostFileOpenResult
   | HostVNodeEvent
+  | HostVaultReadResult
+  | HostVaultStreamChunk
 
 /** First message the host sends. Worker initialises the plugin module
  *  and replies with WorkerReady on success or WorkerBootError on failure. */
@@ -152,6 +154,62 @@ export interface HostVNodeEvent {
     | { kind: 'fullscreen'; viewId: string }
 }
 
+/** v1.2 capability: snapshot of one note's body / frontmatter, sent
+ *  across the worker bridge as a plain object. The host normalises
+ *  Uint8Arrays / Date / Map into plain types before serialising;
+ *  `frontmatter` is the host's parsed view (never raw YAML). */
+export interface NoteWithBodyWire {
+  id: string
+  title: string
+  folderPath: string
+  body: string
+  /** Plain JSON object or null. The host parses YAML; the worker never
+   *  sees raw YAML, so it cannot probe noteser-core parser bugs through
+   *  this surface. */
+  frontmatter: Record<string, unknown> | null
+  updatedAt: number
+}
+
+/** Host's reply to a `worker:requestVaultRead` in mode `'all'` or
+ *  `'one'`. v1.2 capability — requires `vault.read.all` permission.
+ *  `requestSeq` matches the seq the worker emitted so the plugin's
+ *  pending Promise resolves to the right call.
+ *
+ *  For `mode === 'all'` the host returns `notes`; for `'one'` it
+ *  returns a single `note` (or null when the id is unknown / deleted).
+ *  Errors land here when the permission was revoked, the vault has
+ *  not hydrated yet, or the projected payload exceeds
+ *  `MAX_ENVELOPE_BYTES` and the plugin should fall back to
+ *  `stream()`. */
+export interface HostVaultReadResult {
+  type: 'host:vaultReadResult'
+  seq: number
+  requestSeq: number
+  ok: boolean
+  notes?: ReadonlyArray<NoteWithBodyWire>
+  note?: NoteWithBodyWire | null
+  error?: string
+}
+
+/** One chunk of a vault-wide stream read. v1.2 capability — requires
+ *  `vault.read.all` permission. The host paginates over the in-memory
+ *  notes array on the main thread, chunks at `chunkSize` (capped at
+ *  500 to stay under `MAX_ENVELOPE_BYTES`), and emits one of these per
+ *  page.
+ *
+ *  Termination: a chunk with `notes: []` signals end-of-stream. A
+ *  non-empty `error` on any chunk terminates the iterator with that
+ *  error (used on mid-flight permission revocation). `chunkIndex` is
+ *  1-indexed and strictly increasing per `requestSeq`. */
+export interface HostVaultStreamChunk {
+  type: 'host:vaultStreamChunk'
+  seq: number
+  requestSeq: number
+  chunkIndex: number
+  notes: ReadonlyArray<NoteWithBodyWire>
+  error?: string
+}
+
 // ─── Worker → Host ─────────────────────────────────────────────────────────
 
 export type WorkerToHost =
@@ -164,6 +222,7 @@ export type WorkerToHost =
   | WorkerNotify
   | WorkerRequestFileSave
   | WorkerRequestFileOpen
+  | WorkerRequestVaultRead
   | WorkerError
 
 /** Sent in reply to host:boot once the plugin module loaded and
@@ -259,6 +318,34 @@ export interface WorkerRequestFileOpen {
   accept?: string[]
 }
 
+/** Plugin asking the host for vault-wide note reads. v1.2 capability —
+ *  requires `vault.read.all` permission.
+ *
+ *  Three modes:
+ *  - `'all'`     — return every non-deleted note in one response. Host
+ *                  rejects with `'Vault too large; use stream().'` when
+ *                  projected serialised size exceeds 4 MiB.
+ *  - `'one'`     — return a single note by id (or null when unknown /
+ *                  deleted). `noteId` is required.
+ *  - `'stream'`  — paginate over the vault in chunks. The host emits
+ *                  one `host:vaultStreamChunk` per page; the worker
+ *                  yields each chunk to the plugin's AsyncIterable.
+ *                  Default `chunkSize` is 100; max 500 (the spec
+ *                  ceiling, to stay under `MAX_ENVELOPE_BYTES`).
+ *
+ *  Host replies with `host:vaultReadResult` (modes `'all'` / `'one'`)
+ *  or a sequence of `host:vaultStreamChunk` carrying the same
+ *  `requestSeq`. */
+export interface WorkerRequestVaultRead {
+  type: 'worker:requestVaultRead'
+  seq: number
+  mode: 'all' | 'one' | 'stream'
+  /** Required when `mode === 'one'`. Ignored for the other modes. */
+  noteId?: string
+  /** Only meaningful for `mode === 'stream'`. Default 100, max 500. */
+  chunkSize?: number
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 export function isHostToWorker(msg: unknown): msg is HostToWorker {
@@ -272,6 +359,8 @@ export function isHostToWorker(msg: unknown): msg is HostToWorker {
     'host:fileSaveResult',
     'host:fileOpenResult',
     'host:vnodeEvent',
+    'host:vaultReadResult',
+    'host:vaultStreamChunk',
   ])
 }
 
@@ -287,6 +376,7 @@ export function isWorkerToHost(msg: unknown): msg is WorkerToHost {
     'worker:error',
     'worker:requestFileSave',
     'worker:requestFileOpen',
+    'worker:requestVaultRead',
   ])
 }
 

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -32,6 +32,21 @@ export type {
   SvgChild,
 } from './PluginVNode'
 
+/** A note's body + frontmatter as the host renders them. Returned by
+ *  the v1.2 `ctx.vault.read.*` family. Strings only — the host never
+ *  hands the worker a `Uint8Array` (postMessage clones it) or a raw
+ *  YAML string (the worker would have to re-parse, opening a fresh
+ *  parser-bug surface). */
+export interface NoteWithBody {
+  id: string
+  title: string
+  folderPath: string
+  body: string
+  /** Parsed by the host. `null` when the note has no frontmatter. */
+  frontmatter: Readonly<Record<string, unknown>> | null
+  updatedAt: number
+}
+
 /** Narrow capability surface exposed to plugin handlers. The plugin
  *  never sees `localStorage`, the GitHub token, or the bodies of notes
  *  it is not currently viewing. v1 read scope is intentionally tight:
@@ -82,6 +97,43 @@ export interface PluginCtx {
    * `['.pdf', 'application/pdf']`.
    */
   requestFileOpen(args?: { accept?: string[] }): Promise<{ bytes: Uint8Array; filename: string } | null>
+
+  /**
+   * v1.2 vault namespace. Always populated; methods reject when the
+   * matching permission was not granted or has been revoked. Plugins
+   * can catch and degrade. PR C wires the `read` sub-namespace; PRs
+   * D / F introduce `write` and `events` later.
+   *
+   * Spec reference: docs/plugins-v1.2-plan.md §4.1.
+   */
+  vault: {
+    read: {
+      /**
+       * Snapshot every non-deleted note in the vault. Resolves with a
+       * plain array of `NoteWithBody`. For very large vaults the host
+       * rejects with `'Vault too large; use stream().'`; plugins MUST
+       * fall back to `stream()` in that case.
+       *
+       * Requires `vault.read.all` permission.
+       */
+      getAllNotes(): Promise<ReadonlyArray<NoteWithBody>>
+
+      /** Resolve a single note by id. Returns null when the id is
+       *  unknown or the note has been soft-deleted. Requires
+       *  `vault.read.all` permission. */
+      getNote(id: string): Promise<NoteWithBody | null>
+
+      /**
+       * Paginate over the vault. Each iteration yields up to
+       * `chunkSize` notes (default 100, max 500). The iterator
+       * completes naturally when the vault is exhausted; it throws
+       * when the permission is revoked mid-stream.
+       *
+       * Requires `vault.read.all` permission.
+       */
+      stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
+    }
+  }
 }
 
 export interface PluginHandlers {

--- a/src/plugins/vaultSnapshot.ts
+++ b/src/plugins/vaultSnapshot.ts
@@ -1,0 +1,244 @@
+// Host-side snapshot of the vault, packaged for the `vault.read.all`
+// capability. The plugin Worker has no access to `useNoteStore` /
+// IndexedDB / the DOM; this module sits on the main thread and turns
+// the Zustand store into a plain-object array the host can post to the
+// worker bridge.
+//
+// Performance contract (docs/plugins-v1.2-plan.md §4.1 + perf #79):
+//   - The first call walks every non-deleted note and parses its
+//     frontmatter. On a 5000-note vault that is the dominant cost; the
+//     work is chunked over `requestIdleCallback` slices in the stream
+//     path so the main thread is never blocked for >50ms.
+//   - We cache the assembled array keyed by a vault snapshot SHA. A
+//     second `getAllNotes()` call within the same SHA returns the
+//     cached array instantly. The SHA is a cheap rolling hash of the
+//     `(id, updatedAt)` pairs of every note + every folder — not a
+//     cryptographic digest, just an identity key.
+//
+// What this module does NOT do:
+//   - It does not post any messages itself. PluginHost handles the
+//     protocol; this module hands it a plain array.
+//   - It does not honour the `vault.read.all` permission gate — that
+//     check lives in PluginHost, before this module is reached.
+
+import { useNoteStore } from '@/stores/noteStore'
+import { useFolderStore } from '@/stores/folderStore'
+import { parseFrontmatter } from '@/utils/frontmatter'
+import type { Note, Folder } from '@/types'
+import type { NoteWithBodyWire } from './protocol'
+
+/** Max projected serialised payload for `getAllNotes()` before the
+ *  host forces the plugin to use `stream()`. Two orders of magnitude
+ *  more than `MAX_ENVELOPE_BYTES` is intentional — `getAllNotes` is
+ *  meant for small vaults and dev plugins; the stream path is for the
+ *  general case. */
+export const MAX_GET_ALL_BYTES = 4 * 1024 * 1024 // 4 MiB
+
+/** Cached snapshot, keyed by the vault SHA. */
+let cached: { sha: string; notes: ReadonlyArray<NoteWithBodyWire> } | null = null
+
+/** Identity-cached folder-path map. Recomputed when the folders array
+ *  identity changes (Zustand replaces it on every mutation). */
+let folderPathCache: { folders: ReadonlyArray<Folder>; byId: Map<string, string> } | null = null
+
+/**
+ * Build a cheap identity hash from the live store's `(id, updatedAt)`
+ * pairs plus folder ids. NOT cryptographic — only used to detect
+ * whether the cached snapshot is still valid.
+ */
+export function computeVaultSha(): string {
+  const notes = useNoteStore.getState().notes
+  const folders = useFolderStore.getState().folders
+  // FNV-1a 32-bit. Fast, deterministic, plenty for cache-key duty.
+  let h = 0x811c9dc5
+  const mix = (s: string): void => {
+    for (let i = 0; i < s.length; i++) {
+      h ^= s.charCodeAt(i)
+      h = (h + ((h << 1) | 0) + ((h << 4) | 0) + ((h << 7) | 0) + ((h << 8) | 0) + ((h << 24) | 0)) | 0
+    }
+  }
+  mix(`n:${notes.length}`)
+  for (let i = 0; i < notes.length; i++) {
+    const n = notes[i]
+    if (n.isDeleted) continue
+    mix(`${n.id}|${n.updatedAt}|`)
+  }
+  mix(`f:${folders.length}`)
+  for (let i = 0; i < folders.length; i++) {
+    const f = folders[i]
+    mix(`${f.id}|${f.parentId ?? '_'}|${f.name}|`)
+  }
+  // Force unsigned, hex-encode.
+  return ((h >>> 0) >>> 0).toString(16)
+}
+
+/** Reset the cache. Tests + the host invalidate this on permission
+ *  revocation so a follow-up call rebuilds against the live store. */
+export function resetVaultSnapshotCacheForTests(): void {
+  cached = null
+  folderPathCache = null
+}
+
+/**
+ * Synchronously snapshot the entire (non-deleted) vault into wire
+ * objects. Cheap when the cache is warm (single SHA compare); ~tens of
+ * ms on a 5000-note cold call because frontmatter parsing dominates.
+ *
+ * For large vaults the caller should prefer the streaming path so the
+ * main thread is never blocked for >50ms — `streamVaultSnapshot`
+ * cooperatively yields between chunks.
+ */
+export function snapshotAllNotes(): ReadonlyArray<NoteWithBodyWire> {
+  const sha = computeVaultSha()
+  if (cached && cached.sha === sha) return cached.notes
+
+  const notes = useNoteStore.getState().notes
+  const folders = useFolderStore.getState().folders
+  const byId = getFolderPathMap(folders)
+  const out: NoteWithBodyWire[] = []
+  for (let i = 0; i < notes.length; i++) {
+    const n = notes[i]
+    if (n.isDeleted) continue
+    out.push(noteToWire(n, byId))
+  }
+  cached = { sha, notes: out }
+  return out
+}
+
+/**
+ * Stream the vault in chunks. Each chunk is `chunkSize` notes (the
+ * plan's section 4.1 caps this at 500; the SDK defaults to 100). The
+ * caller awaits `onChunk` between pages, so a slow consumer (the
+ * worker bridge under back-pressure) throttles the iterator naturally.
+ *
+ * The iterator yields to the main thread between every chunk via
+ * `queueMicrotask`. A 5000-note vault with chunkSize=100 yields 50
+ * times during the walk, each chunk costing well under 50ms. The cap
+ * lives in `MAX_STREAM_CHUNK_SIZE`; values above it are clamped.
+ */
+export const MIN_STREAM_CHUNK_SIZE = 1
+export const DEFAULT_STREAM_CHUNK_SIZE = 100
+export const MAX_STREAM_CHUNK_SIZE = 500
+
+export async function streamVaultSnapshot(
+  opts: {
+    chunkSize?: number
+    /** Called once per chunk. Resolve before the next chunk emits. */
+    onChunk: (notes: ReadonlyArray<NoteWithBodyWire>, chunkIndex: number) => void | Promise<void>
+    /** Called once with `0` after the last non-empty chunk. */
+    onEnd?: () => void | Promise<void>
+    /** Polled before each chunk. Returning true aborts mid-stream and
+     *  invokes `onAbort(reason)` instead of `onEnd`. Used by the host
+     *  to terminate the iterator on permission revocation. */
+    isAborted?: () => string | null
+    onAbort?: (reason: string) => void | Promise<void>
+  },
+): Promise<void> {
+  const requested = opts.chunkSize ?? DEFAULT_STREAM_CHUNK_SIZE
+  const chunkSize = Math.max(
+    MIN_STREAM_CHUNK_SIZE,
+    Math.min(MAX_STREAM_CHUNK_SIZE, Math.floor(requested) || DEFAULT_STREAM_CHUNK_SIZE),
+  )
+
+  // Take a snapshot of the notes array UP FRONT. Walking the live
+  // Zustand array while it mutates would yield stale duplicates or
+  // skip entries; the cached snapshot is also handed to `getAllNotes`
+  // callers so both paths see the same world.
+  const all = snapshotAllNotes()
+  let chunkIndex = 0
+  for (let i = 0; i < all.length; i += chunkSize) {
+    const reason = opts.isAborted?.() ?? null
+    if (reason !== null) {
+      await opts.onAbort?.(reason)
+      return
+    }
+    chunkIndex++
+    const slice = all.slice(i, i + chunkSize)
+    await opts.onChunk(slice, chunkIndex)
+    // Cooperative yield. queueMicrotask is enough — the worker
+    // postMessage queued before the next iteration also yields the
+    // main thread macrotask boundary.
+    await new Promise<void>((resolve) => queueMicrotask(resolve))
+  }
+  await opts.onEnd?.()
+}
+
+/**
+ * Build a single note's wire object. Used by the `getNote(id)` path on
+ * the host. Returns null when the id is unknown or the note is
+ * soft-deleted.
+ */
+export function snapshotNoteById(id: string): NoteWithBodyWire | null {
+  const note = useNoteStore.getState().notes.find((n) => n.id === id)
+  if (!note || note.isDeleted) return null
+  const folders = useFolderStore.getState().folders
+  return noteToWire(note, getFolderPathMap(folders))
+}
+
+/** Convert one in-memory Note into the wire shape. Frontmatter parses
+ *  to a plain object so the worker never sees raw YAML. */
+function noteToWire(note: Note, folderPathById: Map<string, string>): NoteWithBodyWire {
+  const folderPath = note.folderId !== null ? folderPathById.get(note.folderId) ?? '' : ''
+  const { hasFrontmatter, fields, body } = parseFrontmatter(note.content ?? '')
+  const frontmatter: Record<string, unknown> | null = hasFrontmatter
+    ? fieldsToFrontmatter(fields)
+    : null
+  return {
+    id: note.id,
+    title: note.title ?? 'Untitled',
+    folderPath,
+    body: hasFrontmatter ? body : (note.content ?? ''),
+    frontmatter,
+    updatedAt: note.updatedAt,
+  }
+}
+
+function fieldsToFrontmatter(
+  fields: ReadonlyArray<{ key: string; value: unknown; isUnknown: boolean }>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const f of fields) {
+    if (f.isUnknown) continue
+    if (!f.key) continue
+    // Last-write-wins for repeated keys, matching what the rest of the
+    // app does on serialise.
+    out[f.key] = f.value
+  }
+  return out
+}
+
+function getFolderPathMap(folders: ReadonlyArray<Folder>): Map<string, string> {
+  if (folderPathCache && folderPathCache.folders === folders) return folderPathCache.byId
+  const byId = new Map<string, string>()
+  const ix = new Map(folders.map((f) => [f.id, f] as const))
+  for (const f of folders) {
+    const parts: string[] = []
+    let cur: string | null = f.id
+    // Guard against pathological cycles in the persisted store.
+    let hops = 0
+    while (cur && hops++ < 256) {
+      const cf = ix.get(cur)
+      if (!cf) break
+      parts.unshift(cf.name)
+      cur = cf.parentId
+    }
+    byId.set(f.id, parts.join('/'))
+  }
+  folderPathCache = { folders, byId }
+  return byId
+}
+
+/**
+ * Project the serialised payload size of an array of notes. Used to
+ * decide whether `getAllNotes()` should reject with "use stream()".
+ * JSON.stringify is the same encoding postMessage's structured clone
+ * costs at the upper bound, and the value is bounded by the cache so
+ * we only pay it on first call per SHA.
+ */
+export function projectPayloadSize(notes: ReadonlyArray<NoteWithBodyWire>): number {
+  try {
+    return JSON.stringify(notes).length
+  } catch {
+    return Number.POSITIVE_INFINITY
+  }
+}

--- a/src/plugins/workerEntry.ts
+++ b/src/plugins/workerEntry.ts
@@ -23,8 +23,9 @@ import type {
   HostToWorker,
   WorkerToHost,
   HostBootMessage,
+  NoteWithBodyWire,
 } from './protocol'
-import type { PluginCtx, PluginDefinition } from './sdk'
+import type { PluginCtx, PluginDefinition, NoteWithBody } from './sdk'
 
 interface PluginState {
   manifest: PluginManifest
@@ -52,7 +53,30 @@ interface PendingFileOpen {
   resolve: (v: { bytes: Uint8Array; filename: string } | null) => void
   reject: (err: Error) => void
 }
-const pending = new Map<number, PendingFileSave | PendingFileOpen>()
+interface PendingVaultReadAll {
+  kind: 'vault.all'
+  resolve: (notes: ReadonlyArray<NoteWithBody>) => void
+  reject: (err: Error) => void
+}
+interface PendingVaultReadOne {
+  kind: 'vault.one'
+  resolve: (note: NoteWithBody | null) => void
+  reject: (err: Error) => void
+}
+interface PendingVaultReadStream {
+  kind: 'vault.stream'
+  /** Emits one chunk per host:vaultStreamChunk arrival, or completes
+   *  with null when the host signals end-of-stream / error. */
+  push: (chunk: ReadonlyArray<NoteWithBody> | null, error: string | null) => void
+}
+const pending = new Map<
+  number,
+  | PendingFileSave
+  | PendingFileOpen
+  | PendingVaultReadAll
+  | PendingVaultReadOne
+  | PendingVaultReadStream
+>()
 
 let nextRequestSeq = 0
 function allocRequestSeq(): number {
@@ -111,6 +135,59 @@ self.onmessage = async (event: MessageEvent<HostToWorker>) => {
             p.reject(new Error(msg.error ?? 'File open failed.'))
           }
         }
+        return
+      }
+
+      case 'host:vaultReadResult': {
+        const p = pending.get(msg.requestSeq)
+        if (!p) return
+        if (p.kind === 'vault.all') {
+          pending.delete(msg.requestSeq)
+          if (!msg.ok) {
+            p.reject(new Error(msg.error ?? 'vault.read.getAllNotes failed.'))
+            return
+          }
+          p.resolve((msg.notes ?? []) as ReadonlyArray<NoteWithBody>)
+          return
+        }
+        if (p.kind === 'vault.one') {
+          pending.delete(msg.requestSeq)
+          if (!msg.ok) {
+            p.reject(new Error(msg.error ?? 'vault.read.getNote failed.'))
+            return
+          }
+          // `note` may be undefined on the wire when the host sent the
+          // null variant (host normalises null → omitted spread); the
+          // SDK contract is null-when-not-found.
+          p.resolve(msg.note === undefined ? null : (msg.note as NoteWithBody | null))
+          return
+        }
+        // Wrong response kind for the pending request shape — emit a
+        // worker:error so the dev sees the protocol mismatch instead
+        // of a silently hung Promise.
+        emit({
+          type: 'worker:error',
+          seq: 0,
+          message: `vaultReadResult arrived for a non-read pending request (kind=${p.kind}).`,
+        })
+        return
+      }
+
+      case 'host:vaultStreamChunk': {
+        const p = pending.get(msg.requestSeq)
+        if (!p || p.kind !== 'vault.stream') return
+        if (msg.error) {
+          pending.delete(msg.requestSeq)
+          p.push(null, msg.error)
+          return
+        }
+        if (msg.notes.length === 0) {
+          // End-of-stream marker.
+          pending.delete(msg.requestSeq)
+          p.push(null, null)
+          return
+        }
+        p.push(msg.notes as ReadonlyArray<NoteWithBody>, null)
         return
       }
 
@@ -335,8 +412,115 @@ function buildCtx(parentSeq: number): PluginCtx {
       })
       return promise
     },
+    vault: {
+      read: {
+        getAllNotes() {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<ReadonlyArray<NoteWithBody>>((resolve, reject) => {
+            pending.set(requestSeq, { kind: 'vault.all', resolve, reject })
+          })
+          emit({
+            type: 'worker:requestVaultRead',
+            seq: requestSeq,
+            mode: 'all',
+          })
+          return promise
+        },
+        getNote(id: string) {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<NoteWithBody | null>((resolve, reject) => {
+            pending.set(requestSeq, { kind: 'vault.one', resolve, reject })
+          })
+          emit({
+            type: 'worker:requestVaultRead',
+            seq: requestSeq,
+            mode: 'one',
+            noteId: id,
+          })
+          return promise
+        },
+        stream(opts?: { chunkSize?: number }) {
+          return makeVaultStream(opts?.chunkSize)
+        },
+      },
+    },
   }
 }
+
+/**
+ * Build the AsyncIterable that backs `ctx.vault.read.stream()`.
+ *
+ * Implementation note: chunks arrive on a fan-in queue keyed by the
+ * request seq. The iterator's `next()` pulls from that queue, awaiting
+ * a host:vaultStreamChunk when empty. End-of-stream is signalled by
+ * `push(null, null)`; an error by `push(null, error)`. We DO NOT post
+ * a new envelope per chunk — the host paginates on its own cadence.
+ */
+function makeVaultStream(chunkSize: number | undefined): AsyncIterable<ReadonlyArray<NoteWithBody>> {
+  const requestSeq = allocRequestSeq()
+  const buffer: ReadonlyArray<NoteWithBody>[] = []
+  let done = false
+  let error: string | null = null
+  // Pending consumer waker. When `next()` is called with an empty
+  // buffer we park here; the chunk handler resolves us.
+  let wake: (() => void) | null = null
+
+  pending.set(requestSeq, {
+    kind: 'vault.stream',
+    push(chunk, err) {
+      if (err) {
+        error = err
+        done = true
+      } else if (chunk === null) {
+        done = true
+      } else {
+        buffer.push(chunk)
+      }
+      const w = wake
+      wake = null
+      w?.()
+    },
+  })
+
+  emit({
+    type: 'worker:requestVaultRead',
+    seq: requestSeq,
+    mode: 'stream',
+    ...(typeof chunkSize === 'number' ? { chunkSize } : {}),
+  })
+
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<ReadonlyArray<NoteWithBody>> {
+      return {
+        async next(): Promise<IteratorResult<ReadonlyArray<NoteWithBody>>> {
+          while (buffer.length === 0 && !done) {
+            await new Promise<void>((resolve) => {
+              wake = resolve
+            })
+          }
+          if (buffer.length > 0) {
+            return { value: buffer.shift() as ReadonlyArray<NoteWithBody>, done: false }
+          }
+          if (error !== null) throw new Error(error)
+          return { value: undefined as unknown as ReadonlyArray<NoteWithBody>, done: true }
+        },
+        async return(): Promise<IteratorResult<ReadonlyArray<NoteWithBody>>> {
+          // Plugin abandoned the iterator (e.g. `break` out of for-await).
+          // Mark complete; the host will still finish emitting chunks
+          // but the plugin no longer cares.
+          done = true
+          pending.delete(requestSeq)
+          return { value: undefined as unknown as ReadonlyArray<NoteWithBody>, done: true }
+        },
+      }
+    },
+  }
+}
+
+// Mark `NoteWithBodyWire` referenced so the import is not stripped by
+// TS' isolatedModules pass — the worker treats wire and SDK shapes as
+// structurally identical, but we still want the type-level link.
+type _NoteWithBodyWireAlias = NoteWithBodyWire
 
 function emit(msg: WorkerToHost): void {
   ;(self as unknown as { postMessage: (msg: unknown) => void }).postMessage(msg)

--- a/src/stores/pluginInstallStore.ts
+++ b/src/stores/pluginInstallStore.ts
@@ -10,7 +10,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { idbStorage } from '@/utils/idbStorage'
-import type { PluginManifest } from '@/plugins/manifest'
+import type { PluginManifest, PluginPermission } from '@/plugins/manifest'
 
 export interface InstalledPluginRecord {
   manifest: PluginManifest
@@ -27,6 +27,11 @@ export interface InstalledPluginRecord {
   /** When `false`, the bootstrap skips this plugin on app load.
    *  Lets a user pause a misbehaving plugin without uninstalling. */
   enabled: boolean
+  /** v1.2: per-install capability revocation list. Persisted across
+   *  reboots — a permission revoked here stays revoked until the user
+   *  re-grants it. The manifest's declared `permissions` list is the
+   *  ceiling; revocation can only subtract from it. */
+  revokedPermissions?: PluginPermission[]
 }
 
 interface PluginInstallState {
@@ -36,6 +41,11 @@ interface PluginInstallState {
   install: (record: InstalledPluginRecord) => void
   uninstall: (pluginId: string) => void
   setEnabled: (pluginId: string, enabled: boolean) => void
+  /** Mark a permission revoked for the given plugin. Idempotent. Used
+   *  by Settings → Plugins to disable a capability at runtime; the
+   *  PluginHost reads the same flag on boot to seed its in-memory
+   *  revocation set. */
+  setPermissionRevoked: (pluginId: string, permission: PluginPermission, revoked: boolean) => void
 }
 
 export const usePluginInstallStore = create<PluginInstallState>()(
@@ -62,6 +72,24 @@ export const usePluginInstallStore = create<PluginInstallState>()(
           if (!cur || cur.enabled === enabled) return state
           return {
             records: { ...state.records, [pluginId]: { ...cur, enabled } },
+          }
+        }),
+
+      setPermissionRevoked: (pluginId, permission, revoked) =>
+        set((state) => {
+          const cur = state.records[pluginId]
+          if (!cur) return state
+          const existing = cur.revokedPermissions ?? []
+          const alreadyRevoked = existing.includes(permission)
+          if (revoked === alreadyRevoked) return state
+          const next = revoked
+            ? [...existing, permission]
+            : existing.filter((p) => p !== permission)
+          return {
+            records: {
+              ...state.records,
+              [pluginId]: { ...cur, revokedPermissions: next },
+            },
           }
         }),
     }),


### PR DESCRIPTION
## Summary

- Lands the v1.2 `vault.read.all` capability per
  [`docs/plugins-v1.2-plan.md` §4.1](docs/plugins-v1.2-plan.md) —
  unblocks backlinks (#71), AI-RAG context (#70), and properties
  aggregation (#72) by letting an installed plugin read every note's
  body + parsed frontmatter from inside the worker sandbox.
- Adds three SDK methods under `ctx.vault.read`: `getAllNotes()` (with
  a 4 MiB projected-payload guard), `getNote(id)`, and
  `stream({ chunkSize? })` (default 100, max 500). The host snapshots
  on the main thread and caches by a cheap rolling SHA so a second
  call within the same snapshot is free. The stream path yields
  between chunks so a 5000-note walk stays under the §9 / #79 perf
  budget (no main-thread task >50ms).
- Wire protocol: new `worker:requestVaultRead` envelope, with
  `host:vaultReadResult` (modes `'all'` / `'one'`) and
  `host:vaultStreamChunk` (mode `'stream'`). Mid-flight permission
  revocation terminates the stream with the `'notes: [], error: …'`
  pattern from §5.3.
- Settings → Plugins gains a per-installed-plugin permissions block
  the user can toggle to revoke `vault.read.all` after install.
  Revocation is persisted on the install record and re-applied on
  every boot; the running worker's next call is rejected immediately
  with `'Permission "vault.read.all" was revoked.'`.
- Manifest validator + install-preview modal accept and describe the
  new permission as informational (`vault.write`'s destructive red
  bullet lands with PR D).
- Reference plugin under `public/plugins/noteser-vault-read-demo/`
  exercises `getAllNotes()` and `stream({ chunkSize: 50 })` from two
  palette commands, notifying the count on success or the rejection
  on revoke.

Spec sections: 4.1, 5, 6, 7, 8. Perf budget anchor: plan §9 + #79.

## Test plan

- [x] `npx tsc --noEmit` zero errors.
- [x] `npm run lint` clean (`next lint` reports no warnings or errors).
- [x] `npm test -- --ci` green (197 suites, 2427 tests + 17 skipped).
- [x] New `src/plugins/__tests__/vaultRead.test.ts` covers: manifest
  acceptance (and the dedupe + unknown-permission paths), the host
  snapshot + SHA cache invalidation, the chunked stream's slice
  counts at `chunkSize` 1 / 100 / above-cap, mid-flight revocation
  via `isAborted`, and the PluginHost wire-protocol gate
  (no-permission rejection, declared-permission pass-through,
  `revokePermission` rejection, `restorePermission` re-enable).
- [ ] Manual: install the reference plugin, run "Vault read demo:
  count notes" and "Vault read demo: stream notes", confirm the
  toasts report the right counts; revoke `vault.read.all` in
  Settings, re-run, confirm both rejections.

## Out of scope (per the spec)

- `vault.write` (PR D)
- `fs.openDirectory` (PR E)
- `vault.events` (PR F)
- VNode set extension (PR A)

If PR A merges first, expect conflicts on `src/plugins/protocol.ts`,
`src/plugins/sdk.ts`, and `packages/noteser-plugin-sdk/src/sdk.ts` —
both PRs extend the same union types and `PluginCtx` shape but on
disjoint slots. See the "Conflict expectations" subsection in
`docs/plugins-v1.2-impl-notes.md`.