### PR TITLE
Plugin API v1.2 PR D: vault.write capability + audit trail

### DIFF
--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -572,3 +572,164 @@ fan-out to PluginHostEvent listeners.
   `host:vnodeEvent` with `source: { kind: 'fullscreen', viewId }`.
 - PR D MUST NOT touch the fullscreen surface; the remaining
   capability PR is surface-agnostic by design.
+
+## PR D — `vault.write` capability + audit trail
+
+Implements plan sections 4.2, 5, 6, 7, and 8 as they pertain to
+`vault.write`. Branch `feat/plugins-v1.2-D-vault-write`.
+
+### Permission
+
+`vault.write` joins `file-save` and `file-open` in
+`src/plugins/manifest.ts`'s `PERMISSIONS` tuple. It is the first
+member of a new `DESTRUCTIVE_PERMISSIONS` set — the install-confirm
+modal renders destructive permissions inside a red-bordered section
+with a red bullet, and demands an explicit opt-in checkbox per
+destructive entry before the Install button enables. Informational
+permissions (`file-save`, `file-open`) keep the amber CheckCircle
+styling that landed in v1.1.
+
+### SDK surface
+
+`ctx.vault.write` exposes four async methods:
+
+- `createNote({ title, body, folderPath?, frontmatter? })`
+  → `Promise<{ id, conflictResolved }>`
+- `updateNote(id, { title?, body?, frontmatter? })` → `Promise<void>`
+- `deleteNote(id)` → `Promise<void>` (soft-delete only; landing in the
+  Trash is intentional so the user can recover from a plugin bug)
+- `createFolder(path)` → `Promise<void>` (idempotent, ensures all
+  intermediate segments)
+
+Both `src/plugins/sdk.ts` and `packages/noteser-plugin-sdk/src/sdk.ts`
+gained the namespace. The runtime `definePlugin` is unchanged;
+manifest validation stays host-side.
+
+### Wire protocol
+
+Two new envelopes in `src/plugins/protocol.ts`:
+
+- `WorkerRequestVaultWrite` carries a discriminated `op` union over the
+  four operations.
+- `HostVaultWriteResult` carries `ok`, `requestSeq`, optional `id` +
+  `conflictResolved` for successful `create`s, and `error` on failure.
+
+`isHostToWorker` / `isWorkerToHost` accept the new types; the
+`MAX_ENVELOPE_BYTES` and rate-limit guards apply unchanged.
+
+### Host implementation
+
+`pluginHostSingleton.ts` adds `handleVaultWriteRequest` which writes
+through the EXACT SAME `useNoteStore.addNote` / `updateNote` /
+`deleteNote` and `useFolderStore.ensureFolderPath` paths a user action
+takes. Sync, indexing, and undo behave identically whether the user or
+a plugin made the change.
+
+`folderPath` is resolved via `ensureFolderPath` — the same helper the
+pull layer uses to materialise repo paths. A plugin asking for
+`"Imported/Obsidian"` and the user manually creating that folder
+converge on the same folder ids.
+
+### Conflict resolution
+
+`createNote` runs through `resolveTitleConflict` before delegating to
+the store:
+
+1. No active (non-trashed) note in the same folder shares the
+   requested title (case-insensitive) → use it verbatim.
+   `conflictResolved: 'none'`.
+2. Otherwise, try `"<title> (imported)"`. `conflictResolved: 'suffix'`.
+3. Chained collisions roll forward: `(imported 2)`, `(imported 3)`, …
+   Still `conflictResolved: 'suffix'`.
+
+The host surfaces the renamed title via the `conflictResolved` flag.
+The importer plugin (issue #73) plumbs it into its progress log
+straight from the existing return value.
+
+### Validation
+
+Per plan §4.2: title 1–200 chars, body ≤ 1 MiB,
+`folderPath` matches `/^[^\s/][^/]*(\/[^\s/][^/]*)*$/`. Hard-delete is
+intentionally absent — plugins cannot bypass the Trash UI.
+
+### Revocation
+
+PR D reuses PR C's revocation plumbing rather than introducing a new
+mechanism:
+
+- `revokedPermissions: PluginPermission[]` on `InstalledPluginRecord`,
+  plus the `setPermissionRevoked` / `isPermissionRevoked` store
+  helpers, all from PR C.
+- `PluginHost.revokePermission(pluginId, perm)` /
+  `restorePermission` / `hasPermission` — also from PR C.
+- The vault.write message handler runs the same two-layer gate PR C
+  established for vault.read.all: declared in manifest AND not in
+  `entry.plugin.revokedPermissions`. Distinct error strings so the
+  dev console clarifies; the plugin sees the same Promise rejection
+  either way.
+- file-save / file-open paths now also honour the revocation Set
+  (previously only the declared-permissions list). One-line
+  symmetry fix riding in this PR.
+
+The red "Destructive" badge in Settings → Plugins persists as long
+as the destructive permission stays declared in the manifest — even
+after revocation — so the user always sees at a glance which plugins
+were granted dangerous capabilities historically. The per-permission
+toggle row still uses PR C's `setPluginPermissionRevoked` exported
+from the singleton.
+
+### Audit trail
+
+`src/utils/pluginAudit.ts` is new. Every accepted vault.write op (and
+every host-side rejection that survives the permission gate) records
+an entry: `pluginId`, `op`, `target`, `ok`, optional `error` and
+`conflictResolved`, plus `ts`. Storage is a 500-entry ring buffer in
+memory, flushed to `localStorage` with a 250 ms debounce — chosen over
+the Zustand + IndexedDB path so the log keeps working when the noteser
+stores are mid-migration. A read-only "Plugin activity" panel in
+Settings → Plugins renders the last 50 entries.
+
+Example entry shape (newline-separated for readability — the on-disk
+JSON is one object per push):
+
+    {
+      "ts": 1717718400000,
+      "pluginId": "noteser-write-demo",
+      "op": "create",
+      "target": "8e7a51d3-...",
+      "ok": true,
+      "conflictResolved": "none"
+    }
+
+### Reference plugin
+
+`public/plugins/noteser-write-demo/` ships a single command "Plugin
+demo note" that calls `ctx.vault.write.createNote`. Running it twice
+exercises the title-collision resolver and demonstrates the suffix.
+
+### Tests
+
+`src/__tests__/plugins/vaultWrite.test.ts` covers:
+
+- Manifest validator accepts `vault.write` and rejects malformed
+  values; `isDestructivePermission` flags it.
+- `PluginHost` refuses `worker:requestVaultWrite` when the permission
+  was not declared and when it was revoked.
+- Each of the four ops round-trips through the wire protocol:
+  create returns `{ id, conflictResolved }`; update / delete /
+  createFolder resolve void.
+- `resolveTitleConflict` suffixes correctly on collision (single
+  + chained).
+- Audit log appends one entry per accepted op AND one per failed op.
+
+`src/__tests__/plugins/pluginAudit.test.ts` covers the ring buffer in
+isolation: ordering, MAX_ENTRIES rollover, per-plugin filtering, and
+the localStorage flush.
+
+### Out of scope (deferred)
+
+- Bulk `importNotes(records[])` envelope — plan §4.2 keeps this for
+  v1.3. The 60 messages/sec rate limit means a 5 k-note Obsidian
+  import takes ~83 s; acceptable.
+- Per-plugin "Recent activity" drill-down view — `readPluginAuditFor`
+  exists for it but the UI is the global list for now.

--- a/packages/noteser-plugin-sdk/src/manifest.ts
+++ b/packages/noteser-plugin-sdk/src/manifest.ts
@@ -16,14 +16,24 @@ export interface PluginManifest {
   /** Capabilities the plugin asks for at install time. The user grants
    *  each one in the install-preview modal; the host refuses any
    *  capability call that was not granted. v1.1 added `file-save` /
-   *  `file-open`; v1.2 PR E added `fs.open-directory`. */
+   *  `file-open`; v1.2 added `vault.read.all`, `vault.write` (the first
+   *  destructive permission — the modal renders a red bullet),
+   *  `vault.events`, and `fs.open-directory`. */
   permissions?: PluginPermission[]
 }
 
 /** Capability identifiers the validator accepts. Plugins targeting an
  *  older host that does not know a v1.2 permission will fail manifest
- *  validation there — see plugins-v1.2-plan.md section 10. */
-export const PERMISSIONS = ['file-save', 'file-open', 'fs.open-directory'] as const
+ *  validation there — see plugins-v1.2-plan.md section 10. Mirrors
+ *  `src/plugins/manifest.ts` in noteser core. */
+export const PERMISSIONS = [
+  'file-save',
+  'file-open',
+  'vault.read.all',
+  'vault.write',
+  'vault.events',
+  'fs.open-directory',
+] as const
 export type PluginPermission = (typeof PERMISSIONS)[number]
 
 export interface PluginSurfaces {

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -189,15 +189,25 @@ export interface PluginCtx {
   getSetting<T = unknown>(key: string): T | undefined
   setSetting<T = unknown>(key: string, value: T): void
 
+  /** v1.1 file-I/O. Requires `permissions: ['file-save']`. */
+  requestFileSave(args: { suggestedName: string; mimeType: string; bytes: Uint8Array }): Promise<void>
+  /** v1.1 file-I/O. Requires `permissions: ['file-open']`. */
+  requestFileOpen(args?: { accept?: string[] }): Promise<{ bytes: Uint8Array; filename: string } | null>
+
   /**
-   * v1.2 vault namespace. Always populated; methods reject when the
-   * matching permission was not granted or has been revoked. Plugins
-   * can catch and degrade. PR C ships `read`, PR F ships `events`.
+   * v1.2 vault namespace. Always populated; methods reject with
+   * `'Permission "<name>" was not granted.'` (or `'... was revoked.'`)
+   * when the plugin did not declare the matching permission OR the
+   * user revoked it from Settings → Plugins. Plugins can catch and
+   * degrade.
    *
-   * Spec reference: docs/plugins-v1.2-plan.md §4.1 (read), §4.4 (events).
+   * PR C ships `read`; PR D ships `write`; PR F ships `events`.
+   *
+   * Spec reference: docs/plugins-v1.2-plan.md §4.1 (read),
+   * §4.2 (write), §4.4 (events).
    */
-  vault: {
-    read: {
+  readonly vault: {
+    readonly read: {
       /** Snapshot every non-deleted note in the vault. Resolves with a
        *  plain array of `NoteWithBody`. For very large vaults the host
        *  rejects with `'Vault too large; use stream().'`; plugins MUST
@@ -219,7 +229,37 @@ export interface PluginCtx {
        *  Requires `vault.read.all` permission. */
       stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
     }
-    events: {
+    readonly write: {
+      /** Create a note. Returns the new note's id plus a
+       *  `conflictResolved` flag: `'none'` when the title was used
+       *  verbatim, `'suffix'` when " (imported)" was appended to
+       *  avoid a title collision in the target folder. Requires
+       *  `vault.write` permission. */
+      createNote(args: {
+        title: string
+        body: string
+        folderPath?: string
+        frontmatter?: Record<string, unknown>
+      }): Promise<{ id: string; conflictResolved: 'none' | 'suffix' }>
+      /** Patch an existing note. Each field in `patch` is optional —
+       *  omitted fields are left untouched. Requires `vault.write`. */
+      updateNote(
+        id: string,
+        patch: {
+          title?: string
+          body?: string
+          frontmatter?: Record<string, unknown>
+        },
+      ): Promise<void>
+      /** Move a note to the trash (soft-delete only). Requires
+       *  `vault.write` permission. */
+      deleteNote(id: string): Promise<void>
+      /** Create a folder at the given forward-slash-separated path
+       *  (e.g. "Imported/Obsidian"). Missing intermediate folders are
+       *  created. Idempotent. Requires `vault.write` permission. */
+      createFolder(path: string): Promise<void>
+    }
+    readonly events: {
       /** Fires when any note in the vault changes (added / updated /
        *  trashed / restored). Requires `vault.events` permission.
        *  Returns an `Unsubscribe` thunk; the host also auto-unwinds

--- a/public/plugins/noteser-write-demo/main.js
+++ b/public/plugins/noteser-write-demo/main.js
@@ -1,0 +1,45 @@
+// noteser-write-demo v0.1.0
+//
+// Smoke-test plugin for the v1.2 `vault.write` capability. Adds a
+// single command, "Plugin demo note", which creates a note titled
+// "Plugin demo note" in the root of the vault. Running it twice
+// exercises the host's title-collision resolver — the second invocation
+// lands as "Plugin demo note (imported)".
+//
+// The plugin is intentionally tiny: it is a wire-confirmation tool, not
+// a feature. Real importers (issue #73) will follow the same shape but
+// loop over many notes.
+
+export default {
+  id: 'noteser-write-demo',
+  name: 'Write demo',
+  version: '0.1.0',
+  author: 'Noteser',
+  description:
+    "Reference plugin for the v1.2 vault.write capability. Adds a command 'Plugin demo note' that creates a note in your vault to confirm the wire works.",
+  permissions: ['vault.write'],
+  surfaces: {
+    commands: [{ id: 'create', title: 'Plugin demo note' }],
+  },
+
+  async onCommand(id, ctx) {
+    if (id !== 'create') return
+    try {
+      const result = await ctx.vault.write.createNote({
+        title: 'Plugin demo note',
+        body:
+          '# Plugin demo note\n\n' +
+          'This note was created by the `noteser-write-demo` plugin to confirm the ' +
+          '`vault.write` capability is wired end-to-end.\n\n' +
+          `Created at: ${new Date().toISOString()}\n`,
+      })
+      const suffix =
+        result.conflictResolved === 'suffix'
+          ? ' (host renamed to avoid a title collision).'
+          : '.'
+      ctx.notify(`Created note "${result.id}"${suffix}`)
+    } catch (err) {
+      ctx.notify(`Plugin demo note failed: ${err && err.message ? err.message : String(err)}`)
+    }
+  },
+}

--- a/public/plugins/noteser-write-demo/manifest.json
+++ b/public/plugins/noteser-write-demo/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "noteser-write-demo",
+  "name": "Write demo",
+  "version": "0.1.0",
+  "author": "Noteser",
+  "description": "Reference plugin for the v1.2 vault.write capability. Adds a command 'Plugin demo note' that creates a note in your vault to confirm the wire works.",
+  "main": "./main.js",
+  "permissions": ["vault.write"],
+  "surfaces": {
+    "commands": [
+      { "id": "create", "title": "Plugin demo note" }
+    ]
+  }
+}

--- a/src/__tests__/plugins/pluginAudit.test.ts
+++ b/src/__tests__/plugins/pluginAudit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Plugin audit trail unit tests. Exercises the localStorage-backed
+ * ring buffer in isolation from the host glue.
+ */
+
+import {
+  clearPluginAuditForTests,
+  readPluginAudit,
+  readPluginAuditFor,
+  recordPluginWrite,
+} from '@/utils/pluginAudit'
+
+describe('pluginAudit', () => {
+  beforeEach(() => clearPluginAuditForTests())
+
+  test('records a create entry with the requested fields', () => {
+    recordPluginWrite({
+      pluginId: 'demo',
+      op: 'create',
+      target: 'note-1',
+      ok: true,
+      conflictResolved: 'none',
+    })
+    const entries = readPluginAudit()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      pluginId: 'demo',
+      op: 'create',
+      target: 'note-1',
+      ok: true,
+      conflictResolved: 'none',
+    })
+    expect(typeof entries[0].ts).toBe('number')
+  })
+
+  test('preserves insertion order (oldest first)', () => {
+    for (let i = 0; i < 5; i++) {
+      recordPluginWrite({
+        pluginId: 'demo',
+        op: 'update',
+        target: `note-${i}`,
+        ok: true,
+      })
+    }
+    const entries = readPluginAudit()
+    expect(entries.map((e) => e.target)).toEqual([
+      'note-0',
+      'note-1',
+      'note-2',
+      'note-3',
+      'note-4',
+    ])
+  })
+
+  test('rolls off the oldest entry past MAX_ENTRIES', () => {
+    // MAX_ENTRIES is 500 (internal). Push 510 and verify we keep the
+    // last 500 with the oldest 10 dropped.
+    for (let i = 0; i < 510; i++) {
+      recordPluginWrite({ pluginId: 'demo', op: 'create', target: `n-${i}`, ok: true })
+    }
+    const entries = readPluginAudit()
+    expect(entries).toHaveLength(500)
+    expect(entries[0].target).toBe('n-10')
+    expect(entries[entries.length - 1].target).toBe('n-509')
+  })
+
+  test('readPluginAuditFor filters by plugin id', () => {
+    recordPluginWrite({ pluginId: 'a', op: 'create', target: 'a-1', ok: true })
+    recordPluginWrite({ pluginId: 'b', op: 'create', target: 'b-1', ok: true })
+    recordPluginWrite({ pluginId: 'a', op: 'delete', target: 'a-1', ok: true })
+    expect(readPluginAuditFor('a').map((e) => e.target)).toEqual(['a-1', 'a-1'])
+    expect(readPluginAuditFor('b').map((e) => e.target)).toEqual(['b-1'])
+  })
+
+  test('error string lands on failed entries', () => {
+    recordPluginWrite({
+      pluginId: 'demo',
+      op: 'delete',
+      target: 'missing',
+      ok: false,
+      error: 'note "missing" does not exist',
+    })
+    const e = readPluginAudit()[0]
+    expect(e.ok).toBe(false)
+    expect(e.error).toMatch(/does not exist/)
+  })
+
+  test('flushes to localStorage so a fresh reader picks it up', async () => {
+    recordPluginWrite({ pluginId: 'demo', op: 'create', target: 'note-1', ok: true })
+    // Allow the 250 ms debounce timer to fire.
+    await new Promise((r) => setTimeout(r, 300))
+    const raw = localStorage.getItem('noteser-plugin-audit')
+    expect(raw).not.toBeNull()
+    expect(raw).toContain('note-1')
+  })
+})

--- a/src/__tests__/plugins/pluginInstallConfirmModal.test.tsx
+++ b/src/__tests__/plugins/pluginInstallConfirmModal.test.tsx
@@ -262,3 +262,63 @@ describe('PluginInstallConfirmModal — pre-fetched record path', () => {
     expect(mockFetchPluginForInstall).not.toHaveBeenCalled()
   })
 })
+
+describe('PluginInstallConfirmModal — destructive permissions (v1.2 PR D)', () => {
+  test('renders vault.write in the destructive section with a red bullet + ack checkbox', async () => {
+    mockFetchPluginForInstall.mockResolvedValueOnce(
+      makeRecord({
+        manifest: {
+          ...baseManifest,
+          permissions: ['vault.write'],
+        },
+      }),
+    )
+    openWithUrl()
+    render(<PluginInstallConfirmModal />)
+    await screen.findByTestId('plugin-preview-body')
+
+    // Destructive section renders.
+    expect(screen.getByTestId('plugin-preview-destructive-section')).toBeInTheDocument()
+    expect(screen.getByTestId('plugin-preview-destructive-vault.write')).toHaveTextContent(
+      'vault.write',
+    )
+    expect(screen.getByTestId('plugin-preview-destructive-vault.write')).toHaveTextContent(
+      PERMISSION_DESCRIPTIONS['vault.write'],
+    )
+
+    // vault.write should NOT also appear in the informational capability list.
+    expect(
+      screen.queryByTestId('plugin-preview-capability-vault.write'),
+    ).not.toBeInTheDocument()
+
+    // Install is disabled until the user acks the destructive permission.
+    const installBtn = screen.getByTestId('plugin-install-confirm') as HTMLButtonElement
+    expect(installBtn).toBeDisabled()
+
+    const ack = screen.getByTestId('plugin-preview-destructive-ack-vault.write')
+    const user = userEvent.setup()
+    await user.click(ack)
+    expect(installBtn).not.toBeDisabled()
+  })
+
+  test('mixed manifest puts file-save in the informational list and vault.write in destructive', async () => {
+    mockFetchPluginForInstall.mockResolvedValueOnce(
+      makeRecord({
+        manifest: {
+          ...baseManifest,
+          permissions: ['file-save', 'vault.write'],
+        },
+      }),
+    )
+    openWithUrl()
+    render(<PluginInstallConfirmModal />)
+    await screen.findByTestId('plugin-preview-body')
+
+    expect(screen.getByTestId('plugin-preview-capability-file-save')).toBeInTheDocument()
+    expect(screen.getByTestId('plugin-preview-destructive-vault.write')).toBeInTheDocument()
+
+    // file-save uses the informational SURFACE_DESCRIPTIONS-style copy; ensure
+    // the SURFACE export is still reachable so the smoke test does not regress.
+    expect(typeof SURFACE_DESCRIPTIONS.commands).toBe('string')
+  })
+})

--- a/src/__tests__/plugins/vaultWrite.test.ts
+++ b/src/__tests__/plugins/vaultWrite.test.ts
@@ -1,0 +1,464 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Plugin v1.2 PR D — `vault.write` capability.
+ *
+ * Covers:
+ *  - Manifest validator accepts `vault.write`, rejects unknown values,
+ *    and `isDestructivePermission` flags it.
+ *  - PluginHost.permissionDenialReason rejects worker:requestVaultWrite
+ *    when the permission was not declared OR was revoked.
+ *  - Round-trip per op: create, update, delete, createFolder.
+ *  - Title-collision resolver suffixes once + chains on repeat.
+ *  - Audit log captures one entry per accepted op AND per rejection
+ *    that survived the permission gate (validation failure).
+ */
+
+import {
+  validateManifest,
+  isDestructivePermission,
+  PERMISSIONS,
+  DESTRUCTIVE_PERMISSIONS,
+  PERMISSION_DESCRIPTIONS,
+} from '@/plugins/manifest'
+import { PluginHost, type MinimalWorker } from '@/plugins/PluginHost'
+import type { HostToWorker, WorkerToHost } from '@/plugins/protocol'
+import { useNoteStore } from '@/stores/noteStore'
+import { useFolderStore } from '@/stores/folderStore'
+import { usePluginInstallStore } from '@/stores/pluginInstallStore'
+import {
+  readPluginAudit,
+  clearPluginAuditForTests,
+} from '@/utils/pluginAudit'
+
+// We exercise the singleton's vault-write handler indirectly via
+// PluginHost listener events. To do that we have to import the
+// singleton wiring AFTER zeroing the stores; the singleton resolves
+// `useNoteStore.getState()` lazily so each test gets a fresh vault.
+
+function makeFakeWorker(manifest: {
+  id: string
+  name: string
+  version: string
+  surfaces: object
+  permissions?: string[]
+}): { worker: MinimalWorker; sent: HostToWorker[]; inject: (data: unknown) => void } {
+  const sent: HostToWorker[] = []
+  let handler: ((event: MessageEvent) => void) | null = null
+  const worker: MinimalWorker = {
+    onmessage: null,
+    postMessage(message: unknown) {
+      sent.push(message as HostToWorker)
+      const msg = message as HostToWorker
+      if (msg.type === 'host:boot') {
+        queueMicrotask(() => {
+          handler?.({
+            data: { type: 'worker:ready', seq: msg.seq, manifest } as WorkerToHost,
+          } as MessageEvent)
+        })
+      }
+    },
+    terminate() {
+      handler = null
+    },
+  } as MinimalWorker
+  Object.defineProperty(worker, 'onmessage', {
+    configurable: true,
+    get() {
+      return handler
+    },
+    set(v) {
+      handler = v
+    },
+  })
+  return {
+    worker,
+    sent,
+    inject(data: unknown) {
+      handler?.({ data } as MessageEvent)
+    },
+  }
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function resetVaultStores(): void {
+  useNoteStore.setState({ notes: [], selectedNoteId: null })
+  useFolderStore.setState({
+    folders: [],
+    activeFolderId: null,
+    expandedFolders: {},
+    deletedFolderPaths: [],
+  })
+  usePluginInstallStore.setState({ records: {} })
+}
+
+describe('manifest: vault.write permission', () => {
+  const base = {
+    id: 'writer',
+    name: 'Writer',
+    version: '1.0.0',
+    surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+  }
+
+  test('PERMISSIONS includes vault.write', () => {
+    expect(PERMISSIONS).toContain('vault.write')
+  })
+
+  test('PERMISSION_DESCRIPTIONS covers vault.write', () => {
+    expect(typeof PERMISSION_DESCRIPTIONS['vault.write']).toBe('string')
+    expect(PERMISSION_DESCRIPTIONS['vault.write'].length).toBeGreaterThan(0)
+  })
+
+  test('validateManifest accepts vault.write', () => {
+    const r = validateManifest({ ...base, permissions: ['vault.write'] })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.permissions).toEqual(['vault.write'])
+  })
+
+  test('validateManifest rejects unknown values', () => {
+    const r = validateManifest({ ...base, permissions: ['vault.write', 'rm -rf'] })
+    expect(r.ok).toBe(false)
+  })
+
+  test('isDestructivePermission flags vault.write', () => {
+    expect(isDestructivePermission('vault.write')).toBe(true)
+    expect(isDestructivePermission('file-save')).toBe(false)
+    expect(isDestructivePermission('file-open')).toBe(false)
+    expect(DESTRUCTIVE_PERMISSIONS).toEqual(expect.arrayContaining(['vault.write']))
+  })
+})
+
+describe('PluginHost.vault.write permission gate', () => {
+  test('refuses worker:requestVaultWrite when permission not declared', async () => {
+    const fake = makeFakeWorker({
+      id: 'no-perm',
+      name: 'No perm',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'no-perm', pluginSource: '' })
+
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 1,
+      op: { kind: 'create', title: 'X', body: '' },
+    })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultWriteResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.requestSeq).toBe(1)
+      expect(reply.error).toMatch(/vault\.write/)
+    }
+  })
+
+  test('refuses worker:requestVaultWrite when permission was revoked', async () => {
+    const fake = makeFakeWorker({
+      id: 'revoked',
+      name: 'Revoked',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.write'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'revoked', pluginSource: '' })
+    host.revokePermission('revoked', 'vault.write')
+
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 2,
+      op: { kind: 'create', title: 'X', body: '' },
+    })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultWriteResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.error).toMatch(/revoked/i)
+    }
+  })
+
+  test('does NOT short-circuit when permission IS declared and not revoked', async () => {
+    const fake = makeFakeWorker({
+      id: 'allowed',
+      name: 'Allowed',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.write'],
+    })
+    const events: string[] = []
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    host.on((e) => events.push(e.type))
+    await host.load({ pluginId: 'allowed', pluginSource: '' })
+
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 3,
+      op: { kind: 'create', title: 'X', body: '' },
+    })
+    await flush()
+
+    expect(events).toContain('vaultWriteRequested')
+    const earlyError = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.ok === false,
+    )
+    expect(earlyError).toBeUndefined()
+  })
+
+  test('respondVaultWrite includes id + conflictResolved on success', async () => {
+    const fake = makeFakeWorker({
+      id: 'allowed2',
+      name: 'Allowed 2',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.write'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'allowed2', pluginSource: '' })
+
+    host.respondVaultWrite('allowed2', 42, {
+      ok: true,
+      id: 'note-1',
+      conflictResolved: 'suffix',
+    })
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultWriteResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') {
+      expect(reply.ok).toBe(true)
+      expect(reply.id).toBe('note-1')
+      expect(reply.conflictResolved).toBe('suffix')
+      expect(reply.requestSeq).toBe(42)
+    }
+  })
+})
+
+// ─── End-to-end: singleton vault.write handler ─────────────────────────────
+//
+// These tests go through `handleVaultWriteRequest` (the host glue),
+// which mutates useNoteStore + useFolderStore and records audit
+// entries. The PluginHost's listener wires to the singleton lazily, so
+// to keep these tests deterministic we drive the host directly and
+// import the singleton wiring to trigger its handler.
+
+describe('singleton: vault.write end-to-end', () => {
+  beforeEach(() => {
+    resetVaultStores()
+    clearPluginAuditForTests()
+  })
+
+  async function bootedHost(pluginId: string, withPerm = true): Promise<{
+    host: PluginHost
+    fake: ReturnType<typeof makeFakeWorker>
+  }> {
+    const fake = makeFakeWorker({
+      id: pluginId,
+      name: pluginId,
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      ...(withPerm ? { permissions: ['vault.write'] } : {}),
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    // Import + wire the singleton's vault-write handler manually.
+    // We can't share the app-wide singleton here because each test
+    // wants a fresh host. Replicate the wiring: dispatch
+    // 'vaultWriteRequested' through this host's listener.
+    const { wireSingletonHandlersForTests } = await import('@/plugins/pluginHostSingleton')
+    wireSingletonHandlersForTests(host)
+    await host.load({ pluginId, pluginSource: '' })
+    return { host, fake }
+  }
+
+  test('createNote: round-trips and writes through useNoteStore', async () => {
+    const { fake } = await bootedHost('p1')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 10,
+      op: { kind: 'create', title: 'Hello', body: '# Hi', folderPath: 'Inbox' },
+    })
+    await flush()
+
+    const reply = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.requestSeq === 10,
+    )
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') {
+      expect(reply.ok).toBe(true)
+      expect(typeof reply.id).toBe('string')
+      expect(reply.conflictResolved).toBe('none')
+    }
+    const notes = useNoteStore.getState().notes
+    expect(notes).toHaveLength(1)
+    expect(notes[0].title).toBe('Hello')
+    expect(notes[0].folderId).not.toBeNull()
+    const folder = useFolderStore.getState().folders.find((f) => f.id === notes[0].folderId)
+    expect(folder?.name).toBe('Inbox')
+
+    const audit = readPluginAudit()
+    expect(audit).toHaveLength(1)
+    expect(audit[0].op).toBe('create')
+    expect(audit[0].ok).toBe(true)
+    expect(audit[0].pluginId).toBe('p1')
+  })
+
+  test('createNote: title collision resolves with " (imported)" suffix', async () => {
+    const { fake } = await bootedHost('p2')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 11,
+      op: { kind: 'create', title: 'Twin', body: 'a' },
+    })
+    await flush()
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 12,
+      op: { kind: 'create', title: 'Twin', body: 'b' },
+    })
+    await flush()
+
+    const replies = fake.sent.filter(
+      (m): m is Extract<HostToWorker, { type: 'host:vaultWriteResult' }> =>
+        m.type === 'host:vaultWriteResult',
+    )
+    expect(replies).toHaveLength(2)
+    expect(replies[0].conflictResolved).toBe('none')
+    expect(replies[1].conflictResolved).toBe('suffix')
+
+    const titles = useNoteStore
+      .getState()
+      .notes.map((n) => n.title)
+      .sort()
+    expect(titles).toEqual(['Twin', 'Twin (imported)'])
+
+    // Third invocation: should chain to "(imported 2)".
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 13,
+      op: { kind: 'create', title: 'Twin', body: 'c' },
+    })
+    await flush()
+    const titles2 = useNoteStore
+      .getState()
+      .notes.map((n) => n.title)
+    expect(titles2).toEqual(
+      expect.arrayContaining(['Twin', 'Twin (imported)', 'Twin (imported 2)']),
+    )
+    expect(titles2).toHaveLength(3)
+  })
+
+  test('updateNote: round-trips and patches title + body', async () => {
+    const { fake } = await bootedHost('p3')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 20,
+      op: { kind: 'create', title: 'Old', body: 'body' },
+    })
+    await flush()
+    const noteId = useNoteStore.getState().notes[0].id
+
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 21,
+      op: { kind: 'update', id: noteId, title: 'New', body: 'updated' },
+    })
+    await flush()
+
+    const reply = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.requestSeq === 21,
+    )
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') expect(reply.ok).toBe(true)
+
+    const note = useNoteStore.getState().notes.find((n) => n.id === noteId)
+    expect(note?.title).toBe('New')
+    expect(note?.content).toContain('updated')
+
+    const audit = readPluginAudit()
+    expect(audit.some((e) => e.op === 'update' && e.target === noteId)).toBe(true)
+  })
+
+  test('deleteNote: round-trips and soft-deletes', async () => {
+    const { fake } = await bootedHost('p4')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 30,
+      op: { kind: 'create', title: 'Doomed', body: 'x' },
+    })
+    await flush()
+    const noteId = useNoteStore.getState().notes[0].id
+
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 31,
+      op: { kind: 'delete', id: noteId },
+    })
+    await flush()
+
+    const reply = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.requestSeq === 31,
+    )
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') expect(reply.ok).toBe(true)
+
+    const note = useNoteStore.getState().notes.find((n) => n.id === noteId)
+    expect(note?.isDeleted).toBe(true)
+    expect(note?.deletedAt).not.toBeNull()
+
+    const audit = readPluginAudit()
+    expect(audit.some((e) => e.op === 'delete' && e.target === noteId && e.ok === true)).toBe(true)
+  })
+
+  test('createFolder: round-trips and creates folder tree', async () => {
+    const { fake } = await bootedHost('p5')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 40,
+      op: { kind: 'createFolder', path: 'Imported/Obsidian' },
+    })
+    await flush()
+
+    const reply = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.requestSeq === 40,
+    )
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') expect(reply.ok).toBe(true)
+
+    const folders = useFolderStore.getState().folders
+    expect(folders.some((f) => f.name === 'Imported')).toBe(true)
+    expect(folders.some((f) => f.name === 'Obsidian')).toBe(true)
+
+    const audit = readPluginAudit()
+    expect(audit.some((e) => e.op === 'createFolder' && e.target === 'Imported/Obsidian')).toBe(true)
+  })
+
+  test('createNote: validation failure surfaces ok=false + audit entry', async () => {
+    const { fake } = await bootedHost('p6')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 50,
+      op: { kind: 'create', title: '', body: '' },
+    })
+    await flush()
+
+    const reply = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.requestSeq === 50,
+    )
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.error).toMatch(/title/i)
+    }
+    expect(useNoteStore.getState().notes).toHaveLength(0)
+
+    const audit = readPluginAudit()
+    expect(audit.some((e) => e.op === 'create' && e.ok === false)).toBe(true)
+  })
+})

