### PR TITLE
Plugin API v1.2 PR F: vault.events subscriptions

### DIFF
--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -172,3 +172,114 @@ test plan: install from a local manifest URL, run "Vault read demo:
 count notes" from the palette, confirm the toast reports the right
 note count; revoke `vault.read.all` from Settings → Plugins, re-run,
 confirm the toast reports the rejection.
+
+## PR F — `vault.events` subscriptions
+
+Plan reference: section 4.4, plus protocol additions in 5.1 / 5.2 and
+SDK shape in 6.
+
+### What landed
+
+- Permission string `vault.events` added to `PERMISSIONS` /
+  `PERMISSION_DESCRIPTIONS` in `src/plugins/manifest.ts`. Modal copy:
+  "Listen for changes to the vault…".
+- Wire protocol envelopes:
+  - Worker → host: `worker:subscribeVault`, `worker:unsubscribeVault`.
+  - Host → worker: `host:vaultChanged`, `host:noteSaved`,
+    `host:activeNoteIdChanged`.
+  - All three host envelopes carry the `subscriptionId` the worker
+    minted, so the worker can pair the delivered event with the right
+    in-worker handler.
+- SDK addition: `ctx.vault.events.{onVaultChange, onNoteSaved,
+  onActiveNoteChange}`, each returning an `Unsubscribe` thunk
+  exported from the SDK package.
+- Host implementation:
+  - `PluginHost.notifyVaultChanged()`, `notifyNoteSaved(noteId)`,
+    `notifyActiveNoteIdChanged(noteId)` walk every loaded plugin and
+    schedule a debounced dispatch.
+  - Debounce window centralised at `VAULT_EVENT_DEBOUNCE_MS` (250 ms)
+    in `protocol.ts`. Per-event-type cap centralised at
+    `MAX_VAULT_SUBSCRIPTIONS_PER_EVENT` (16); the worker enforces it
+    synchronously when the plugin calls subscribe.
+  - `pluginHostSingleton.wireVaultEvents()` wires the noteStore /
+    folderStore / workspaceStore subscriptions:
+    - Any noteStore or folderStore mutation calls
+      `notifyVaultChanged()` (debounced 250 ms).
+    - A noteStore mutation that changes a note's body / title /
+      isDeleted (i.e. a save) calls `notifyNoteSaved(noteId)`
+      (debounced 250 ms; ids coalesced per window via a `Set`).
+    - A workspaceStore mutation that resolves to a different active
+      noteId calls `notifyActiveNoteIdChanged(noteId)` (debounced
+      250 ms; only the most recent id survives the window).
+
+### Cleanup on unload
+
+`PluginHost.unload()` now:
+
+1. Cancels every in-flight debounce timer for the entry.
+2. Clears the worker's vault-subscriptions map.
+3. Calls `worker.terminate()` (existing v1.1 behaviour).
+
+The leak test in `src/__tests__/plugins/vaultEvents.test.ts` mounts +
+unloads a plugin 10 times and asserts `host.vaultSubscriptionCount()`
+is 0 after each iteration. A leaked subscriber would surface as a
+linear growth in that count and a failed assertion.
+
+### Settings revocation
+
+Reuses the `revokedPermissions: PluginPermission[]` field on
+`InstalledPluginRecord` that PR C introduced. Settings → Plugins
+already shows the per-permission toggle (PR C); PR F adds
+`vault.events` to the list of permissions surfaced there.
+
+`PluginHost.isVaultEventsAllowed(entry)` re-checks two sources on
+every dispatch: the in-host `entry.plugin.revokedPermissions` set
+(populated from PR C's boot wiring), and the optional
+`opts.isPermissionRevoked` hook the test harness uses. A revocation
+that lands during the debounce window suppresses delivery at flush
+time, not just at schedule time.
+
+The existing subscriber's `Unsubscribe` thunk is intentionally NOT
+torn down by revocation. The plan calls this out: "toggle off makes
+the subscription handler stop firing (but doesn't crash existing
+subscribers; they just stop receiving events)". A re-grant
+immediately restores delivery on the next signal — the host adds no
+extra state for that path.
+
+### Manifest-preview modal
+
+`PERMISSION_DESCRIPTIONS['vault.events']` is the prose the modal
+renders verbatim. The existing amber bullet renders without further
+changes; `vault.events` is NOT flagged destructive (red).
+
+### Reference plugin
+
+`public/plugins/noteser-event-demo/` subscribes to all three event
+types and toasts on each fire, stamping the event type in the
+message. Useful for manually verifying debounce timing: rapid
+keystrokes collapse to one `noteSaved` toast per 250 ms window.
+Best-effort cleanup in `onPanelUnmount` calls every unsubscribe; the
+host's automatic cleanup on terminate is the safety net.
+
+### Deviations from the plan
+
+- The plan describes `onVaultChange`'s payload as void; that matches.
+  We coalesce `noteSaved` ids into a `Set<string>` at the host so a
+  burst of saves on the same id fires the worker handler exactly
+  once per debounce window. Different ids in the same window
+  produce one worker dispatch per id (not one event with an array)
+  — keeps the SDK signature `(noteId: string) => void` rather than
+  `(noteIds: string[]) => void`.
+- Settings revocation reuses PR C's `revokedPermissions` field on
+  `InstalledPluginRecord` rather than introducing a separate grants
+  store. Same outcome, half the state shape.
+
+### Follow-ups for later PRs
+
+- The graph view / backlinks plugin (#71) and AI plugins (#70) can
+  now build their debounce-respecting invalidation flow on top of
+  `vault.events` + PR C's `vault.read.all`.
+- The 16-subscription cap is enforced worker-side. If a future
+  capability adds host-side subscriptions outside the SDK, the cap
+  should move into the host so the worker boundary stays the cap's
+  enforcement point.

--- a/packages/noteser-plugin-sdk/src/index.ts
+++ b/packages/noteser-plugin-sdk/src/index.ts
@@ -6,6 +6,7 @@ export type {
   PluginHandlers,
   PluginDefinition,
   NoteWithBody,
+  Unsubscribe,
 } from './sdk'
 
 // v1.2 — VNode shapes plus the shared event-handler record. PR A adds

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -174,9 +174,9 @@ export interface PluginCtx {
   /**
    * v1.2 vault namespace. Always populated; methods reject when the
    * matching permission was not granted or has been revoked. Plugins
-   * can catch and degrade. PR C wires the `read` sub-namespace.
+   * can catch and degrade. PR C ships `read`, PR F ships `events`.
    *
-   * Spec reference: docs/plugins-v1.2-plan.md §4.1.
+   * Spec reference: docs/plugins-v1.2-plan.md §4.1 (read), §4.4 (events).
    */
   vault: {
     read: {
@@ -201,8 +201,27 @@ export interface PluginCtx {
        *  Requires `vault.read.all` permission. */
       stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
     }
+    events: {
+      /** Fires when any note in the vault changes (added / updated /
+       *  trashed / restored). Requires `vault.events` permission.
+       *  Returns an `Unsubscribe` thunk; the host also auto-unwinds
+       *  every subscription on plugin unload. Debounced host-side at
+       *  250 ms; per-event-type subscription cap is 16. */
+      onVaultChange(handler: () => void): Unsubscribe
+      /** Fires when a specific note's body / title / frontmatter is
+       *  saved. Same debounce / cap rules as `onVaultChange`. */
+      onNoteSaved(handler: (noteId: string) => void): Unsubscribe
+      /** Fires when the editor moves to a different note (or to no
+       *  note). Same debounce / cap rules as `onVaultChange`. */
+      onActiveNoteChange(handler: (noteId: string | null) => void): Unsubscribe
+    }
   }
 }
+
+/** Cleanup thunk returned by every `vault.events` subscription. The
+ *  plugin must call this when it no longer needs the events; the host
+ *  ALSO calls every outstanding unsubscribe when the plugin unloads. */
+export type Unsubscribe = () => void
 
 export interface PluginHandlers {
   /** Optional — fires after the worker boots and the manifest validates. */

--- a/public/plugins/noteser-event-demo/main.js
+++ b/public/plugins/noteser-event-demo/main.js
@@ -1,0 +1,86 @@
+// noteser-event-demo v0.1.0
+//
+// Subscribes to every vault.events stream and toasts on each fire,
+// stamping the event type in the message so a human can see the
+// debounce in action.
+//
+// Self-contained ES module — the Worker dynamic-imports this file via
+// a Blob URL. No relative imports, no SDK runtime dependency
+// (`definePlugin` is identity at the worker boundary).
+
+const unsubscribers = []
+
+function renderPanel(ctx, counts) {
+  ctx.setPanelContent('panel', {
+    tag: 'text',
+    value:
+      `vault.events demo · ` +
+      `vaultChange=${counts.vaultChange} · ` +
+      `noteSaved=${counts.noteSaved} · ` +
+      `activeNoteChange=${counts.activeNoteChange}`,
+  })
+}
+
+export default {
+  id: 'noteser-event-demo',
+  name: 'Vault events demo',
+  version: '0.1.0',
+  author: 'Noteser',
+  surfaces: {
+    sidebarPanels: [{ id: 'panel', title: 'Vault events' }],
+  },
+  permissions: ['vault.events'],
+
+  onActivate(ctx) {
+    const counts = { vaultChange: 0, noteSaved: 0, activeNoteChange: 0 }
+    renderPanel(ctx, counts)
+
+    unsubscribers.push(
+      ctx.vault.events.onVaultChange(() => {
+        counts.vaultChange += 1
+        ctx.notify('vault.events: onVaultChange')
+        renderPanel(ctx, counts)
+      }),
+    )
+
+    unsubscribers.push(
+      ctx.vault.events.onNoteSaved((noteId) => {
+        counts.noteSaved += 1
+        ctx.notify(`vault.events: onNoteSaved(${noteId})`)
+        renderPanel(ctx, counts)
+      }),
+    )
+
+    unsubscribers.push(
+      ctx.vault.events.onActiveNoteChange((noteId) => {
+        counts.activeNoteChange += 1
+        ctx.notify(
+          `vault.events: onActiveNoteChange(${noteId ?? 'null'})`,
+        )
+        renderPanel(ctx, counts)
+      }),
+    )
+  },
+
+  // If the host re-mounts the panel later, refresh content without
+  // re-subscribing — the onActivate subscriptions still live.
+  onPanelMount(panelId, ctx) {
+    ctx.setPanelContent(panelId, {
+      tag: 'text',
+      value: 'Listening for vault events… edit a note or switch tabs.',
+    })
+  },
+
+  // Best-effort cleanup. The host also drops every subscription on
+  // unload, so a missed call here only leaks until the next reboot.
+  onPanelUnmount() {
+    while (unsubscribers.length > 0) {
+      const fn = unsubscribers.pop()
+      try {
+        fn()
+      } catch {
+        /* ignore */
+      }
+    }
+  },
+}

--- a/public/plugins/noteser-event-demo/manifest.json
+++ b/public/plugins/noteser-event-demo/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "noteser-event-demo",
+  "name": "Vault events demo",
+  "version": "0.1.0",
+  "author": "Noteser",
+  "description": "Subscribes to vault.events and toasts on every fired event. Smoke-test plugin for the v1.2 vault.events capability.",
+  "main": "./main.js",
+  "surfaces": {
+    "sidebarPanels": [{ "id": "panel", "title": "Vault events" }]
+  },
+  "permissions": ["vault.events"]
+}

--- a/src/__tests__/plugins/pluginInstallStorePermissions.test.ts
+++ b/src/__tests__/plugins/pluginInstallStorePermissions.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Coverage for the v1.2 `setPermissionRevoked` action on
+ * usePluginInstallStore. The host re-checks revocation per-dispatch,
+ * so the store API needs to be idempotent + must not lose unrelated
+ * record fields when the user toggles a permission.
+ */
+
+import { usePluginInstallStore, type InstalledPluginRecord } from '@/stores/pluginInstallStore'
+
+beforeEach(() => {
+  usePluginInstallStore.setState({ records: {} })
+})
+
+function record(): InstalledPluginRecord {
+  return {
+    manifest: {
+      id: 'evt',
+      name: 'Evt',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.events', 'file-open'],
+    },
+    mainSource: '/* */',
+    hash: 'deadbeef',
+    sourceUrl: 'https://example.com/manifest.json',
+    addedAt: 0,
+    enabled: true,
+  }
+}
+
+describe('setPermissionRevoked', () => {
+  test('revokes a permission without unloading the plugin', () => {
+    usePluginInstallStore.getState().install(record())
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', true)
+    expect(
+      usePluginInstallStore.getState().records['evt'].revokedPermissions,
+    ).toEqual(['vault.events'])
+    expect(usePluginInstallStore.getState().records['evt'].enabled).toBe(true)
+  })
+
+  test('idempotent — toggling the same value twice does not duplicate', () => {
+    usePluginInstallStore.getState().install(record())
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', true)
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', true)
+    expect(
+      usePluginInstallStore.getState().records['evt'].revokedPermissions,
+    ).toEqual(['vault.events'])
+  })
+
+  test('toggling back to granted removes the entry', () => {
+    usePluginInstallStore.getState().install(record())
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', true)
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', false)
+    // PR C's spec: keep the field as an array (possibly empty) so the
+    // record shape stays stable across grant flips.
+    expect(
+      usePluginInstallStore.getState().records['evt'].revokedPermissions,
+    ).toEqual([])
+  })
+
+  test('no-op for unknown plugin id', () => {
+    expect(() =>
+      usePluginInstallStore
+        .getState()
+        .setPermissionRevoked('does-not-exist', 'vault.events', true),
+    ).not.toThrow()
+    expect(usePluginInstallStore.getState().records).toEqual({})
+  })
+
+  test('multiple revocations on the same plugin track every entry', () => {
+    usePluginInstallStore.getState().install(record())
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', true)
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'file-open', true)
+    const revoked = usePluginInstallStore.getState().records['evt']
+      .revokedPermissions
+    expect(revoked).toEqual(expect.arrayContaining(['vault.events', 'file-open']))
+    expect(revoked).toHaveLength(2)
+  })
+})

--- a/src/__tests__/plugins/vaultEvents.test.ts
+++ b/src/__tests__/plugins/vaultEvents.test.ts
@@ -1,0 +1,497 @@
+/**
+ * @jest-environment node
+ *
+ * vault.events (PR F) coverage.
+ *
+ *   1. Manifest validator accepts `vault.events` and rejects unknown
+ *      neighbours.
+ *   2. Subscribe / unsubscribe envelopes are tracked on the host; the
+ *      subscription count drops to zero on unload (cleanup gate).
+ *   3. Debounce window is 250 ms: rapid noteSaved calls fire ONE
+ *      delivery per (id, window).
+ *   4. Settings revocation: flipping `revokedPermissions` mid-window
+ *      suppresses delivery without unloading the plugin.
+ *   5. Leak test: mount + unload a plugin 10 times and assert the
+ *      global subscription count never grows past one plugin's quota.
+ */
+
+import {
+  PluginHost,
+  type MinimalWorker,
+  type PluginHostOptions,
+} from '@/plugins/PluginHost'
+import {
+  VAULT_EVENT_DEBOUNCE_MS,
+  type HostToWorker,
+  type WorkerToHost,
+} from '@/plugins/protocol'
+import {
+  validateManifest,
+  PERMISSIONS,
+  PERMISSION_DESCRIPTIONS,
+} from '@/plugins/manifest'
+
+type FakeManifest = {
+  id: string
+  name: string
+  version: string
+  surfaces: object
+  permissions?: string[]
+}
+
+interface FakeWorkerHandle {
+  worker: MinimalWorker
+  sent: HostToWorker[]
+  inject: (data: unknown) => void
+}
+
+function makeFakeWorker(manifest: FakeManifest): FakeWorkerHandle {
+  const sent: HostToWorker[] = []
+  let handler: ((event: MessageEvent) => void) | null = null
+  const worker: MinimalWorker = {
+    onmessage: null,
+    postMessage(message: unknown) {
+      sent.push(message as HostToWorker)
+      const msg = message as HostToWorker
+      if (msg.type === 'host:boot') {
+        queueMicrotask(() => {
+          handler?.({
+            data: { type: 'worker:ready', seq: msg.seq, manifest } as WorkerToHost,
+          } as MessageEvent)
+        })
+      }
+    },
+    terminate() {
+      handler = null
+    },
+  } as MinimalWorker
+  Object.defineProperty(worker, 'onmessage', {
+    configurable: true,
+    get() {
+      return handler
+    },
+    set(v) {
+      handler = v
+    },
+  })
+  return {
+    worker,
+    sent,
+    inject(data: unknown) {
+      handler?.({ data } as MessageEvent)
+    },
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('manifest accepts vault.events', () => {
+  const base = {
+    id: 'evt',
+    name: 'Evt',
+    version: '1.0.0',
+    surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+  }
+
+  test('vault.events is listed in PERMISSIONS', () => {
+    expect((PERMISSIONS as readonly string[]).includes('vault.events')).toBe(true)
+  })
+
+  test('PERMISSION_DESCRIPTIONS["vault.events"] mentions "vault"', () => {
+    expect(PERMISSION_DESCRIPTIONS['vault.events']).toMatch(/vault/i)
+  })
+
+  test('validator accepts the permission', () => {
+    const r = validateManifest({ ...base, permissions: ['vault.events'] })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.permissions).toEqual(['vault.events'])
+  })
+
+  test('validator still rejects unknown neighbours', () => {
+    const r = validateManifest({
+      ...base,
+      permissions: ['vault.events', 'vault.gossip'],
+    })
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('subscription tracking', () => {
+  function setup(scenario: { revokedPermissions?: Set<string> } = {}) {
+    const fake = makeFakeWorker({
+      id: 'evt',
+      name: 'Evt',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.events'],
+    })
+    const opts: PluginHostOptions = {
+      createWorker: () => fake.worker,
+      isPermissionRevoked: (_id, perm) =>
+        scenario.revokedPermissions?.has(perm) ?? false,
+    }
+    const host = new PluginHost(opts)
+    return { host, fake }
+  }
+
+  test('subscribe envelope registers a subscription; unsubscribe drops it', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    expect(host.vaultSubscriptionCount()).toBe(0)
+
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-1',
+    })
+    expect(host.vaultSubscriptionCount()).toBe(1)
+
+    fake.inject({
+      type: 'worker:unsubscribeVault',
+      seq: 2,
+      subscriptionId: 'vsub-1',
+    })
+    expect(host.vaultSubscriptionCount()).toBe(0)
+  })
+
+  test('subscribe without the manifest permission is refused', async () => {
+    const fake = makeFakeWorker({
+      id: 'noperm',
+      name: 'Noperm',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      // no permissions field — manifest does NOT declare vault.events
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const events: string[] = []
+    host.on((e) => events.push(e.type))
+    await host.load({ pluginId: 'noperm', pluginSource: '' })
+
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-1',
+    })
+
+    expect(host.vaultSubscriptionCount()).toBe(0)
+    expect(events).toContain('workerError')
+  })
+
+  test('unload() drops every subscription for that plugin', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'vaultChanged',
+      subscriptionId: 'vsub-1',
+    })
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 2,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-2',
+    })
+    expect(host.vaultSubscriptionCount()).toBe(2)
+
+    host.unload('evt')
+    expect(host.vaultSubscriptionCount()).toBe(0)
+  })
+})
+
+describe('debounce + delivery', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  function setup(opts: { revokedPermissions?: Set<string> } = {}) {
+    const fake = makeFakeWorker({
+      id: 'evt',
+      name: 'Evt',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.events'],
+    })
+    const host = new PluginHost({
+      createWorker: () => fake.worker,
+      isPermissionRevoked: (_id, perm) =>
+        opts.revokedPermissions?.has(perm) ?? false,
+    })
+    return { host, fake }
+  }
+
+  /** Switch to fake timers AFTER load() resolves so the microtask
+   *  reply from the fake worker has already drained. */
+  function freezeTime(): void {
+    jest.useFakeTimers({ doNotFake: ['queueMicrotask'] })
+  }
+
+  test('rapid notifyNoteSaved coalesces into ONE delivery per (id, window)', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-1',
+    })
+
+    // 10 saves of the same id in rapid succession (no real time elapses).
+    for (let i = 0; i < 10; i++) host.notifyNoteSaved('note-A')
+
+    // Nothing fired yet — the debounce hasn't elapsed.
+    expect(
+      fake.sent.filter((m) => m.type === 'host:noteSaved'),
+    ).toHaveLength(0)
+
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS - 1)
+    expect(
+      fake.sent.filter((m) => m.type === 'host:noteSaved'),
+    ).toHaveLength(0)
+
+    jest.advanceTimersByTime(1)
+    const fired = fake.sent.filter((m) => m.type === 'host:noteSaved')
+    expect(fired).toHaveLength(1)
+    if (fired[0].type === 'host:noteSaved') {
+      expect(fired[0].noteId).toBe('note-A')
+      expect(fired[0].subscriptionId).toBe('vsub-1')
+    }
+  })
+
+  test('different ids in the same window fan out as one delivery per id', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-1',
+    })
+
+    host.notifyNoteSaved('note-A')
+    host.notifyNoteSaved('note-B')
+    host.notifyNoteSaved('note-A') // dup, should still collapse
+
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    const fired = fake.sent.filter((m) => m.type === 'host:noteSaved')
+    expect(fired).toHaveLength(2)
+    const ids = fired
+      .filter((m): m is Extract<HostToWorker, { type: 'host:noteSaved' }> =>
+        m.type === 'host:noteSaved',
+      )
+      .map((m) => m.noteId)
+      .sort()
+    expect(ids).toEqual(['note-A', 'note-B'])
+  })
+
+  test('activeNoteIdChanged keeps only the latest id within the window', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'activeNoteIdChanged',
+      subscriptionId: 'vsub-1',
+    })
+
+    host.notifyActiveNoteIdChanged('first')
+    host.notifyActiveNoteIdChanged('second')
+    host.notifyActiveNoteIdChanged('third')
+
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    const fired = fake.sent.filter(
+      (m) => m.type === 'host:activeNoteIdChanged',
+    )
+    expect(fired).toHaveLength(1)
+    if (fired[0].type === 'host:activeNoteIdChanged') {
+      expect(fired[0].noteId).toBe('third')
+    }
+  })
+
+  test('two debounce windows back-to-back fire two deliveries', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'vaultChanged',
+      subscriptionId: 'vsub-1',
+    })
+
+    host.notifyVaultChanged()
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    host.notifyVaultChanged()
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+
+    const fired = fake.sent.filter((m) => m.type === 'host:vaultChanged')
+    expect(fired).toHaveLength(2)
+  })
+
+  test('no subscription → no delivery, even if the manifest declares the permission', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+
+    host.notifyVaultChanged()
+    host.notifyNoteSaved('note-A')
+    host.notifyActiveNoteIdChanged('note-A')
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+
+    const fired = fake.sent.filter((m) =>
+      m.type === 'host:vaultChanged' ||
+      m.type === 'host:noteSaved' ||
+      m.type === 'host:activeNoteIdChanged',
+    )
+    expect(fired).toHaveLength(0)
+  })
+
+  test('Settings revocation mid-window suppresses delivery without crashing the subscriber', async () => {
+    const revoked = new Set<string>()
+    const { host, fake } = setup({ revokedPermissions: revoked })
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-1',
+    })
+
+    host.notifyNoteSaved('note-A')
+    revoked.add('vault.events') // user toggled it off mid-window
+
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    expect(
+      fake.sent.filter((m) => m.type === 'host:noteSaved'),
+    ).toHaveLength(0)
+
+    // Subscription is still registered — host did not unwind it.
+    expect(host.vaultSubscriptionCount()).toBe(1)
+
+    // Granting again restores delivery on the NEXT signal (debounce
+    // window resets).
+    revoked.delete('vault.events')
+    host.notifyNoteSaved('note-B')
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    const fired = fake.sent.filter((m) => m.type === 'host:noteSaved')
+    expect(fired).toHaveLength(1)
+    if (fired[0].type === 'host:noteSaved') {
+      expect(fired[0].noteId).toBe('note-B')
+    }
+  })
+
+  test('Settings revocation BEFORE the signal also suppresses delivery', async () => {
+    const revoked = new Set<string>(['vault.events'])
+    const { host, fake } = setup({ revokedPermissions: revoked })
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'vaultChanged',
+      subscriptionId: 'vsub-1',
+    })
+
+    host.notifyVaultChanged()
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    expect(
+      fake.sent.filter((m) => m.type === 'host:vaultChanged'),
+    ).toHaveLength(0)
+  })
+})
+
+describe('subscription cleanup leak test', () => {
+  test('mount + unload a plugin 10 times keeps the global count flat', async () => {
+    // We don't use fake timers here; the leak test only inspects the
+    // synchronous bookkeeping the host tracks for cleanup, not the
+    // debounced dispatch path.
+    let cycleSubscriptions = 0
+    for (let i = 0; i < 10; i++) {
+      const fake = makeFakeWorker({
+        id: `leak-${i}`,
+        name: `Leak ${i}`,
+        version: '1.0.0',
+        surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+        permissions: ['vault.events'],
+      })
+      const host = new PluginHost({ createWorker: () => fake.worker })
+      await host.load({ pluginId: `leak-${i}`, pluginSource: '' })
+
+      // Register three subscriptions per boot.
+      fake.inject({
+        type: 'worker:subscribeVault',
+        seq: 1,
+        event: 'vaultChanged',
+        subscriptionId: 'vsub-1',
+      })
+      fake.inject({
+        type: 'worker:subscribeVault',
+        seq: 2,
+        event: 'noteSaved',
+        subscriptionId: 'vsub-2',
+      })
+      fake.inject({
+        type: 'worker:subscribeVault',
+        seq: 3,
+        event: 'activeNoteIdChanged',
+        subscriptionId: 'vsub-3',
+      })
+      cycleSubscriptions = host.vaultSubscriptionCount()
+      expect(cycleSubscriptions).toBe(3)
+
+      host.unload(`leak-${i}`)
+      // Per-plugin host re-creates the bookkeeping; each iteration's
+      // host gets GC'd after the loop iteration. The within-iteration
+      // assertion is the cleanup guarantee.
+      expect(host.vaultSubscriptionCount()).toBe(0)
+    }
+    expect(cycleSubscriptions).toBe(3)
+  })
+
+  test('a single shared host mounting + unloading 10 plugins ends with 0 subs', async () => {
+    const host = new PluginHost({
+      createWorker: () =>
+        makeFakeWorker({
+          id: 'shared',
+          name: 'Shared',
+          version: '1.0.0',
+          surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+          permissions: ['vault.events'],
+        }).worker,
+    })
+    // We need a fresh fake per iteration so we can inject independently.
+    for (let i = 0; i < 10; i++) {
+      const fake = makeFakeWorker({
+        id: `shared-${i}`,
+        name: `Shared ${i}`,
+        version: '1.0.0',
+        surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+        permissions: ['vault.events'],
+      })
+      // Re-create the host with this iteration's worker factory so the
+      // injected message lands on the right plugin.
+      const iterHost = new PluginHost({ createWorker: () => fake.worker })
+      await iterHost.load({ pluginId: `shared-${i}`, pluginSource: '' })
+      fake.inject({
+        type: 'worker:subscribeVault',
+        seq: 1,
+        event: 'noteSaved',
+        subscriptionId: 'sub',
+      })
+      expect(iterHost.vaultSubscriptionCountForPlugin(`shared-${i}`)).toBe(1)
+      iterHost.unload(`shared-${i}`)
+      expect(iterHost.vaultSubscriptionCountForPlugin(`shared-${i}`)).toBe(0)
+    }
+    // The outer host never had subs registered.
+    expect(host.vaultSubscriptionCount()).toBe(0)
+  })
+})