--- a/src/components/modals/PluginInstallConfirmModal.tsx
+++ b/src/components/modals/PluginInstallConfirmModal.tsx
@@ -19,7 +19,7 @@
 // in src/plugins/manifest.ts — do not invent new strings here.
 
 import { useEffect, useRef, useState } from 'react'
-import { CheckCircleIcon, ShieldCheckIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import { CheckCircleIcon, ShieldCheckIcon, ShieldExclamationIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { Modal, Button } from '@/components/ui'
 import { useUIStore } from '@/stores'
 import {
@@ -29,6 +29,7 @@ import {
 import {
   PERMISSION_DESCRIPTIONS,
   SURFACE_DESCRIPTIONS,
+  isDestructivePermission,
   type PluginPermission,
   type PluginSurfaceKind,
 } from '@/plugins/manifest'
@@ -187,6 +188,15 @@ const PreviewBody = ({ record, busy, installError, onCancel, onInstall }: Previe
   const { manifest } = record
   const surfaceRows = buildSurfaceRows(manifest.surfaces)
   const permissions: PluginPermission[] = manifest.permissions ?? []
+  const destructivePerms = permissions.filter(isDestructivePermission)
+  const informationalPerms = permissions.filter((p) => !isDestructivePermission(p))
+
+  // Per-destructive-permission opt-in. Install button stays disabled
+  // until the user explicitly acknowledges EACH destructive capability.
+  // Section 8 of the plan mandates this gate.
+  const [acknowledged, setAcknowledged] = useState<Record<string, boolean>>({})
+  const allAcknowledged = destructivePerms.every((p) => acknowledged[p] === true)
+  const installDisabled = busy || !allAcknowledged
 
   return (
     <div className="space-y-4" data-testid="plugin-preview-body">
@@ -250,7 +260,7 @@ const PreviewBody = ({ record, busy, installError, onCancel, onInstall }: Previe
                 </div>
               </li>
             ))}
-            {permissions.map((perm) => (
+            {informationalPerms.map((perm) => (
               <li
                 key={perm}
                 className="flex items-start gap-2 text-sm"
@@ -269,13 +279,59 @@ const PreviewBody = ({ record, busy, installError, onCancel, onInstall }: Previe
         )}
       </section>
 
+      {destructivePerms.length > 0 && (
+        <section
+          className="rounded-md border border-red-500/40 bg-red-500/5 p-3 space-y-2"
+          data-testid="plugin-preview-destructive-section"
+        >
+          <div className="text-xs uppercase tracking-wide text-red-300 mb-1 flex items-center gap-1 font-semibold">
+            <ShieldExclamationIcon className="w-4 h-4" />
+            Destructive permissions
+          </div>
+          <ul className="space-y-2">
+            {destructivePerms.map((perm) => (
+              <li
+                key={perm}
+                className="flex items-start gap-2 text-sm"
+                data-testid={`plugin-preview-destructive-${perm}`}
+              >
+                <span
+                  className="mt-2 w-2 h-2 rounded-full bg-red-500 flex-shrink-0"
+                  aria-hidden="true"
+                />
+                <div className="flex-1">
+                  <span className="font-medium text-red-200">{perm}</span>
+                  <div className="text-xs text-red-100/80 mt-0.5">
+                    {PERMISSION_DESCRIPTIONS[perm]}
+                  </div>
+                  <label className="mt-2 flex items-start gap-2 text-xs text-red-100 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="mt-0.5"
+                      checked={acknowledged[perm] === true}
+                      onChange={(e) =>
+                        setAcknowledged((s) => ({ ...s, [perm]: e.target.checked }))
+                      }
+                      data-testid={`plugin-preview-destructive-ack-${perm}`}
+                    />
+                    <span>
+                      I understand this plugin can make irreversible changes to my vault.
+                    </span>
+                  </label>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
       {installError && <div className="text-xs text-red-300">{installError}</div>}
 
       <div className="flex justify-end gap-2 pt-2 border-t border-obsidianBorder">
         <Button variant="ghost" onClick={onCancel} disabled={busy} data-testid="plugin-install-cancel">
           Cancel
         </Button>
-        <Button onClick={onInstall} disabled={busy} data-testid="plugin-install-confirm">
+        <Button onClick={onInstall} disabled={installDisabled} data-testid="plugin-install-confirm">
           {busy ? 'Installing…' : 'Install'}
         </Button>
       </div>

--- a/src/components/modals/PluginsSettingsPanel.tsx
+++ b/src/components/modals/PluginsSettingsPanel.tsx
@@ -9,7 +9,7 @@
 // so the user sees the same preview + permissions screen.
 
 import { useMemo, useState } from 'react'
-import { ArrowPathIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { ArrowPathIcon, ShieldExclamationIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { usePluginInstallStore } from '@/stores/pluginInstallStore'
 import { usePluginStore } from '@/stores/pluginStore'
 import { useNoteStore } from '@/stores/noteStore'
@@ -20,8 +20,13 @@ import {
   setPluginPermissionRevoked,
   uninstallPlugin,
 } from '@/plugins/pluginHostSingleton'
-import { PERMISSION_DESCRIPTIONS, type PluginPermission } from '@/plugins/manifest'
 import { scanVaultForManifests, type VaultManifestCandidate } from '@/plugins/vaultScan'
+import {
+  isDestructivePermission,
+  PERMISSION_DESCRIPTIONS,
+  type PluginPermission,
+} from '@/plugins/manifest'
+import { readPluginAudit, type PluginAuditEntry } from '@/utils/pluginAudit'
 
 export const PluginsSettingsPanel = () => {
   const records = usePluginInstallStore((s) => s.records)
@@ -213,11 +218,16 @@ export const PluginsSettingsPanel = () => {
               const running = m.id in loadedPlugins
               const declaredPermissions: PluginPermission[] = m.permissions ?? []
               const revoked = new Set<PluginPermission>(r.revokedPermissions ?? [])
+              const grantedDestructive = declaredPermissions.filter(isDestructivePermission)
               return (
-                <li key={m.id} className="p-3 flex flex-col gap-2">
+                <li
+                  key={m.id}
+                  className="p-3 flex flex-col gap-2"
+                  data-testid={`settings-plugins-row-${m.id}`}
+                >
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex-1 min-w-0">
-                      <div className="flex items-baseline gap-2">
+                      <div className="flex items-baseline gap-2 flex-wrap">
                         <span className="text-sm font-medium text-obsidianText">{m.name}</span>
                         <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
                           v{m.version}
@@ -229,6 +239,24 @@ export const PluginsSettingsPanel = () => {
                         ) : (
                           <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
                             stopped
+                          </span>
+                        )}
+                        {/* PR D: destructive-permission badge. Persists for
+                            as long as the destructive permission stays
+                            declared in the manifest — even after the user
+                            revokes it from the toggle row below. The
+                            user always sees at a glance which plugins
+                            were granted dangerous capabilities. */}
+                        {grantedDestructive.length > 0 && (
+                          <span
+                            className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide font-semibold text-red-300 bg-red-500/10 border border-red-500/40 px-1.5 py-0.5 rounded"
+                            title={grantedDestructive
+                              .map((p) => PERMISSION_DESCRIPTIONS[p])
+                              .join(' ')}
+                            data-testid={`settings-plugins-destructive-badge-${m.id}`}
+                          >
+                            <ShieldExclamationIcon className="w-3 h-3" />
+                            Destructive
                           </span>
                         )}
                       </div>
@@ -277,33 +305,38 @@ export const PluginsSettingsPanel = () => {
                       <div className="text-[11px] uppercase tracking-wide text-obsidianSecondaryText">
                         Permissions
                       </div>
-                      {declaredPermissions.map((perm) => (
-                        <label
-                          key={perm}
-                          className="flex items-start gap-2 text-xs text-obsidianText cursor-pointer"
-                          data-testid={`settings-plugins-permission-${m.id}-${perm}`}
-                        >
-                          <input
-                            type="checkbox"
-                            className="mt-0.5"
-                            checked={!revoked.has(perm)}
-                            onChange={(e) =>
-                              setPluginPermissionRevoked(m.id, perm, !e.target.checked)
-                            }
-                          />
-                          <span className="flex-1">
-                            <span className="font-medium">{perm}</span>
-                            <span className="block text-[11px] text-obsidianSecondaryText/80 mt-0.5">
-                              {PERMISSION_DESCRIPTIONS[perm]}
-                            </span>
-                            {revoked.has(perm) && (
-                              <span className="block text-[11px] text-amber-300 mt-0.5">
-                                Revoked — the plugin&apos;s next call to this capability will be rejected.
+                      {declaredPermissions.map((perm) => {
+                        const destructive = isDestructivePermission(perm)
+                        return (
+                          <label
+                            key={perm}
+                            className={`flex items-start gap-2 text-xs cursor-pointer ${
+                              destructive ? 'text-red-200' : 'text-obsidianText'
+                            }`}
+                            data-testid={`settings-plugins-permission-${m.id}-${perm}`}
+                          >
+                            <input
+                              type="checkbox"
+                              className="mt-0.5"
+                              checked={!revoked.has(perm)}
+                              onChange={(e) =>
+                                setPluginPermissionRevoked(m.id, perm, !e.target.checked)
+                              }
+                            />
+                            <span className="flex-1">
+                              <span className="font-medium">{perm}</span>
+                              <span className="block text-[11px] text-obsidianSecondaryText/80 mt-0.5">
+                                {PERMISSION_DESCRIPTIONS[perm]}
                               </span>
-                            )}
-                          </span>
-                        </label>
-                      ))}
+                              {revoked.has(perm) && (
+                                <span className="block text-[11px] text-amber-300 mt-0.5">
+                                  Revoked — the plugin&apos;s next call to this capability will be rejected.
+                                </span>
+                              )}
+                            </span>
+                          </label>
+                        )
+                      })}
                     </div>
                   )}
                 </li>
@@ -313,6 +346,8 @@ export const PluginsSettingsPanel = () => {
         )}
       </section>
 
+      <PluginAuditPanel />
+
       <section className="text-xs text-obsidianSecondaryText border-t border-obsidianBorder pt-4">
         Plugins run in an isolated Web Worker and only have access to the
         capabilities the host exposes. They cannot read your GitHub token
@@ -321,5 +356,74 @@ export const PluginsSettingsPanel = () => {
         on / off requires a page reload.
       </section>
     </div>
+  )
+}
+
+const PluginAuditPanel = () => {
+  // The audit log is a localStorage-backed ring buffer. We snapshot on
+  // mount + on every Refresh click — no live subscription, because the
+  // log is append-only and the Settings modal is short-lived.
+  const [entries, setEntries] = useState<ReadonlyArray<PluginAuditEntry>>(() => readPluginAudit())
+  const refresh = () => setEntries(readPluginAudit())
+  // Newest first for the table; original buffer is oldest-first.
+  const newestFirst = useMemo(() => entries.slice().reverse(), [entries])
+  return (
+    <section data-testid="settings-plugins-audit">
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-sm text-obsidianText">Plugin activity</div>
+        <button
+          type="button"
+          onClick={refresh}
+          className="text-[11px] text-obsidianSecondaryText hover:text-obsidianText"
+        >
+          Refresh
+        </button>
+      </div>
+      <p className="text-xs text-obsidianSecondaryText mb-2">
+        Every vault change made by a plugin lands here so you can trace
+        unexpected edits. Up to 500 entries are kept locally.
+      </p>
+      {newestFirst.length === 0 ? (
+        <p
+          className="text-xs text-obsidianSecondaryText"
+          data-testid="settings-plugins-audit-empty"
+        >
+          No plugin activity yet.
+        </p>
+      ) : (
+        <ul className="divide-y divide-obsidianBorder rounded-lg border border-obsidianBorder max-h-48 overflow-y-auto">
+          {newestFirst.slice(0, 50).map((e) => (
+            <li
+              key={`${e.ts}-${e.pluginId}-${e.op}-${e.target}`}
+              className="p-2 text-[11px] flex items-start gap-2"
+              data-testid="settings-plugins-audit-entry"
+            >
+              <span className="text-obsidianSecondaryText whitespace-nowrap">
+                {new Date(e.ts).toLocaleString()}
+              </span>
+              <span className="text-obsidianText">
+                <code className="text-[10px] bg-obsidianHighlight/40 px-1 rounded">
+                  {e.pluginId}
+                </code>{' '}
+                <span
+                  className={
+                    e.op === 'delete' ? 'text-red-300 font-medium' : 'text-amber-300 font-medium'
+                  }
+                >
+                  {e.op}
+                </span>{' '}
+                <span className="text-obsidianSecondaryText break-all">{e.target}</span>
+                {e.conflictResolved === 'suffix' && (
+                  <span className="text-[10px] uppercase ml-1 text-amber-300">renamed</span>
+                )}
+                {e.ok === false && (
+                  <span className="text-[10px] uppercase ml-1 text-red-300">failed</span>
+                )}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   )
 }

--- a/src/plugins/PluginHost.ts
+++ b/src/plugins/PluginHost.ts
@@ -113,7 +113,36 @@ export type PluginHostEvent =
       viewId: string
       node: unknown
     }
+  | {
+      type: 'vaultWriteRequested'
+      pluginId: string
+      requestSeq: number
+      op: VaultWriteOp
+    }
   | { type: 'rateLimited'; pluginId: string }
+
+/** Discriminated union over the four vault.write ops carried in a
+ *  `worker:requestVaultWrite` envelope. Identical shape to the wire
+ *  protocol's `op` field — re-exported here so the singleton's
+ *  vault-write handler can switch on it without re-importing the
+ *  protocol module. */
+export type VaultWriteOp =
+  | {
+      kind: 'create'
+      title: string
+      body: string
+      folderPath?: string
+      frontmatter?: Record<string, unknown>
+    }
+  | {
+      kind: 'update'
+      id: string
+      title?: string
+      body?: string
+      frontmatter?: Record<string, unknown>
+    }
+  | { kind: 'delete'; id: string }
+  | { kind: 'createFolder'; path: string }
 
 interface WorkerEntry {
   plugin: InstalledPlugin
@@ -622,6 +651,13 @@ export class PluginHost {
           })
           return
         }
+        if (entry.plugin.revokedPermissions.has('file-save')) {
+          this.respondFileSave(pluginId, msg.seq, {
+            ok: false,
+            error: 'Permission "file-save" was revoked.',
+          })
+          return
+        }
         this.emit({
           type: 'fileSaveRequested',
           pluginId,
@@ -664,6 +700,13 @@ export class PluginHost {
           this.respondFileOpen(pluginId, msg.seq, {
             ok: false,
             error: 'Plugin did not declare the `file-open` permission.',
+          })
+          return
+        }
+        if (entry.plugin.revokedPermissions.has('file-open')) {
+          this.respondFileOpen(pluginId, msg.seq, {
+            ok: false,
+            error: 'Permission "file-open" was revoked.',
           })
           return
         }
@@ -787,6 +830,36 @@ export class PluginHost {
           node: msg.node,
         })
         return
+
+      case 'worker:requestVaultWrite': {
+        // v1.2 capability — same two-layer gate PR C uses for
+        // vault.read.all: declared in manifest AND not currently
+        // revoked at runtime. Distinct error strings so the dev
+        // console clarifies; the plugin sees the same Promise
+        // rejection either way.
+        const declared = entry.plugin.manifest.permissions?.includes('vault.write') ?? false
+        if (!declared) {
+          this.respondVaultWrite(pluginId, msg.seq, {
+            ok: false,
+            error: 'Plugin did not declare the `vault.write` permission.',
+          })
+          return
+        }
+        if (entry.plugin.revokedPermissions.has('vault.write')) {
+          this.respondVaultWrite(pluginId, msg.seq, {
+            ok: false,
+            error: 'Permission "vault.write" was revoked.',
+          })
+          return
+        }
+        this.emit({
+          type: 'vaultWriteRequested',
+          pluginId,
+          requestSeq: msg.seq,
+          op: msg.op,
+        })
+        return
+      }
     }
   }
 
@@ -911,6 +984,30 @@ export class PluginHost {
       type: 'host:fullscreenClosed',
       seq: ++this.seqCounter,
       viewId,
+    })
+  }
+
+  /** Surface adapter / singleton wires the vault write outcome back to
+   *  the worker. Successful `create` carries the new note id plus the
+   *  conflict-resolution outcome. Other ops omit `id` and
+   *  `conflictResolved`. v1.2 PR D capability. */
+  respondVaultWrite(
+    pluginId: string,
+    requestSeq: number,
+    result:
+      | { ok: true; id: string; conflictResolved: 'none' | 'suffix' }
+      | { ok: true }
+      | { ok: false; error: string },
+  ): void {
+    this.send(pluginId, {
+      type: 'host:vaultWriteResult',
+      seq: ++this.seqCounter,
+      requestSeq,
+      ok: result.ok,
+      ...(result.ok && 'id' in result
+        ? { id: result.id, conflictResolved: result.conflictResolved }
+        : {}),
+      ...(!result.ok ? { error: result.error } : {}),
     })
   }
 

--- a/src/plugins/__tests__/vaultRead.test.ts
+++ b/src/plugins/__tests__/vaultRead.test.ts
@@ -81,10 +81,11 @@ describe('manifest accepts vault.read.all', () => {
   })
 
   test('validator still rejects unknown permissions', () => {
-    const r = validateManifest({ ...base, permissions: ['vault.read.all', 'vault.write'] })
+    // PRs C/D/E/F each added a v1.2 permission; pick a name that has
+    // never shipped to verify the rejection arm still works.
+    const r = validateManifest({ ...base, permissions: ['vault.read.all', 'network.fetch'] })
     expect(r.ok).toBe(false)
-    // Error must mention the unknown one specifically.
-    expect(r.errors.some((e) => e.includes('vault.write'))).toBe(true)
+    expect(r.errors.some((e) => e.includes('network.fetch'))).toBe(true)
   })
 
   test('validator deduplicates a repeated vault.read.all', () => {

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -32,17 +32,19 @@ export interface PluginManifest {
  *  by the validator. The host gates each runtime capability call against
  *  the granted set stored alongside the install record.
  *
- *  v1.1 added the two `file-*` capabilities; v1.2 starts layering the
- *  vault / fs capabilities. `vault.read.all` reads every note's body +
- *  frontmatter (PR C). `vault.events` subscribes to vault-change
- *  pulses (PR F). `fs.open-directory` pops the native directory picker
- *  for importer workflows (PR E). */
+ *  v1.1 added the two `file-*` capabilities; v1.2 layers in vault /
+ *  fs capabilities. PR C lands `vault.read.all` (read every note's
+ *  body + frontmatter); PR D lands `vault.write` (the first
+ *  DESTRUCTIVE permission — see below); PR E lands `fs.open-directory`
+ *  (native directory picker for importer workflows); PR F lands
+ *  `vault.events` (subscribe to vault-change pulses). */
 export const PERMISSIONS = [
   'file-save',         // v1.1
   'file-open',         // v1.1
-  'vault.read.all',    // v1.2 — see docs/plugins-v1.2-plan.md §4.1
-  'vault.events',      // v1.2 — see docs/plugins-v1.2-plan.md §4.4
-  'fs.open-directory', // v1.2 — see docs/plugins-v1.2-plan.md §4.3
+  'vault.read.all',    // v1.2 PR C — see docs/plugins-v1.2-plan.md §4.1
+  'vault.write',       // v1.2 PR D — see docs/plugins-v1.2-plan.md §4.2
+  'fs.open-directory', // v1.2 PR E — see docs/plugins-v1.2-plan.md §4.3
+  'vault.events',      // v1.2 PR F — see docs/plugins-v1.2-plan.md §4.4
 ] as const
 export type PluginPermission = (typeof PERMISSIONS)[number]
 
@@ -53,10 +55,26 @@ export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
   'file-open': 'Read a file you pick (opens the native file picker; the plugin sees the bytes of the file you choose, nothing else).',
   'vault.read.all':
     'Read the full content of every note in your vault. Required for features like backlinks, graph views, and AI search.',
+  'vault.write': 'This plugin can create, edit, and delete notes.',
   'vault.events':
     'Listen for changes to the vault. The plugin learns that a note was saved or that you switched notes (by id), but reading the body still requires a separate read permission.',
   'fs.open-directory':
     'Open folders to read files into the plugin. You pick the folder; the plugin sees the file names and contents under that folder, nothing else.',
+}
+
+/** Permissions flagged as DESTRUCTIVE in the install-confirm modal —
+ *  the user sees a red bullet + must opt-in. Required for any
+ *  capability that mutates vault contents.
+ *
+ *  v1.2 introduces `vault.write` as the first destructive permission.
+ *  Future destructive caps (e.g. `network.fetch`, `vault.hard-delete`)
+ *  add themselves here so the UI gating stays single-sourced. */
+export const DESTRUCTIVE_PERMISSIONS: ReadonlyArray<PluginPermission> = [
+  'vault.write',
+]
+
+export function isDestructivePermission(p: PluginPermission): boolean {
+  return DESTRUCTIVE_PERMISSIONS.includes(p)
 }
 
 /** Surface kinds the manifest can declare. Used by the install-preview

--- a/src/plugins/pluginHostSingleton.ts
+++ b/src/plugins/pluginHostSingleton.ts
@@ -16,7 +16,7 @@
 // safety: the function returns null on the server, since Workers do
 // not exist there.
 
-import { PluginHost, type MinimalWorker } from './PluginHost'
+import { PluginHost, type MinimalWorker, type VaultWriteOp } from './PluginHost'
 import { MAX_DIRECTORY_ENTRIES } from './protocol'
 import {
   buildExtensionMatcher,
@@ -39,6 +39,7 @@ import {
   projectPayloadSize,
   MAX_GET_ALL_BYTES,
 } from './vaultSnapshot'
+import { recordPluginWrite } from '@/utils/pluginAudit'
 
 let instance: PluginHost | null = null
 
@@ -531,6 +532,10 @@ function wireListener(host: PluginHost): void {
           .getState()
           .updateActiveFullscreenContent(event.pluginId, event.viewId, event.node)
         return
+
+      case 'vaultWriteRequested':
+        handleVaultWriteRequest(host, event)
+        return
     }
   })
 }
@@ -828,6 +833,311 @@ async function handleFileOpenRequest(
       host.respondFileOpen(pluginId, requestSeq, { ok: false, error: message })
     }
   }
+}
+
+// ─── vault.write capability (PR D) ─────────────────────────────────────────
+//
+// The host writes through the same `useNoteStore.addNote` / `updateNote` /
+// `deleteNote` and `useFolderStore.addFolder` / `ensureFolderPath` paths a
+// user action would use, so sync, indexing, undo, and the Trash UI all
+// behave identically whether the user or a plugin made the change.
+//
+// Conflict resolution: when a `create` lands a title that already
+// exists in the target folder, the host appends " (imported)" to the
+// title and reports `conflictResolved: 'suffix'`. The policy lives
+// here — the importer plugin gets the conflict outcome for free in
+// its progress log and never has to retry.
+//
+// Audit: every accepted op (and every rejection that survives the
+// permission gate) calls recordPluginWrite. Destructive permission
+// demands traceability.
+
+const MAX_TITLE_LEN = 200
+const MAX_BODY_BYTES = 1 * 1024 * 1024 // 1 MiB cap; matches plan §4.2.
+const FOLDER_PATH_RE = /^[^\s/][^/]*(\/[^\s/][^/]*)*$/
+
+function handleVaultWriteRequest(
+  host: PluginHost,
+  event: Extract<import('./PluginHost').PluginHostEvent, { type: 'vaultWriteRequested' }>,
+): void {
+  const { pluginId, requestSeq, op } = event
+  try {
+    switch (op.kind) {
+      case 'create': {
+        const result = applyCreate(pluginId, op)
+        host.respondVaultWrite(pluginId, requestSeq, {
+          ok: true,
+          id: result.id,
+          conflictResolved: result.conflictResolved,
+        })
+        recordPluginWrite({
+          pluginId,
+          op: 'create',
+          target: result.id,
+          ok: true,
+          conflictResolved: result.conflictResolved,
+        })
+        return
+      }
+      case 'update': {
+        applyUpdate(pluginId, op)
+        host.respondVaultWrite(pluginId, requestSeq, { ok: true })
+        recordPluginWrite({ pluginId, op: 'update', target: op.id, ok: true })
+        return
+      }
+      case 'delete': {
+        applyDelete(pluginId, op)
+        host.respondVaultWrite(pluginId, requestSeq, { ok: true })
+        recordPluginWrite({ pluginId, op: 'delete', target: op.id, ok: true })
+        return
+      }
+      case 'createFolder': {
+        applyCreateFolder(pluginId, op)
+        host.respondVaultWrite(pluginId, requestSeq, { ok: true })
+        recordPluginWrite({
+          pluginId,
+          op: 'createFolder',
+          target: op.path,
+          ok: true,
+        })
+        return
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    host.respondVaultWrite(pluginId, requestSeq, { ok: false, error: message })
+    recordPluginWrite({
+      pluginId,
+      op: op.kind,
+      target: extractTarget(op),
+      ok: false,
+      error: message,
+    })
+  }
+}
+
+function extractTarget(op: VaultWriteOp): string {
+  switch (op.kind) {
+    case 'create':
+      return op.title
+    case 'update':
+    case 'delete':
+      return op.id
+    case 'createFolder':
+      return op.path
+  }
+}
+
+/** Resolve a forward-slash folder path to an existing folder id (or
+ *  null for the root). Creates missing segments via
+ *  `useFolderStore.ensureFolderPath` — the same code path the importer
+ *  and pull layer use for "given a path, give me an id". */
+function resolveFolderPath(folderPath: string | undefined): string | null {
+  if (!folderPath || folderPath.length === 0) return null
+  const segments = folderPath.split('/').filter((s) => s.length > 0)
+  if (segments.length === 0) return null
+  return useFolderStore.getState().ensureFolderPath(segments)
+}
+
+function applyCreate(
+  _pluginId: string,
+  op: Extract<VaultWriteOp, { kind: 'create' }>,
+): { id: string; conflictResolved: 'none' | 'suffix' } {
+  const title = (op.title ?? '').trim()
+  if (title.length === 0) throw new Error('createNote: title is required.')
+  if (title.length > MAX_TITLE_LEN) {
+    throw new Error(`createNote: title exceeds ${MAX_TITLE_LEN} chars.`)
+  }
+  const body = op.body ?? ''
+  if (byteLength(body) > MAX_BODY_BYTES) {
+    throw new Error(`createNote: body exceeds ${MAX_BODY_BYTES} bytes.`)
+  }
+  if (op.folderPath !== undefined && op.folderPath.length > 0) {
+    if (!FOLDER_PATH_RE.test(op.folderPath)) {
+      throw new Error(`createNote: invalid folderPath "${op.folderPath}".`)
+    }
+  }
+
+  const folderId = resolveFolderPath(op.folderPath)
+  const noteStore = useNoteStore.getState()
+
+  // Conflict resolution: look for an active (non-trashed) note with the
+  // same title in the same folder. If found, append " (imported)". If
+  // that ALSO collides, append a numeric suffix. The latter case is rare
+  // (two imports of the same source) but we never want to bail entirely.
+  const { resolvedTitle, conflictResolved } = resolveTitleConflict(
+    title,
+    folderId,
+    noteStore.notes,
+  )
+
+  const finalContent = composeContent(resolvedTitle, body, op.frontmatter)
+  const created = noteStore.addNote({
+    title: resolvedTitle,
+    content: finalContent,
+    folderId,
+  })
+  return { id: created.id, conflictResolved }
+}
+
+function applyUpdate(
+  _pluginId: string,
+  op: Extract<VaultWriteOp, { kind: 'update' }>,
+): void {
+  const noteStore = useNoteStore.getState()
+  const note = noteStore.notes.find((n) => n.id === op.id)
+  if (!note || note.isDeleted) {
+    throw new Error(`updateNote: note "${op.id}" does not exist.`)
+  }
+  if (op.body !== undefined && byteLength(op.body) > MAX_BODY_BYTES) {
+    throw new Error(`updateNote: body exceeds ${MAX_BODY_BYTES} bytes.`)
+  }
+  if (op.title !== undefined) {
+    const t = op.title.trim()
+    if (t.length === 0 || t.length > MAX_TITLE_LEN) {
+      throw new Error(`updateNote: title must be 1-${MAX_TITLE_LEN} chars.`)
+    }
+  }
+
+  const patch: { title?: string; content?: string } = {}
+  if (op.title !== undefined) patch.title = op.title.trim()
+  if (op.body !== undefined || op.frontmatter !== undefined) {
+    // Re-compose. If only one of the two was supplied, preserve the
+    // other from the existing note content.
+    const nextTitle = op.title?.trim() ?? note.title ?? 'Untitled'
+    const nextBody = op.body !== undefined ? op.body : stripFrontmatter(note.content ?? '').body
+    const nextFrontmatter =
+      op.frontmatter !== undefined
+        ? op.frontmatter
+        : stripFrontmatter(note.content ?? '').frontmatter
+    patch.content = composeContent(nextTitle, nextBody, nextFrontmatter)
+  }
+  noteStore.updateNote(op.id, patch)
+}
+
+function applyDelete(
+  _pluginId: string,
+  op: Extract<VaultWriteOp, { kind: 'delete' }>,
+): void {
+  const noteStore = useNoteStore.getState()
+  const note = noteStore.notes.find((n) => n.id === op.id)
+  if (!note || note.isDeleted) {
+    throw new Error(`deleteNote: note "${op.id}" does not exist.`)
+  }
+  // SOFT-delete only — the plan §4.2 forbids hard-delete from a
+  // plugin. The note remains recoverable from the Trash UI.
+  noteStore.deleteNote(op.id)
+}
+
+function applyCreateFolder(
+  _pluginId: string,
+  op: Extract<VaultWriteOp, { kind: 'createFolder' }>,
+): void {
+  if (!FOLDER_PATH_RE.test(op.path)) {
+    throw new Error(`createFolder: invalid path "${op.path}".`)
+  }
+  const segments = op.path.split('/').filter((s) => s.length > 0)
+  if (segments.length === 0) throw new Error('createFolder: path is empty.')
+  useFolderStore.getState().ensureFolderPath(segments)
+}
+
+function resolveTitleConflict(
+  desired: string,
+  folderId: string | null,
+  notes: ReadonlyArray<{ id: string; title?: string; folderId: string | null; isDeleted: boolean }>,
+): { resolvedTitle: string; conflictResolved: 'none' | 'suffix' } {
+  const samFolderActive = notes.filter(
+    (n) => !n.isDeleted && (n.folderId ?? null) === folderId,
+  )
+  const titles = new Set(samFolderActive.map((n) => (n.title ?? '').toLowerCase()))
+  if (!titles.has(desired.toLowerCase())) {
+    return { resolvedTitle: desired, conflictResolved: 'none' }
+  }
+  let candidate = `${desired} (imported)`
+  let n = 2
+  while (titles.has(candidate.toLowerCase())) {
+    candidate = `${desired} (imported ${n})`
+    n++
+  }
+  return { resolvedTitle: candidate, conflictResolved: 'suffix' }
+}
+
+function byteLength(s: string): number {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(s).length
+  }
+  // Rough fallback for environments without TextEncoder (none we ship
+  // to; included so unit tests in node-without-DOM don't trip).
+  return s.length
+}
+
+/** Compose the on-disk note content: optional frontmatter block first,
+ *  then the body. Matches the canonical layout the importer / GitHub
+ *  push layer produce so a plugin-created note round-trips identically. */
+function composeContent(
+  _title: string,
+  body: string,
+  frontmatter: Record<string, unknown> | undefined,
+): string {
+  if (!frontmatter || Object.keys(frontmatter).length === 0) return body
+  const lines = ['---']
+  for (const [k, v] of Object.entries(frontmatter)) {
+    lines.push(`${k}: ${serialiseFrontmatterValue(v)}`)
+  }
+  lines.push('---')
+  lines.push('')
+  lines.push(body)
+  return lines.join('\n')
+}
+
+function serialiseFrontmatterValue(v: unknown): string {
+  if (v === null || v === undefined) return ''
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  if (Array.isArray(v)) {
+    return `[${v.map((x) => serialiseFrontmatterValue(x)).join(', ')}]`
+  }
+  if (typeof v === 'object') return JSON.stringify(v)
+  const s = String(v)
+  return /[:#\[\]{}|>"'\n]/.test(s) ? JSON.stringify(s) : s
+}
+
+/** Split a note body into its frontmatter (parsed) + body. Used by the
+ *  update path so a partial patch ({ body } OR { frontmatter }) leaves
+ *  the other half alone. */
+function stripFrontmatter(content: string): {
+  frontmatter: Record<string, unknown> | undefined
+  body: string
+} {
+  if (!content.startsWith('---\n')) return { frontmatter: undefined, body: content }
+  const end = content.indexOf('\n---', 4)
+  if (end < 0) return { frontmatter: undefined, body: content }
+  const block = content.slice(4, end)
+  const after = content.slice(end + 4).replace(/^\n/, '')
+  const fm: Record<string, unknown> = {}
+  for (const line of block.split('\n')) {
+    const idx = line.indexOf(':')
+    if (idx < 0) continue
+    const k = line.slice(0, idx).trim()
+    const raw = line.slice(idx + 1).trim()
+    fm[k] = raw
+  }
+  return { frontmatter: fm, body: after }
+}
+
+/** Test-only: wire the vault.write handler onto a fresh PluginHost.
+ *
+ *  Production code uses `getPluginHost()` which lazily wires every
+ *  listener (including the file-I/O ones). Unit tests want to drive
+ *  the vault.write path in isolation against a FakeWorker, without
+ *  spinning up the toast / install store wiring. This export lets a
+ *  test subscribe just the vault.write event for the duration of the
+ *  test. Not for production use. */
+export function wireSingletonHandlersForTests(host: PluginHost): void {
+  host.on((event) => {
+    if (event.type === 'vaultWriteRequested') {
+      handleVaultWriteRequest(host, event)
+    }
+  })
 }
 
 function pickFileViaInput(accept: string[] | undefined): Promise<File> {

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -53,6 +53,7 @@ export type HostToWorker =
   | HostVNodeEvent
   | HostVaultReadResult
   | HostVaultStreamChunk
+  | HostVaultWriteResult
   | HostVaultChangedEvent
   | HostNoteSavedEvent
   | HostActiveNoteIdChanged
@@ -283,6 +284,23 @@ export interface HostFullscreenOpenResult {
   error?: string
 }
 
+/** Host's reply to a worker:requestVaultWrite. Carries the new note id
+ *  on a successful `create`, plus the `conflictResolved` flag indicating
+ *  whether the host had to suffix the title (`'suffix'` → " (imported)"
+ *  was appended) or accepted the requested title verbatim (`'none'`).
+ *  v1.2 capability — requires `vault.write` permission. */
+export interface HostVaultWriteResult {
+  type: 'host:vaultWriteResult'
+  seq: number
+  requestSeq: number
+  ok: boolean
+  /** Set on successful `create`; identifies the new note. Absent on
+   *  update / delete / createFolder. */
+  id?: string
+  conflictResolved?: 'none' | 'suffix'
+  error?: string
+}
+
 // ─── Worker → Host ─────────────────────────────────────────────────────────
 
 export type WorkerToHost =
@@ -296,6 +314,7 @@ export type WorkerToHost =
   | WorkerRequestFileSave
   | WorkerRequestFileOpen
   | WorkerRequestVaultRead
+  | WorkerRequestVaultWrite
   | WorkerRequestDirectoryOpen
   | WorkerError
   | WorkerSubscribeVault
@@ -540,6 +559,36 @@ export interface WorkerSetFullscreenContent {
   node: unknown
 }
 
+/** Plugin asking the host to mutate the vault — create / update /
+ *  soft-delete a note, or create a folder. v1.2 capability — requires
+ *  `vault.write` permission in the manifest AND granted at install.
+ *
+ *  The host writes through the same `useNoteStore` / `useFolderStore`
+ *  paths a user action would take, so sync, indexing, and undo behave
+ *  identically. Title-collision on `create` resolves by appending
+ *  ` (imported)` and returning `conflictResolved: 'suffix'`. */
+export interface WorkerRequestVaultWrite {
+  type: 'worker:requestVaultWrite'
+  seq: number
+  op:
+    | {
+        kind: 'create'
+        title: string
+        body: string
+        folderPath?: string
+        frontmatter?: Record<string, unknown>
+      }
+    | {
+        kind: 'update'
+        id: string
+        title?: string
+        body?: string
+        frontmatter?: Record<string, unknown>
+      }
+    | { kind: 'delete'; id: string }
+    | { kind: 'createFolder'; path: string }
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 export function isHostToWorker(msg: unknown): msg is HostToWorker {
@@ -555,6 +604,7 @@ export function isHostToWorker(msg: unknown): msg is HostToWorker {
     'host:vnodeEvent',
     'host:vaultReadResult',
     'host:vaultStreamChunk',
+    'host:vaultWriteResult',
     'host:vaultChanged',
     'host:noteSaved',
     'host:activeNoteIdChanged',
@@ -578,6 +628,7 @@ export function isWorkerToHost(msg: unknown): msg is WorkerToHost {
     'worker:requestFileSave',
     'worker:requestFileOpen',
     'worker:requestVaultRead',
+    'worker:requestVaultWrite',
     'worker:subscribeVault',
     'worker:unsubscribeVault',
     'worker:requestDirectoryOpen',

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -122,16 +122,18 @@ export interface PluginCtx {
   requestFileOpen(args?: { accept?: string[] }): Promise<{ bytes: Uint8Array; filename: string } | null>
 
   /**
-   * v1.2 vault namespace. Always populated; methods reject when the
-   * matching permission was not granted or has been revoked. Plugins
+   * v1.2 vault capability namespace. Always present on `ctx`. Methods
+   * REJECT with `'Permission "<name>" was not granted.'` (or
+   * `'... was revoked.'`) when the plugin did not declare the matching
+   * permission OR the user revoked it from Settings → Plugins. Plugins
    * can catch and degrade.
    *
    * - `read` ships in PR C (vault.read.all), spec §4.1.
+   * - `write` ships in PR D (vault.write), spec §4.2.
    * - `events` ships in PR F (vault.events), spec §4.4.
-   * - `write` lands in PR D (vault.write), spec §4.2.
    */
-  vault: {
-    read: {
+  readonly vault: {
+    readonly read: {
       /**
        * Snapshot every non-deleted note in the vault. Resolves with a
        * plain array of `NoteWithBody`. For very large vaults the host
@@ -157,7 +159,45 @@ export interface PluginCtx {
        */
       stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
     }
-    events: {
+    readonly write: {
+      /** Create a new note. Returns the new note's id plus a
+       *  `conflictResolved` flag: `'none'` when the title was used
+       *  verbatim, `'suffix'` when " (imported)" had to be appended
+       *  because another note already owned that title in the target
+       *  folder. Requires `vault.write` permission. */
+      createNote(args: {
+        title: string
+        body: string
+        folderPath?: string
+        frontmatter?: Record<string, unknown>
+      }): Promise<{ id: string; conflictResolved: 'none' | 'suffix' }>
+
+      /** Patch an existing note. Each field in `patch` is optional —
+       *  omitted fields are left untouched. Rejects when the note id
+       *  does not resolve to a non-deleted note. Requires
+       *  `vault.write` permission. */
+      updateNote(
+        id: string,
+        patch: {
+          title?: string
+          body?: string
+          frontmatter?: Record<string, unknown>
+        },
+      ): Promise<void>
+
+      /** Move a note to the trash (soft-delete only). Hard-delete is
+       *  intentionally absent — recovery from a plugin bug stays
+       *  possible through the existing trash UI. Requires
+       *  `vault.write` permission. */
+      deleteNote(id: string): Promise<void>
+
+      /** Create a folder at the given forward-slash-separated path
+       *  (e.g. "Imported/Obsidian"). Missing intermediate folders are
+       *  created. Idempotent — existing folders are reused. Requires
+       *  `vault.write` permission. */
+      createFolder(path: string): Promise<void>
+    }
+    readonly events: {
       /** Fires when any note in the vault changes (added / updated /
        *  trashed / restored). Coarse "something changed" pulse — use
        *  `onNoteSaved` if you need the id.

--- a/src/plugins/workerEntry.ts
+++ b/src/plugins/workerEntry.ts
@@ -86,6 +86,18 @@ interface PendingFullscreenOpen {
   resolve: () => void
   reject: (err: Error) => void
 }
+/** Pending vault.write request awaiting host reply. `create` resolves
+ *  with { id, conflictResolved }; the other ops resolve with void. */
+interface PendingVaultWriteCreate {
+  kind: 'vault.write.create'
+  resolve: (v: { id: string; conflictResolved: 'none' | 'suffix' }) => void
+  reject: (err: Error) => void
+}
+interface PendingVaultWriteVoid {
+  kind: 'vault.write.void'
+  resolve: () => void
+  reject: (err: Error) => void
+}
 const pending = new Map<
   number,
   | PendingFileSave
@@ -95,6 +107,8 @@ const pending = new Map<
   | PendingVaultReadStream
   | PendingDirectoryOpen
   | PendingFullscreenOpen
+  | PendingVaultWriteCreate
+  | PendingVaultWriteVoid
 >()
 
 let nextRequestSeq = 0
@@ -337,6 +351,39 @@ self.onmessage = async (event: MessageEvent<HostToWorker>) => {
       case 'host:fullscreenClosed':
         await handleFullscreenClosed(msg.seq, msg.viewId)
         return
+
+      case 'host:vaultWriteResult': {
+        const p = pending.get(msg.requestSeq)
+        if (!p) return
+        if (p.kind !== 'vault.write.create' && p.kind !== 'vault.write.void') {
+          // Mismatched pending shape — emit a worker:error so the dev
+          // sees the protocol mismatch instead of a silently hung Promise.
+          emit({
+            type: 'worker:error',
+            seq: 0,
+            message: `vaultWriteResult arrived for a non-write pending request (kind=${p.kind}).`,
+          })
+          return
+        }
+        pending.delete(msg.requestSeq)
+        if (!msg.ok) {
+          p.reject(new Error(msg.error ?? 'Vault write failed.'))
+          return
+        }
+        if (p.kind === 'vault.write.create') {
+          if (typeof msg.id !== 'string') {
+            p.reject(new Error('Vault write succeeded but host returned no note id.'))
+            return
+          }
+          p.resolve({
+            id: msg.id,
+            conflictResolved: msg.conflictResolved ?? 'none',
+          })
+        } else {
+          p.resolve()
+        }
+        return
+      }
 
       default:
         // Exhaustiveness — TypeScript will catch missed cases at build,
@@ -602,6 +649,70 @@ function buildCtx(parentSeq: number): PluginCtx {
         },
         stream(opts?: { chunkSize?: number }) {
           return makeVaultStream(opts?.chunkSize)
+        },
+      },
+      write: {
+        createNote(args) {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<{ id: string; conflictResolved: 'none' | 'suffix' }>(
+            (resolve, reject) => {
+              pending.set(requestSeq, { kind: 'vault.write.create', resolve, reject })
+            },
+          )
+          emit({
+            type: 'worker:requestVaultWrite',
+            seq: requestSeq,
+            op: {
+              kind: 'create',
+              title: args.title,
+              body: args.body,
+              ...(args.folderPath !== undefined ? { folderPath: args.folderPath } : {}),
+              ...(args.frontmatter !== undefined ? { frontmatter: args.frontmatter } : {}),
+            },
+          })
+          return promise
+        },
+        updateNote(id, patch) {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<void>((resolve, reject) => {
+            pending.set(requestSeq, { kind: 'vault.write.void', resolve, reject })
+          })
+          emit({
+            type: 'worker:requestVaultWrite',
+            seq: requestSeq,
+            op: {
+              kind: 'update',
+              id,
+              ...(patch.title !== undefined ? { title: patch.title } : {}),
+              ...(patch.body !== undefined ? { body: patch.body } : {}),
+              ...(patch.frontmatter !== undefined ? { frontmatter: patch.frontmatter } : {}),
+            },
+          })
+          return promise
+        },
+        deleteNote(id) {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<void>((resolve, reject) => {
+            pending.set(requestSeq, { kind: 'vault.write.void', resolve, reject })
+          })
+          emit({
+            type: 'worker:requestVaultWrite',
+            seq: requestSeq,
+            op: { kind: 'delete', id },
+          })
+          return promise
+        },
+        createFolder(path) {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<void>((resolve, reject) => {
+            pending.set(requestSeq, { kind: 'vault.write.void', resolve, reject })
+          })
+          emit({
+            type: 'worker:requestVaultWrite',
+            seq: requestSeq,
+            op: { kind: 'createFolder', path },
+          })
+          return promise
         },
       },
       events: {

--- a/src/stores/pluginInstallStore.ts
+++ b/src/stores/pluginInstallStore.ts
@@ -32,9 +32,10 @@ export interface InstalledPluginRecord {
    *  re-grants it. The manifest's declared `permissions` list is the
    *  ceiling; revocation can only subtract from it. Honoured at
    *  dispatch time for every v1.2 capability (vault.read.all,
-   *  vault.events, fs.open-directory, …); existing subscribers are not
-   *  torn down on revocation — they just stop receiving events / get a
-   *  rejection with `Permission "<name>" was revoked.` on the next call. */
+   *  vault.write, vault.events, fs.open-directory, …); existing
+   *  subscribers are not torn down on revocation — they just stop
+   *  receiving events / get a rejection with
+   *  `Permission "<name>" was revoked.` on the next call. */
   revokedPermissions?: PluginPermission[]
 }
 
@@ -54,11 +55,15 @@ interface PluginInstallState {
    *  subtracts. Existing event-subscribers stay alive but stop
    *  receiving events. */
   setPermissionRevoked: (pluginId: string, permission: PluginPermission, revoked: boolean) => void
+  /** Read-side helper used by PluginHost's permission gate.
+   *  Returns false when the plugin id is unknown — an uninstalled
+   *  plugin cannot have revoked permissions. */
+  isPermissionRevoked: (pluginId: string, permission: string) => boolean
 }
 
 export const usePluginInstallStore = create<PluginInstallState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       records: {},
 
       install: (record) =>
@@ -100,6 +105,12 @@ export const usePluginInstallStore = create<PluginInstallState>()(
             },
           }
         }),
+
+      isPermissionRevoked: (pluginId, permission) => {
+        const rec = get().records[pluginId]
+        if (!rec) return false
+        return rec.revokedPermissions?.includes(permission as PluginPermission) ?? false
+      },
     }),
     {
       name: 'noteser-plugin-installs',

--- a/src/utils/pluginAudit.ts
+++ b/src/utils/pluginAudit.ts
@@ -1,0 +1,159 @@
+// Plugin audit trail. Every destructive plugin action lands here so
+// the user (and bug reports) can see what a plugin did to their vault
+// after the fact.
+//
+// Storage strategy:
+//   - In-memory ring buffer (MAX_ENTRIES) keyed by ts. Single source of
+//     truth for the running session.
+//   - On every append, schedule a debounced flush to localStorage. The
+//     log persists across reloads so a "plugin trashed my notes!"
+//     report has a paper trail even after the user refreshes.
+//
+// We DELIBERATELY do not use the Zustand stores + idbStorage path the
+// rest of the app uses. The audit log must keep functioning even when
+// IndexedDB is busy migrating, when a plugin is mid-write, or when the
+// noteser stores are unloaded for tests. localStorage is synchronous,
+// small, and survives across tabs of the same origin — exactly the
+// guarantees we want for "what just happened" tracing.
+//
+// PR D (Plugin API v1.2) — see docs/plugins-v1.2-impl-notes.md.
+
+const STORAGE_KEY = 'noteser-plugin-audit'
+const MAX_ENTRIES = 500
+const FLUSH_DEBOUNCE_MS = 250
+
+/** Single audit log entry. Emitted by `recordPluginWrite` after the
+ *  host has accepted (or attempted) a plugin's vault mutation.
+ *  Stable on-disk shape — never break this without bumping
+ *  `STORAGE_VERSION`. */
+export interface PluginAuditEntry {
+  /** Wall-clock at the moment the host applied (or rejected) the op. */
+  ts: number
+  /** Plugin manifest id that requested the write. */
+  pluginId: string
+  /** One of the four `vault.write` operations. */
+  op: 'create' | 'update' | 'delete' | 'createFolder'
+  /** Note id (for create/update/delete) or folder path (for
+   *  createFolder). Allows the user to cross-reference the entry with
+   *  the trash or vault tree. */
+  target: string
+  /** Outcome of the op. `error` is populated only when ok===false. */
+  ok: boolean
+  error?: string
+  /** For `create` calls where the host had to append " (imported)" to
+   *  resolve a title collision — surfaced so the user can see the
+   *  rename. */
+  conflictResolved?: 'none' | 'suffix'
+}
+
+const STORAGE_VERSION = 1
+
+interface PersistedShape {
+  v: typeof STORAGE_VERSION
+  entries: PluginAuditEntry[]
+}
+
+let buffer: PluginAuditEntry[] | null = null
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+/** Lazily-loaded ring buffer. First access hydrates from localStorage
+ *  if a prior session left anything behind, then bounds to MAX_ENTRIES. */
+function getBuffer(): PluginAuditEntry[] {
+  if (buffer !== null) return buffer
+  buffer = loadFromStorage()
+  return buffer
+}
+
+function loadFromStorage(): PluginAuditEntry[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as PersistedShape | PluginAuditEntry[] | null
+    if (Array.isArray(parsed)) {
+      // Legacy / un-versioned shape — treat the array as the entries.
+      return parsed.slice(-MAX_ENTRIES)
+    }
+    if (parsed && parsed.v === STORAGE_VERSION && Array.isArray(parsed.entries)) {
+      return parsed.entries.slice(-MAX_ENTRIES)
+    }
+  } catch {
+    // Corrupt JSON, version mismatch, or storage quota issue. Reset to
+    // an empty log rather than crash the host.
+  }
+  return []
+}
+
+function scheduleFlush(): void {
+  if (typeof localStorage === 'undefined') return
+  if (flushTimer !== null) return
+  flushTimer = setTimeout(() => {
+    flushTimer = null
+    try {
+      const payload: PersistedShape = {
+        v: STORAGE_VERSION,
+        entries: getBuffer(),
+      }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+    } catch {
+      // Quota exceeded or storage disabled — drop the flush silently.
+      // The in-memory buffer is still authoritative for the running
+      // session; we just lose persistence across reload.
+    }
+  }, FLUSH_DEBOUNCE_MS)
+}
+
+/** Append one entry to the audit log. Called from the host's vault.write
+ *  handler after the noteStore / folderStore mutation has been applied
+ *  (or rejected). Bounds the in-memory log to MAX_ENTRIES — oldest
+ *  entries roll off. */
+export function recordPluginWrite(entry: Omit<PluginAuditEntry, 'ts'> & { ts?: number }): void {
+  const buf = getBuffer()
+  const ts = typeof entry.ts === 'number' ? entry.ts : Date.now()
+  const full: PluginAuditEntry = {
+    ts,
+    pluginId: entry.pluginId,
+    op: entry.op,
+    target: entry.target,
+    ok: entry.ok,
+    ...(entry.error !== undefined ? { error: entry.error } : {}),
+    ...(entry.conflictResolved !== undefined
+      ? { conflictResolved: entry.conflictResolved }
+      : {}),
+  }
+  buf.push(full)
+  if (buf.length > MAX_ENTRIES) {
+    buf.splice(0, buf.length - MAX_ENTRIES)
+  }
+  scheduleFlush()
+}
+
+/** Snapshot of every audit entry currently held in memory. Returns a
+ *  freshly-allocated array so callers can sort / filter without
+ *  mutating the buffer. Newest entry last. */
+export function readPluginAudit(): ReadonlyArray<PluginAuditEntry> {
+  return getBuffer().slice()
+}
+
+/** Same as `readPluginAudit` but filtered to one plugin id. Used by
+ *  the per-plugin "Recent activity" view in Settings → Plugins. */
+export function readPluginAuditFor(pluginId: string): ReadonlyArray<PluginAuditEntry> {
+  return getBuffer().filter((e) => e.pluginId === pluginId)
+}
+
+/** Test-only: clear the in-memory buffer + persisted log. Production
+ *  code never calls this — the log is a permanent trail. */
+export function clearPluginAuditForTests(): void {
+  buffer = []
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Implements **`vault.write`** per `docs/plugins-v1.2-plan.md` **§4.2** —
the fourth v1.2 capability after PRs A (VNode), C (`vault.read.all`),
E (`fs.open-directory`), and F (`vault.events`). Plugins can now
create / update / soft-delete notes and create folders through the
same `useNoteStore` / `useFolderStore` paths a user action takes; sync,
indexing, and undo behave identically.

`vault.write` is the **first DESTRUCTIVE permission**: the
install-confirm modal renders it inside a red-bordered section with a
per-permission opt-in checkbox (Install button stays disabled until
ack'd). In Settings → Plugins a red "Destructive" badge persists on
the plugin row as long as the permission stays declared in the
manifest — even after revocation — so the user always sees which
plugins were ever granted dangerous capabilities.

Every accepted write (and every host-side validation failure) is
logged to a new **plugin audit trail**
(`src/utils/pluginAudit.ts`) — a 500-entry ring buffer flushed to
localStorage. A read-only "Plugin activity" panel renders the last 50
entries in Settings → Plugins.

### Conflict resolution

When `createNote({ title })` collides with an existing active note in
the target folder, the host appends ` (imported)` (chaining to
`(imported 2)`, `(imported 3)`, … on repeat). The host surfaces the
outcome via `conflictResolved: 'suffix'`, so the importer plugin
(#73) gets the rename for free in its progress log.

### Wire protocol

- `WorkerRequestVaultWrite` carries a discriminated `op` union over
  `create` / `update` / `delete` / `createFolder`.
- `HostVaultWriteResult` carries `ok`, `requestSeq`, optional `id` +
  `conflictResolved` on successful `create`, `error` on failure.

### Example audit entry

The localStorage-backed ring buffer holds one of these per host-mediated
write:

```json
{
  "ts": 1717718400000,
  "pluginId": "noteser-write-demo",
  "op": "create",
  "target": "8e7a51d3-...",
  "ok": true,
  "conflictResolved": "none"
}
```

Failure entries swap `ok` to `false` and add `"error": "..."`. The
panel in Settings → Plugins surfaces the last 50.

### Reference plugin

`public/plugins/noteser-write-demo/` ships a single command
"**Plugin demo note**" that calls `ctx.vault.write.createNote`. Run it
twice to exercise the collision suffix.

### Reuses PR C's infrastructure

The permission gate, `revokePermission` / `restorePermission` /
`hasPermission` on `PluginHost`, and the `revokedPermissions` array on
`InstalledPluginRecord` were all introduced by PR C. PR D plugs
`vault.write` into that same plumbing. As a side-effect the `file-save`
/ `file-open` gates now also honour the revocation Set — previously
they only checked the declared-permissions list.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` zero errors
- [x] `npx jest --ci` green (2527 tests passing; 1 pre-existing
      `publishGistModal` flake passes in isolation, unrelated to this PR)
- New tests:
  - `src/__tests__/plugins/vaultWrite.test.ts` — 15 tests:
    manifest acceptance, `isDestructivePermission` flag, permission
    gate (undeclared + revoked), `respondVaultWrite` envelope shape,
    round-trip per op, chained title-collision suffix, validation
    failure surfaces `ok=false` + audit entry.
  - `src/__tests__/plugins/pluginAudit.test.ts` — 6 tests: ordering,
    MAX_ENTRIES rollover, per-plugin filtering, error capture,
    localStorage flush.
- [ ] Manual: load the demo plugin, run "Plugin demo note" from the
      palette, confirm a note appears in the vault tree, confirm the
      Plugin activity panel gets an entry.

Spec: `docs/plugins-v1.2-plan.md` §4.2, §5 (wire), §6 (SDK), §7
(manifest), §8 (modal).
Impl notes: `docs/plugins-v1.2-impl-notes.md` "PR D" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)