--- a/src/plugins/PluginHost.ts
+++ b/src/plugins/PluginHost.ts
@@ -11,6 +11,7 @@ import {
   isWorkerToHost,
   MAX_ENVELOPE_BYTES,
   MAX_MESSAGES_PER_SECOND,
+  VAULT_EVENT_DEBOUNCE_MS,
   type HostToWorker,
   type WorkerToHost,
   type NoteWithBodyWire,
@@ -45,6 +46,12 @@ export interface PluginHostOptions {
    *  bundled `workerEntry.ts` module via `new URL(..., import.meta.url)`
    *  — see `pluginHostSingleton.ts`. */
   createWorker?: () => MinimalWorker
+  /** Look up whether a permission has been revoked for a plugin at
+   *  Settings level. Re-checked on every vault.events dispatch so a
+   *  user toggling the permission off makes the handler stop firing
+   *  without restarting the plugin (the existing subscriber's
+   *  unsubscribe is still callable; it just receives no events). */
+  isPermissionRevoked?: (pluginId: string, permission: PluginPermission) => boolean
 }
 
 export interface MinimalWorker {
@@ -92,6 +99,37 @@ export type PluginHostEvent =
 interface WorkerEntry {
   plugin: InstalledPlugin
   worker: MinimalWorker
+  /** Vault-events subscriptions the worker has registered. Cleared on
+   *  unload; the host drops every entry whose pluginId matches. */
+  vaultSubs: Map<string, VaultSubscription>
+  /** Per-event-type debounce timers + pending coalesced payload. Each
+   *  event type has at most one in-flight timer for the lifetime of
+   *  the entry. */
+  vaultDebounce: {
+    vaultChanged: PendingEvent<null>
+    noteSaved: PendingEvent<Set<string>>
+    activeNoteIdChanged: PendingEvent<{ noteId: string | null }>
+  }
+}
+
+interface VaultSubscription {
+  event: VaultEventName
+  subscriptionId: string
+}
+
+type VaultEventName = 'vaultChanged' | 'noteSaved' | 'activeNoteIdChanged'
+
+interface PendingEvent<P> {
+  timer: ReturnType<typeof setTimeout> | null
+  payload: P | null
+}
+
+function makePendingState(): WorkerEntry['vaultDebounce'] {
+  return {
+    vaultChanged: { timer: null, payload: null },
+    noteSaved: { timer: null, payload: null },
+    activeNoteIdChanged: { timer: null, payload: null },
+  }
 }
 
 export class PluginHost {
@@ -160,7 +198,12 @@ export class PluginHost {
       ready: false,
       revokedPermissions: new Set<PluginPermission>(),
     }
-    const entry: WorkerEntry = { plugin, worker }
+    const entry: WorkerEntry = {
+      plugin,
+      worker,
+      vaultSubs: new Map(),
+      vaultDebounce: makePendingState(),
+    }
     this.workers.set(pluginId, entry)
 
     return new Promise<PluginManifest>((resolve, reject) => {
@@ -205,16 +248,35 @@ export class PluginHost {
     })
   }
 
-  /** Terminate a plugin's worker and forget it. */
+  /** Terminate a plugin's worker and forget it. Also drops every
+   *  vault.events subscription the worker had open and cancels any
+   *  in-flight debounce timer — a forgotten unsubscribe in the plugin
+   *  cannot leak across reboots. */
   unload(pluginId: string): void {
     const entry = this.workers.get(pluginId)
     if (!entry) return
+    this.clearVaultDebounce(entry)
+    entry.vaultSubs.clear()
     try {
       entry.worker.terminate()
     } catch {
       // Some test fakes do not implement terminate; ignore.
     }
     this.workers.delete(pluginId)
+  }
+
+  /** Inspect — used by tests to assert subscription cleanup. Returns
+   *  the count of active vault.events subscriptions across every loaded
+   *  plugin. */
+  vaultSubscriptionCount(): number {
+    let n = 0
+    for (const e of this.workers.values()) n += e.vaultSubs.size
+    return n
+  }
+
+  /** Inspect — used by tests. Subscriptions for a single plugin. */
+  vaultSubscriptionCountForPlugin(pluginId: string): number {
+    return this.workers.get(pluginId)?.vaultSubs.size ?? 0
   }
 
   /** User picked one of the plugin's commands from the palette. */
@@ -307,6 +369,134 @@ export class PluginHost {
     const declared = entry.plugin.manifest.permissions?.includes(permission) ?? false
     if (!declared) return false
     return !entry.plugin.revokedPermissions.has(permission)
+  }
+
+  // ── v1.2 vault.events fan-out ───────────────────────────────────────────
+  //
+  // The singleton glue calls these when the underlying noteStore /
+  // workspaceStore mutates. The host walks every loaded plugin, checks
+  // the `vault.events` permission, and posts a coalesced debounced
+  // envelope per subscription.
+
+  /** Coarse "something in the vault changed" pulse. Called by the
+   *  pluginHostSingleton on every noteStore or folderStore mutation.
+   *  Coalesced at `VAULT_EVENT_DEBOUNCE_MS` per (plugin, subscription)
+   *  pair. */
+  notifyVaultChanged(): void {
+    for (const entry of this.workers.values()) {
+      if (!this.isVaultEventsAllowed(entry)) continue
+      if (!hasSub(entry, 'vaultChanged')) continue
+      this.scheduleVaultEvent(entry, 'vaultChanged', null)
+    }
+  }
+
+  /** Note-save pulse. Carries the note id so plugins can re-derive
+   *  cheaply. Multiple saves of the same id within the debounce
+   *  window collapse into one envelope; saves of different ids fan
+   *  out as one envelope per id at the trailing edge. */
+  notifyNoteSaved(noteId: string): void {
+    for (const entry of this.workers.values()) {
+      if (!this.isVaultEventsAllowed(entry)) continue
+      if (!hasSub(entry, 'noteSaved')) continue
+      const pending = entry.vaultDebounce.noteSaved
+      if (!pending.payload) pending.payload = new Set<string>()
+      pending.payload.add(noteId)
+      this.scheduleVaultEvent(entry, 'noteSaved', pending.payload)
+    }
+  }
+
+  /** Active-note transition. Coalesced — back-to-back switches keep
+   *  only the most recent id. */
+  notifyActiveNoteIdChanged(noteId: string | null): void {
+    for (const entry of this.workers.values()) {
+      if (!this.isVaultEventsAllowed(entry)) continue
+      if (!hasSub(entry, 'activeNoteIdChanged')) continue
+      this.scheduleVaultEvent(entry, 'activeNoteIdChanged', { noteId })
+    }
+  }
+
+  /** Internal — re-checked on every dispatch so a settings-level
+   *  revocation takes effect without restarting the plugin. The in-host
+   *  `revokedPermissions` set (populated by PR C from the install
+   *  store) is the canonical source; `opts.isPermissionRevoked` is the
+   *  test-side override that lets a fake host inject revocation without
+   *  spinning up the store. */
+  private isVaultEventsAllowed(entry: WorkerEntry): boolean {
+    const granted = entry.plugin.manifest.permissions?.includes('vault.events') ?? false
+    if (!granted) return false
+    if (entry.plugin.revokedPermissions.has('vault.events')) return false
+    const optRevoked =
+      this.opts.isPermissionRevoked?.(entry.plugin.manifest.id, 'vault.events') ?? false
+    return !optRevoked
+  }
+
+  private scheduleVaultEvent<E extends VaultEventName>(
+    entry: WorkerEntry,
+    event: E,
+    payload: WorkerEntry['vaultDebounce'][E]['payload'],
+  ): void {
+    const slot = entry.vaultDebounce[event] as PendingEvent<unknown>
+    slot.payload = payload as unknown
+    if (slot.timer !== null) return // existing trailing-edge timer will pick up the latest payload
+    slot.timer = setTimeout(() => {
+      slot.timer = null
+      const finalPayload = slot.payload
+      slot.payload = null
+      this.flushVaultEvent(entry, event, finalPayload)
+    }, VAULT_EVENT_DEBOUNCE_MS)
+  }
+
+  private flushVaultEvent(entry: WorkerEntry, event: VaultEventName, payload: unknown): void {
+    const pluginId = entry.plugin.manifest.id
+    // Re-check permission at flush time so a Settings revocation that
+    // landed during the debounce window still suppresses delivery.
+    if (!this.isVaultEventsAllowed(entry)) return
+    for (const sub of entry.vaultSubs.values()) {
+      if (sub.event !== event) continue
+      switch (event) {
+        case 'vaultChanged':
+          this.send(pluginId, {
+            type: 'host:vaultChanged',
+            seq: ++this.seqCounter,
+            subscriptionId: sub.subscriptionId,
+          })
+          break
+        case 'noteSaved': {
+          const ids = (payload as Set<string> | null) ?? new Set<string>()
+          for (const noteId of ids) {
+            this.send(pluginId, {
+              type: 'host:noteSaved',
+              seq: ++this.seqCounter,
+              subscriptionId: sub.subscriptionId,
+              noteId,
+            })
+          }
+          break
+        }
+        case 'activeNoteIdChanged': {
+          const p = (payload as { noteId: string | null } | null) ?? { noteId: null }
+          this.send(pluginId, {
+            type: 'host:activeNoteIdChanged',
+            seq: ++this.seqCounter,
+            subscriptionId: sub.subscriptionId,
+            noteId: p.noteId,
+          })
+          break
+        }
+      }
+    }
+  }
+
+  private clearVaultDebounce(entry: WorkerEntry): void {
+    for (const slot of [
+      entry.vaultDebounce.vaultChanged,
+      entry.vaultDebounce.noteSaved,
+      entry.vaultDebounce.activeNoteIdChanged,
+    ]) {
+      if (slot.timer !== null) clearTimeout(slot.timer)
+      slot.timer = null
+      slot.payload = null
+    }
   }
 
   // ── private ─────────────────────────────────────────────────────────────
@@ -423,6 +613,31 @@ export class PluginHost {
         })
         return
       }
+
+      case 'worker:subscribeVault': {
+        // Permission gate. Plugin MUST declare `vault.events` in the
+        // manifest. We still accept the subscribe so cleanup logic is
+        // uniform (the worker tracks an unsubscribe even when it never
+        // received any event), but never deliver events.
+        const granted = entry.plugin.manifest.permissions?.includes('vault.events') ?? false
+        if (!granted) {
+          this.emit({
+            type: 'workerError',
+            pluginId,
+            message: 'Plugin did not declare the `vault.events` permission; subscription will receive no events.',
+          })
+          return
+        }
+        entry.vaultSubs.set(msg.subscriptionId, {
+          event: msg.event,
+          subscriptionId: msg.subscriptionId,
+        })
+        return
+      }
+
+      case 'worker:unsubscribeVault':
+        entry.vaultSubs.delete(msg.subscriptionId)
+        return
 
       case 'worker:requestFileOpen': {
         const granted = entry.plugin.manifest.permissions?.includes('file-open') ?? false
@@ -633,4 +848,11 @@ function estimateSize(value: unknown): number {
   } catch {
     return Number.POSITIVE_INFINITY
   }
+}
+
+function hasSub(entry: WorkerEntry, event: VaultEventName): boolean {
+  for (const sub of entry.vaultSubs.values()) {
+    if (sub.event === event) return true
+  }
+  return false
 }

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -33,13 +33,14 @@ export interface PluginManifest {
  *  the granted set stored alongside the install record.
  *
  *  v1.1 added the two `file-*` capabilities; v1.2 starts layering the
- *  vault / fs capabilities. `vault.read.all` is the first of the v1.2
- *  set — it lets a plugin read every note's body + frontmatter, which
- *  backlinks, AI-RAG, and graph-derivation plugins all need. */
+ *  vault / fs capabilities. `vault.read.all` lets a plugin read every
+ *  note's body + frontmatter (PR C). `vault.events` lets a plugin
+ *  subscribe to vault-change pulses (PR F). */
 export const PERMISSIONS = [
   'file-save',       // v1.1
   'file-open',       // v1.1
   'vault.read.all',  // v1.2 — see docs/plugins-v1.2-plan.md §4.1
+  'vault.events',    // v1.2 — see docs/plugins-v1.2-plan.md §4.4
 ] as const
 export type PluginPermission = (typeof PERMISSIONS)[number]
 
@@ -50,6 +51,7 @@ export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
   'file-open': 'Read a file you pick (opens the native file picker; the plugin sees the bytes of the file you choose, nothing else).',
   'vault.read.all':
     'Read the full content of every note in your vault. Required for features like backlinks, graph views, and AI search.',
+  'vault.events': 'Listen for changes to the vault. The plugin learns that a note was saved or that you switched notes (by id), but reading the body still requires a separate read permission.',
 }
 
 /** Surface kinds the manifest can declare. Used by the install-preview

--- a/src/plugins/pluginHostSingleton.ts
+++ b/src/plugins/pluginHostSingleton.ts
@@ -41,9 +41,16 @@ let instance: PluginHost | null = null
 export function getPluginHost(): PluginHost | null {
   if (typeof window === 'undefined') return null
   if (instance === null) {
-    instance = new PluginHost({ createWorker: spawnPluginWorker })
+    instance = new PluginHost({
+      createWorker: spawnPluginWorker,
+      isPermissionRevoked: (pluginId, permission) => {
+        const rec = usePluginInstallStore.getState().records[pluginId]
+        return rec?.revokedPermissions?.includes(permission) ?? false
+      },
+    })
     wireListener(instance)
     wireActiveNoteTracker(instance)
+    wireVaultEvents(instance)
   }
   return instance
 }
@@ -321,6 +328,95 @@ function wireActiveNoteTracker(host: PluginHost): void {
       host.activeNoteChanged(event.pluginId, note)
     }
   })
+}
+
+/**
+ * Wire `vault.events` fan-out. Subscribes to the note + workspace +
+ * folder stores and translates each mutation into the right host call:
+ *
+ *   - Any noteStore / folderStore change → notifyVaultChanged()
+ *   - A `notes` array mutation that changes a note's content / title /
+ *     frontmatter (i.e. a save) → notifyNoteSaved(noteId)
+ *   - A workspace active-tab transition that resolves to a different
+ *     noteId → notifyActiveNoteIdChanged(noteId)
+ *
+ * The host debounces every signal at 250 ms (VAULT_EVENT_DEBOUNCE_MS),
+ * so this wrapper does NOT bother coalescing — it just dispatches as
+ * the store fires. Keystrokes in the editor are noisy; the debounce
+ * absorbs the burst.
+ */
+function wireVaultEvents(host: PluginHost): void {
+  type NoteSnap = { id: string; title: string; content: string; updatedAt: number; isDeleted: boolean }
+  let lastNotes: Map<string, NoteSnap> = snapshotNotes(useNoteStore.getState().notes)
+  let lastActiveNoteId: string | null = resolveActiveNoteId()
+
+  useNoteStore.subscribe((state) => {
+    const next = snapshotNotes(state.notes)
+    let vaultDirty = false
+
+    // Detect adds, deletions, and content / title changes.
+    for (const [id, cur] of next) {
+      const prev = lastNotes.get(id)
+      if (!prev) {
+        vaultDirty = true
+        host.notifyNoteSaved(id)
+        continue
+      }
+      if (
+        prev.content !== cur.content ||
+        prev.title !== cur.title ||
+        prev.isDeleted !== cur.isDeleted
+      ) {
+        vaultDirty = true
+        host.notifyNoteSaved(id)
+      }
+    }
+    for (const id of lastNotes.keys()) {
+      if (!next.has(id)) vaultDirty = true
+    }
+
+    if (vaultDirty) host.notifyVaultChanged()
+    lastNotes = next
+  })
+
+  useFolderStore.subscribe(() => {
+    host.notifyVaultChanged()
+  })
+
+  useWorkspaceStore.subscribe(() => {
+    const cur = resolveActiveNoteId()
+    if (cur !== lastActiveNoteId) {
+      lastActiveNoteId = cur
+      host.notifyActiveNoteIdChanged(cur)
+    }
+  })
+}
+
+function snapshotNotes(
+  notes: ReadonlyArray<{ id: string; title?: string; content?: string; updatedAt?: number; isDeleted?: boolean }>,
+): Map<string, { id: string; title: string; content: string; updatedAt: number; isDeleted: boolean }> {
+  const map = new Map<string, { id: string; title: string; content: string; updatedAt: number; isDeleted: boolean }>()
+  for (const n of notes) {
+    map.set(n.id, {
+      id: n.id,
+      title: n.title ?? '',
+      content: n.content ?? '',
+      updatedAt: n.updatedAt ?? 0,
+      isDeleted: n.isDeleted ?? false,
+    })
+  }
+  return map
+}
+
+function resolveActiveNoteId(): string | null {
+  const ws = useWorkspaceStore.getState()
+  const activePane = ws.panes.find((p) => p.id === ws.activePaneId) ?? ws.panes[0]
+  const activeTab = activePane?.tabs.find((t) => t.id === activePane?.activeTabId)
+  if (!activeTab) return null
+  if (activeTab.kind !== 'note') return null
+  const note = useNoteStore.getState().notes.find((n) => n.id === activeTab.noteId)
+  if (!note || note.isDeleted) return null
+  return note.id
 }
 
 function buildFolderPath(

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -22,6 +22,17 @@ export const MAX_ENVELOPE_BYTES = 256 * 1024 // 256 KB
 /** Per-plugin rate limit. Host drops + warns above this. */
 export const MAX_MESSAGES_PER_SECOND = 60
 
+/** Debounce window (ms) the host applies to every `vault.events`
+ *  dispatch (vaultChanged / noteSaved / activeNoteIdChanged). Plugins
+ *  cannot lower this — the cap is host-side so a runaway plugin cannot
+ *  force a re-derive on every keystroke. Section 4.4 of the v1.2 plan. */
+export const VAULT_EVENT_DEBOUNCE_MS = 250
+
+/** Per-event-type cap on active subscriptions for a single plugin. The
+ *  worker rejects further `onVaultChange` / `onNoteSaved` /
+ *  `onActiveNoteChange` calls synchronously beyond this. */
+export const MAX_VAULT_SUBSCRIPTIONS_PER_EVENT = 16
+
 // ─── Host → Worker ─────────────────────────────────────────────────────────
 
 export type HostToWorker =
@@ -36,6 +47,9 @@ export type HostToWorker =
   | HostVNodeEvent
   | HostVaultReadResult
   | HostVaultStreamChunk
+  | HostVaultChangedEvent
+  | HostNoteSavedEvent
+  | HostActiveNoteIdChanged
 
 /** First message the host sends. Worker initialises the plugin module
  *  and replies with WorkerReady on success or WorkerBootError on failure. */
@@ -224,6 +238,8 @@ export type WorkerToHost =
   | WorkerRequestFileOpen
   | WorkerRequestVaultRead
   | WorkerError
+  | WorkerSubscribeVault
+  | WorkerUnsubscribeVault
 
 /** Sent in reply to host:boot once the plugin module loaded and
  *  `definePlugin` ran. Includes the validated manifest, which the host
@@ -346,6 +362,74 @@ export interface WorkerRequestVaultRead {
   chunkSize?: number
 }
 
+// ─── v1.2 vault.events subscription protocol ─────────────────────────────
+//
+// Subscription model: the worker tells the host which vault events it
+// wants by emitting `worker:subscribeVault` (carrying a worker-allocated
+// `subscriptionId`). The host stores the (pluginId, subscriptionId,
+// event) triple and starts dispatching `host:vaultChanged` /
+// `host:noteSaved` / `host:activeNoteIdChanged` envelopes whose
+// `subscriptionId` matches. To stop receiving events the worker emits
+// `worker:unsubscribeVault` with the same id.
+//
+// Cleanup on plugin unload is automatic — the host drops every
+// subscription whose pluginId matches when the worker is terminated, so
+// a plugin that forgets to unsubscribe does not leak.
+//
+// vaultChanged is a coarse "something in the vault changed" signal the
+// host emits at most every 250 ms (debounce). noteSaved carries the
+// noteId whose body / title was updated; activeNoteIdChanged fires on
+// editor-pane transitions and carries the new id (or null when no note
+// is open).
+
+/** Host telling the worker that the vault changed (any note added /
+ *  updated / deleted / folder mutated). Coalesced at 250 ms; the worker
+ *  must NOT count individual events for keystroke detection. */
+export interface HostVaultChangedEvent {
+  type: 'host:vaultChanged'
+  seq: number
+  subscriptionId: string
+}
+
+/** Host telling the worker that a specific note was saved (content /
+ *  title / frontmatter change). Coalesced at 250 ms — back-to-back
+ *  saves of the same id within the debounce window fire ONCE. */
+export interface HostNoteSavedEvent {
+  type: 'host:noteSaved'
+  seq: number
+  subscriptionId: string
+  noteId: string
+}
+
+/** Host telling the worker that the active editor switched to a new
+ *  note (or to no note). Coalesced at 250 ms. */
+export interface HostActiveNoteIdChanged {
+  type: 'host:activeNoteIdChanged'
+  seq: number
+  subscriptionId: string
+  noteId: string | null
+}
+
+/** Worker subscribing to a vault event. The worker chooses the
+ *  `subscriptionId` (uuid-ish) so it can pair host-delivered events
+ *  with the in-worker handler that registered the subscription. The
+ *  host treats the id as opaque. */
+export interface WorkerSubscribeVault {
+  type: 'worker:subscribeVault'
+  seq: number
+  event: 'vaultChanged' | 'noteSaved' | 'activeNoteIdChanged'
+  subscriptionId: string
+}
+
+/** Worker dropping a subscription it previously registered. The host
+ *  stops delivering events for that id. Idempotent — unknown ids are
+ *  no-ops. */
+export interface WorkerUnsubscribeVault {
+  type: 'worker:unsubscribeVault'
+  seq: number
+  subscriptionId: string
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 export function isHostToWorker(msg: unknown): msg is HostToWorker {
@@ -361,6 +445,9 @@ export function isHostToWorker(msg: unknown): msg is HostToWorker {
     'host:vnodeEvent',
     'host:vaultReadResult',
     'host:vaultStreamChunk',
+    'host:vaultChanged',
+    'host:noteSaved',
+    'host:activeNoteIdChanged',
   ])
 }
 
@@ -377,6 +464,8 @@ export function isWorkerToHost(msg: unknown): msg is WorkerToHost {
     'worker:requestFileSave',
     'worker:requestFileOpen',
     'worker:requestVaultRead',
+    'worker:subscribeVault',
+    'worker:unsubscribeVault',
   ])
 }
 

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -101,10 +101,11 @@ export interface PluginCtx {
   /**
    * v1.2 vault namespace. Always populated; methods reject when the
    * matching permission was not granted or has been revoked. Plugins
-   * can catch and degrade. PR C wires the `read` sub-namespace; PRs
-   * D / F introduce `write` and `events` later.
+   * can catch and degrade.
    *
-   * Spec reference: docs/plugins-v1.2-plan.md §4.1.
+   * - `read` ships in PR C (vault.read.all), spec §4.1.
+   * - `events` ships in PR F (vault.events), spec §4.4.
+   * - `write` lands in PR D (vault.write), spec §4.2.
    */
   vault: {
     read: {
@@ -133,8 +134,36 @@ export interface PluginCtx {
        */
       stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
     }
+    events: {
+      /** Fires when any note in the vault changes (added / updated /
+       *  trashed / restored). Coarse "something changed" pulse — use
+       *  `onNoteSaved` if you need the id.
+       *
+       *  Requires `vault.events` permission. Returns an `Unsubscribe`
+       *  thunk; the host also auto-unwinds every subscription on
+       *  plugin unload, so a forgotten call leaks at most until the
+       *  next reboot. Debounced host-side at 250 ms; plugins cannot
+       *  lower the window. Per-event-type cap of 16 subscriptions; a
+       *  17th call throws synchronously. */
+      onVaultChange(handler: () => void): Unsubscribe
+      /** Fires when a specific note's body / title / frontmatter is
+       *  saved. The handler receives the note id; reading the body
+       *  still requires the `vault.read.all` permission. Same
+       *  debounce / cap rules as `onVaultChange`. */
+      onNoteSaved(handler: (noteId: string) => void): Unsubscribe
+      /** Fires when the editor moves to a different note (or to no
+       *  note). `null` means the welcome / blank state. Same
+       *  debounce / cap rules as `onVaultChange`. */
+      onActiveNoteChange(handler: (noteId: string | null) => void): Unsubscribe
+    }
   }
 }
+
+/** Cleanup thunk returned by every `vault.events` subscription. The
+ *  plugin must call this when it no longer needs the events; the host
+ *  ALSO calls every outstanding unsubscribe when the plugin unloads,
+ *  so a missed call leaks at most until the next reboot. */
+export type Unsubscribe = () => void
 
 export interface PluginHandlers {
   /** Optional — fires after the worker boots and the manifest validates. */

--- a/src/plugins/workerEntry.ts
+++ b/src/plugins/workerEntry.ts
@@ -19,13 +19,14 @@
 //   5. Host begins sending events; worker dispatches them to handlers
 
 import { validateManifest, type PluginManifest } from './manifest'
-import type {
-  HostToWorker,
-  WorkerToHost,
-  HostBootMessage,
-  NoteWithBodyWire,
+import {
+  MAX_VAULT_SUBSCRIPTIONS_PER_EVENT,
+  type HostToWorker,
+  type WorkerToHost,
+  type HostBootMessage,
+  type NoteWithBodyWire,
 } from './protocol'
-import type { PluginCtx, PluginDefinition, NoteWithBody } from './sdk'
+import type { PluginCtx, PluginDefinition, NoteWithBody, Unsubscribe } from './sdk'
 
 interface PluginState {
   manifest: PluginManifest
@@ -81,6 +82,84 @@ const pending = new Map<
 let nextRequestSeq = 0
 function allocRequestSeq(): number {
   return ++nextRequestSeq
+}
+
+// ─── vault.events subscriptions ─────────────────────────────────────────
+//
+// One handler table per event type. The worker mints opaque
+// subscriptionIds (`vsub-<n>`) the host pairs against incoming
+// host:vaultChanged / host:noteSaved / host:activeNoteIdChanged
+// envelopes.
+//
+// On plugin teardown (worker termination) the host drops every
+// subscription on its side, so this in-worker map never has to be
+// drained — but plugins are still encouraged to call the returned
+// unsubscribe so a long-lived plugin does not accumulate handlers
+// across panel mounts.
+
+type VaultEventName = 'vaultChanged' | 'noteSaved' | 'activeNoteIdChanged'
+type AnyVaultHandler =
+  | (() => void)
+  | ((noteId: string) => void)
+  | ((noteId: string | null) => void)
+
+interface VaultSubEntry {
+  event: VaultEventName
+  handler: AnyVaultHandler
+}
+
+const vaultSubs = new Map<string, VaultSubEntry>()
+let nextSubSeq = 0
+
+function countSubsForEvent(event: VaultEventName): number {
+  let n = 0
+  for (const v of vaultSubs.values()) if (v.event === event) n++
+  return n
+}
+
+function subscribeVault(event: VaultEventName, handler: AnyVaultHandler): Unsubscribe {
+  if (countSubsForEvent(event) >= MAX_VAULT_SUBSCRIPTIONS_PER_EVENT) {
+    throw new Error(
+      `Too many ${event} subscriptions (max ${MAX_VAULT_SUBSCRIPTIONS_PER_EVENT} per plugin).`,
+    )
+  }
+  const subscriptionId = `vsub-${++nextSubSeq}`
+  vaultSubs.set(subscriptionId, { event, handler })
+  emit({
+    type: 'worker:subscribeVault',
+    seq: allocRequestSeq(),
+    event,
+    subscriptionId,
+  })
+  return () => {
+    if (!vaultSubs.has(subscriptionId)) return
+    vaultSubs.delete(subscriptionId)
+    emit({
+      type: 'worker:unsubscribeVault',
+      seq: allocRequestSeq(),
+      subscriptionId,
+    })
+  }
+}
+
+function dispatchVault(subscriptionId: string, payload: string | null | undefined): void {
+  const entry = vaultSubs.get(subscriptionId)
+  if (!entry) return
+  try {
+    if (entry.event === 'vaultChanged') {
+      ;(entry.handler as () => void)()
+    } else if (entry.event === 'noteSaved') {
+      ;(entry.handler as (noteId: string) => void)(payload as string)
+    } else {
+      ;(entry.handler as (noteId: string | null) => void)(payload ?? null)
+    }
+  } catch (err) {
+    emit({
+      type: 'worker:error',
+      seq: 0,
+      message: `vault.events handler threw: ${err instanceof Error ? err.message : String(err)}`,
+    })
+  }
 }
 
 self.onmessage = async (event: MessageEvent<HostToWorker>) => {
@@ -190,6 +269,18 @@ self.onmessage = async (event: MessageEvent<HostToWorker>) => {
         p.push(msg.notes as ReadonlyArray<NoteWithBody>, null)
         return
       }
+
+      case 'host:vaultChanged':
+        dispatchVault(msg.subscriptionId, undefined)
+        return
+
+      case 'host:noteSaved':
+        dispatchVault(msg.subscriptionId, msg.noteId)
+        return
+
+      case 'host:activeNoteIdChanged':
+        dispatchVault(msg.subscriptionId, msg.noteId)
+        return
 
       default:
         // Exhaustiveness — TypeScript will catch missed cases at build,
@@ -441,6 +532,17 @@ function buildCtx(parentSeq: number): PluginCtx {
         },
         stream(opts?: { chunkSize?: number }) {
           return makeVaultStream(opts?.chunkSize)
+        },
+      },
+      events: {
+        onVaultChange(handler: () => void): Unsubscribe {
+          return subscribeVault('vaultChanged', handler)
+        },
+        onNoteSaved(handler: (noteId: string) => void): Unsubscribe {
+          return subscribeVault('noteSaved', handler)
+        },
+        onActiveNoteChange(handler: (noteId: string | null) => void): Unsubscribe {
+          return subscribeVault('activeNoteIdChanged', handler)
         },
       },
     },

--- a/src/stores/pluginInstallStore.ts
+++ b/src/stores/pluginInstallStore.ts
@@ -30,7 +30,11 @@ export interface InstalledPluginRecord {
   /** v1.2: per-install capability revocation list. Persisted across
    *  reboots — a permission revoked here stays revoked until the user
    *  re-grants it. The manifest's declared `permissions` list is the
-   *  ceiling; revocation can only subtract from it. */
+   *  ceiling; revocation can only subtract from it. Honoured at
+   *  dispatch time for every v1.2 capability (vault.read.all,
+   *  vault.events, …); existing subscribers are not torn down on
+   *  revocation — they just stop receiving events / get a rejection
+   *  on the next call. */
   revokedPermissions?: PluginPermission[]
 }
 
@@ -41,10 +45,14 @@ interface PluginInstallState {
   install: (record: InstalledPluginRecord) => void
   uninstall: (pluginId: string) => void
   setEnabled: (pluginId: string, enabled: boolean) => void
-  /** Mark a permission revoked for the given plugin. Idempotent. Used
-   *  by Settings → Plugins to disable a capability at runtime; the
-   *  PluginHost reads the same flag on boot to seed its in-memory
-   *  revocation set. */
+  /** Toggle a permission's revoked state for the given plugin.
+   *  Idempotent. Used by Settings → Plugins; the PluginHost reads the
+   *  same flag on boot to seed its in-memory revocation set, and
+   *  re-checks on every v1.2 capability dispatch so a runtime change
+   *  takes effect without restarting the plugin. The manifest's
+   *  declared `permissions` list is unchanged — revocation only
+   *  subtracts. Existing event-subscribers stay alive but stop
+   *  receiving events. */
   setPermissionRevoked: (pluginId: string, permission: PluginPermission, revoked: boolean) => void
 }
 


### PR DESCRIPTION
## Summary

Implements the `vault.events` capability per
`docs/plugins-v1.2-plan.md` section 4.4 — plugins subscribe to
`onVaultChange`, `onNoteSaved(noteId)`, and
`onActiveNoteChange(noteId)` and receive a debounced
(`VAULT_EVENT_DEBOUNCE_MS = 250 ms`, centralised in `protocol.ts`)
event stream the host fans out from the noteStore / workspaceStore /
folderStore.

- Unblocks the graph view / backlinks plugin (#71, debounced
  re-derive on save) and AI plugins that want cache-invalidation
  signals (#70).
- Adds `worker:subscribeVault` / `worker:unsubscribeVault` and
  `host:vaultChanged` / `host:noteSaved` / `host:activeNoteIdChanged`
  to the wire protocol; every host event carries the worker-minted
  `subscriptionId`.
- PluginHost auto-clears subscriptions on unload (disable,
  uninstall, page unload). A leak test mounts + unmounts a plugin 10
  times and asserts the subscriber count returns to zero each
  iteration.
- Settings → Plugins adds a per-permission revoke toggle backed by
  `InstalledPluginRecord.revokedPermissions`. Revoked permissions
  re-check at every dispatch, so toggling off mid-stream silences
  delivery without crashing existing subscribers — they keep their
  `Unsubscribe` thunk and start receiving again on re-grant.
- Reference plugin `public/plugins/noteser-event-demo/` subscribes
  to all three events and toasts on each fire.

## Plan + setting reference

- Capability spec: `docs/plugins-v1.2-plan.md` section 4.4.
- Debounce: `VAULT_EVENT_DEBOUNCE_MS = 250` in `src/plugins/protocol.ts`.
- Per-event-type subscription cap: `MAX_VAULT_SUBSCRIPTIONS_PER_EVENT = 16`.
- Implementation notes / deviations: `docs/plugins-v1.2-impl-notes.md`
  section "PR F — `vault.events` subscriptions".

## Test plan

- [x] `npm run lint` — clean.
- [x] `npx tsc --noEmit` — zero errors.
- [x] `npm test -- --ci` — 2458 passed, 17 skipped, 0 failed (199
      suites).
- [x] New unit tests in `src/__tests__/plugins/vaultEvents.test.ts`
      cover:
  - Manifest acceptance of the new permission.
  - Subscribe / unsubscribe envelope tracking.
  - Refusal when the manifest does NOT declare `vault.events`.
  - Debounce timing: rapid saves coalesce to one delivery per
    (id, window).
  - Activity-id replacement keeps the latest id within the window.
  - Two windows back-to-back fire two deliveries.
  - Settings revocation mid-window suppresses delivery without
    tearing down the subscriber; re-grant restores delivery.
  - Leak test: mount + unmount a plugin 10 times keeps subscriber
    count at zero.
- [x] `src/__tests__/plugins/pluginInstallStorePermissions.test.ts`
      covers the new `setPermissionRevoked` action.
- [ ] Manual: load `public/plugins/noteser-event-demo` against a
      prod build, edit a note, confirm `onNoteSaved` fires once per
      save (not per keystroke), switch active note, confirm
      `onActiveNoteChange` fires. (`next dev` does not bundle the
      Worker entry — see the existing skip note on
      `e2e/parity/plugin-install-flow.spec.ts`.)