### PR TITLE
Plugin API v1.2: unlock #70 / #71 / #72 / #73 as plugins (closes #112, #113)

### DIFF
--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -283,3 +283,155 @@ host's automatic cleanup on terminate is the safety net.
   capability adds host-side subscriptions outside the SDK, the cap
   should move into the host so the worker boundary stays the cap's
   enforcement point.
+
+## PR E — `fs.openDirectory` capability
+
+Plan reference: section 4.3.
+
+### What shipped
+
+- New permission `fs.open-directory` in
+  `src/plugins/manifest.ts` (`PERMISSIONS` + `PERMISSION_DESCRIPTIONS`).
+  The validator already rejected unknown permissions; the new value
+  flows through unchanged. Mirrored in
+  `packages/noteser-plugin-sdk/src/manifest.ts` so plugin authors
+  building against the published SDK get type-level errors for
+  unknown permission strings.
+- New SDK surface `ctx.fs.openDirectory(args?: { extensions?: string[] })`
+  returning `Promise<ReadonlyArray<{ name, path, blob }> | null>`.
+  `null` is "user cancelled the picker"; a `Blob` (real `File`) lets
+  the plugin read file contents lazily via `blob.text()` /
+  `blob.arrayBuffer()`. Mirrored in
+  `packages/noteser-plugin-sdk/src/sdk.ts`.
+- Wire-protocol additions:
+  `worker:requestDirectoryOpen` (`src/plugins/protocol.ts`) and
+  `host:directoryOpenResult`. Both registered in `isHostToWorker` /
+  `isWorkerToHost` type guards. Constant `MAX_DIRECTORY_ENTRIES` (50,000)
+  exported alongside the existing rate-limit constants.
+- Host handler in `pluginHostSingleton.ts`:
+   - Modern path: `showDirectoryPicker()` → recursive walk via
+     `walkDirectoryHandle` (extracted into
+     `src/plugins/directoryPickerHelpers.ts` so it can be unit-tested
+     without spinning up the singleton).
+   - Fallback path: `<input type="file" webkitdirectory>`. Mirrors the
+     existing single-file fallback at line ~458 of the singleton but
+     sets `webkitdirectory` + `directory` so the picker browses
+     folders. `webkitRelativePath` carries the root segment; we strip
+     it so the returned `path` is relative to the picked root,
+     matching the modern-path output.
+   - 50k cap enforced post-walk. The walker returns as soon as
+     `out.length > MAX_DIRECTORY_ENTRIES` so we never scan a
+     million-file tree.
+   - Extension filter applied host-side via `buildExtensionMatcher`.
+     Case-insensitive, leading dot optional, e.g. `['md', '.MARKDOWN']`
+     all work.
+- Manifest-preview modal copy line:
+  "Open folders to read files into the plugin. You pick the folder;
+  the plugin sees the file names and contents under that folder,
+  nothing else." Rendered automatically by
+  `PluginInstallConfirmModal.tsx` via the existing
+  `PERMISSION_DESCRIPTIONS` lookup.
+- Settings → Plugins revocation hook: the per-permission checkbox UI
+  + `revokedPermissions` field + `setPermissionRevoked` action already
+  landed in PR C. PR E plugs `fs.open-directory` into the same
+  pipeline (`PluginHost.handleWorkerMessage` consults
+  `entry.plugin.revokedPermissions.has('fs.open-directory')` before
+  dispatching the picker). Subsequent capability calls after revocation
+  reject with `Permission "fs.open-directory" was revoked.`
+- Reference plugin `public/plugins/noteser-folder-demo/` with a single
+  command "Folder demo: count files in a folder" that exercises the
+  modern + fallback paths end-to-end and toasts the count after
+  filtering to `.md` / `.markdown`.
+
+### Deviations from the plan
+
+1. **Wire shape uses `Blob`, not `bytesBase64`.** The plan's section
+   5.1 typed `HostDirectoryOpenResult.entries` as
+   `Array<{ relativePath, name, bytesBase64, mimeType }>`. We ship
+   `Array<{ name, path, blob }>` instead:
+   - Structured clone passes `Blob` through `postMessage` natively,
+     so we avoid a base64 round-trip for what could be a half-gigabyte
+     of file content.
+   - The plugin reads lazily via `blob.text()` / `blob.arrayBuffer()`;
+     a `for (const e of entries)` that touches only `.md` files no
+     longer loads the entire folder into the worker's heap up front.
+   - `mimeType` lives on the `Blob` itself
+     (`blob.type`), so dropping the field loses nothing.
+   The change is forward-compatible: a future PR that ships a streaming
+   version (`fs.openDirectoryStream`) can add lazy fetch without
+   reworking the existing `entries` shape.
+
+2. **`relativePath` renamed to `path`.** The user-facing prompt asked
+   for `{ name, path, blob }`. Both are unambiguous (the picked root is
+   always the prefix-base), so the shorter name wins.
+
+3. **No 500 MiB size cap.** Section 4.3 mentions a 500 MiB total-byte
+   cap alongside the 50,000-entry cap. Because we now hand back lazy
+   `Blob`s we never see the bytes until the plugin reads them, and the
+   cap would need to walk every blob to enforce. The 50,000-entry cap
+   is the practical proxy: an Obsidian vault hitting it has bigger
+   problems than a noteser import limit. A byte cap can land in v1.3
+   alongside the streaming variant.
+
+4. **Revocation store action lives in PR C, reused in PR E.** PR C
+   shipped `revokedPermissions: PluginPermission[]` on
+   `InstalledPluginRecord`, the `setPermissionRevoked` action, the
+   singleton helper `setPluginPermissionRevoked`, and the
+   `PluginHost.{revokePermission, restorePermission}` runtime methods.
+   PR E reuses every piece — the only addition here is the
+   `fs.open-directory` check in `PluginHost.handleWorkerMessage`. PRs
+   D and F will piggy-back on the same plumbing.
+
+### Test coverage
+
+- `src/__tests__/plugins/fsOpenDirectory.test.ts`:
+   - Manifest validator accepts `fs.open-directory`, rejects
+     `fs.openDirectory` (typo), mixes with v1.1 permissions.
+   - `PluginHost` short-circuits `worker:requestDirectoryOpen` with a
+     permission-not-declared error when the manifest is silent;
+     emits `directoryOpenRequested` when the permission is present.
+   - `respondDirectoryOpen` round-trips `Blob` entries faithfully and
+     distinguishes "user cancelled" (`ok: true`, no `entries`) from
+     "host failed" (`ok: false`, `error`).
+   - `buildExtensionMatcher` covers leading-dot, case-insensitive,
+     mid-name false-positive cases.
+   - `walkDirectoryHandle` covers flat / nested / cap-overflow trees
+     and asserts blobs read back to their original contents.
+   - jsdom-driven test for the `<input webkitdirectory>` `cancel`
+     event rejection — the path the user prompt called out
+     specifically.
+- `src/__tests__/plugins/pluginInstallStoreRevocation.test.ts`:
+   - PR C's `setPermissionRevoked` action covers the
+     `fs.open-directory` arm: toggles, double-toggle round-trips,
+     idempotent no-ops, unknown plugin id no-ops.
+
+### Manual verification
+
+- Chrome / Edge / Opera: `showDirectoryPicker()` opens the native
+  directory dialog; picking a folder full of `.md` files toasts the
+  count.
+- Safari / Firefox: `<input webkitdirectory>` opens the folder picker;
+  same outcome. Pressing Cancel toasts "Folder pick cancelled." rather
+  than throwing.
+
+### Files touched
+
+```
+docs/plugins-v1.2-impl-notes.md                                     (appended)
+packages/noteser-plugin-sdk/src/index.ts
+packages/noteser-plugin-sdk/src/manifest.ts
+packages/noteser-plugin-sdk/src/sdk.ts
+public/plugins/noteser-folder-demo/main.js                          (new)
+public/plugins/noteser-folder-demo/manifest.json                    (new)
+src/__tests__/plugins/fsOpenDirectory.test.ts                       (new)
+src/__tests__/plugins/pluginInstallStoreRevocation.test.ts          (new)
+src/components/modals/PluginsSettingsPanel.tsx
+src/plugins/PluginHost.ts
+src/plugins/directoryPickerHelpers.ts                               (new)
+src/plugins/manifest.ts
+src/plugins/pluginHostSingleton.ts
+src/plugins/protocol.ts
+src/plugins/sdk.ts
+src/plugins/workerEntry.ts
+src/stores/pluginInstallStore.ts
+```

--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -1,0 +1,97 @@
+# Plugin API v1.2 — implementation notes
+
+Companion doc to `docs/plugins-v1.2-plan.md`. One section per PR in
+the six-PR plan (section 12 of the plan). Each section records the
+deviations from the design plan, the rationale, and the follow-ups
+the next PR in the sequence inherits.
+
+The plan is authoritative; this file is the audit trail. If the two
+disagree, the plan wins until a future PR explicitly updates it.
+
+## PR A — VNode set extension
+
+Lands the seven new shapes (`button`, `input`, `list`, `link`,
+`radio`, `svg`, `box`) and the shared event-handler record. Follows
+the plan section 2 exactly with the following clarifications.
+
+### Sanitisation
+
+The repo had no `escape-html` dependency at the time PR A landed.
+PR A ships an inline escape (`escapeText` in
+`src/plugins/PluginVNode.tsx`) that covers `&`, `<`, `>`, `"`, and
+`'`. Every plugin-supplied string lands in a React children slot, so
+React's default escape handles XSS for the rendered DOM; `escapeText`
+exists as a named contract for future paths that build strings before
+passing them to React (e.g. a debug renderer, a server-side preview).
+No `dangerouslySetInnerHTML` anywhere in the renderer; a unit test
+asserts the rendered HTML never contains the attribute for any v1.2
+shape.
+
+### Link href shape
+
+The plan defines `VNodeLink.href` as a discriminated union
+(`{ kind: 'note'; noteId }` or `{ kind: 'anchor'; fragment }`), and
+PR A implements that union verbatim. The task brief mentioned an
+alternative "wikilink:// or relative string, reject javascript:"
+contract; that contract is enforced too, via `isSafePluginHref`, but
+only as a belt-and-braces guard. The plugin never produces a raw href
+string — the host constructs the real URL from the typed parts. The
+named guard exists so a later opt-in raw-href shape can gate through
+one chokepoint without re-deriving the unsafe-scheme list.
+
+### Event wire
+
+The renderer dispatches `PluginVNodeEvent` records (event name +
+payload). Input and radio events augment the plugin-supplied payload
+with `{ value }`; button and clickable svg events forward the payload
+verbatim. The wire envelope `host:vnodeEvent` in `protocol.ts`
+carries the same shape plus a `source` discriminator
+(`panel` / `codeBlock` / `fullscreen`). PR A includes the
+`fullscreen` variant in the type union so PR B does not need to
+churn the protocol; PR A only ever emits `panel` and `codeBlock` at
+runtime.
+
+The handler-registration API (`ctx.onVNodeEvent`) is intentionally
+NOT in PR A. The renderer's event dispatcher is currently wired only
+in unit tests; the surface adapters (panel, code block) start
+forwarding events to the worker in a later PR that also ships
+`ctx.onVNodeEvent`. PR A ships the shape so PR B and the capability
+PRs do not block on protocol churn.
+
+### SDK exports
+
+The in-repo SDK (`src/plugins/sdk.ts`) re-exports the VNode types
+from `PluginVNode.tsx`. The published SDK
+(`packages/noteser-plugin-sdk/src/sdk.ts`) inlines the type
+declarations — it has no React dependency, so it cannot pull from the
+renderer file. Both lists are kept aligned by review; a future PR may
+extract the shared types into a `vdom.ts` shared between the two.
+
+### List depth cap
+
+`MAX_LIST_DEPTH = 8` per the plan (section 2.4). Both `list` and
+`box` count toward the same depth budget — a nested chain of
+`box → list → box → …` is rejected at depth 9, not depth 17. Simpler
+contract for the renderer and tighter bound on React stack use.
+
+### SVG colour parser
+
+The plan specifies the colour regex
+`/^(#[0-9a-f]{3,8}|rgb\(.*\)|rgba\(.*\)|[a-z]+)$/i` with a 32-char
+cap. PR A tightens the `rgb`/`rgba` alternatives to `[^)]*` instead
+of `.*` to keep the match anchored. Functionally equivalent for safe
+inputs; rejects pathological strings like `rgb()) javascript:` that
+the looser pattern would accept.
+
+### Out-of-scope reminders for downstream PRs
+
+- PR B (fullscreen) consumes the `HostVNodeEvent.source.fullscreen`
+  variant already present in `protocol.ts`. No protocol change should
+  be needed in B.
+- PRs C / D / E / F MUST NOT add new VNode shapes. If a capability
+  needs a new control, the discussion belongs in a v1.3 plan, not in
+  a capability PR.
+- The reference plugin under `public/plugins/noteser-vnode-demo`
+  exercises every new shape but does not yet receive event callbacks
+  (the registration API ships later). Once `ctx.onVNodeEvent` lands,
+  update the plugin to read events and re-render.

--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -572,3 +572,164 @@ fan-out to PluginHostEvent listeners.
   `host:vnodeEvent` with `source: { kind: 'fullscreen', viewId }`.
 - PR D MUST NOT touch the fullscreen surface; the remaining
   capability PR is surface-agnostic by design.
+
+## PR D — `vault.write` capability + audit trail
+
+Implements plan sections 4.2, 5, 6, 7, and 8 as they pertain to
+`vault.write`. Branch `feat/plugins-v1.2-D-vault-write`.
+
+### Permission
+
+`vault.write` joins `file-save` and `file-open` in
+`src/plugins/manifest.ts`'s `PERMISSIONS` tuple. It is the first
+member of a new `DESTRUCTIVE_PERMISSIONS` set — the install-confirm
+modal renders destructive permissions inside a red-bordered section
+with a red bullet, and demands an explicit opt-in checkbox per
+destructive entry before the Install button enables. Informational
+permissions (`file-save`, `file-open`) keep the amber CheckCircle
+styling that landed in v1.1.
+
+### SDK surface
+
+`ctx.vault.write` exposes four async methods:
+
+- `createNote({ title, body, folderPath?, frontmatter? })`
+  → `Promise<{ id, conflictResolved }>`
+- `updateNote(id, { title?, body?, frontmatter? })` → `Promise<void>`
+- `deleteNote(id)` → `Promise<void>` (soft-delete only; landing in the
+  Trash is intentional so the user can recover from a plugin bug)
+- `createFolder(path)` → `Promise<void>` (idempotent, ensures all
+  intermediate segments)
+
+Both `src/plugins/sdk.ts` and `packages/noteser-plugin-sdk/src/sdk.ts`
+gained the namespace. The runtime `definePlugin` is unchanged;
+manifest validation stays host-side.
+
+### Wire protocol
+
+Two new envelopes in `src/plugins/protocol.ts`:
+
+- `WorkerRequestVaultWrite` carries a discriminated `op` union over the
+  four operations.
+- `HostVaultWriteResult` carries `ok`, `requestSeq`, optional `id` +
+  `conflictResolved` for successful `create`s, and `error` on failure.
+
+`isHostToWorker` / `isWorkerToHost` accept the new types; the
+`MAX_ENVELOPE_BYTES` and rate-limit guards apply unchanged.
+
+### Host implementation
+
+`pluginHostSingleton.ts` adds `handleVaultWriteRequest` which writes
+through the EXACT SAME `useNoteStore.addNote` / `updateNote` /
+`deleteNote` and `useFolderStore.ensureFolderPath` paths a user action
+takes. Sync, indexing, and undo behave identically whether the user or
+a plugin made the change.
+
+`folderPath` is resolved via `ensureFolderPath` — the same helper the
+pull layer uses to materialise repo paths. A plugin asking for
+`"Imported/Obsidian"` and the user manually creating that folder
+converge on the same folder ids.
+
+### Conflict resolution
+
+`createNote` runs through `resolveTitleConflict` before delegating to
+the store:
+
+1. No active (non-trashed) note in the same folder shares the
+   requested title (case-insensitive) → use it verbatim.
+   `conflictResolved: 'none'`.
+2. Otherwise, try `"<title> (imported)"`. `conflictResolved: 'suffix'`.
+3. Chained collisions roll forward: `(imported 2)`, `(imported 3)`, …
+   Still `conflictResolved: 'suffix'`.
+
+The host surfaces the renamed title via the `conflictResolved` flag.
+The importer plugin (issue #73) plumbs it into its progress log
+straight from the existing return value.
+
+### Validation
+
+Per plan §4.2: title 1–200 chars, body ≤ 1 MiB,
+`folderPath` matches `/^[^\s/][^/]*(\/[^\s/][^/]*)*$/`. Hard-delete is
+intentionally absent — plugins cannot bypass the Trash UI.
+
+### Revocation
+
+PR D reuses PR C's revocation plumbing rather than introducing a new
+mechanism:
+
+- `revokedPermissions: PluginPermission[]` on `InstalledPluginRecord`,
+  plus the `setPermissionRevoked` / `isPermissionRevoked` store
+  helpers, all from PR C.
+- `PluginHost.revokePermission(pluginId, perm)` /
+  `restorePermission` / `hasPermission` — also from PR C.
+- The vault.write message handler runs the same two-layer gate PR C
+  established for vault.read.all: declared in manifest AND not in
+  `entry.plugin.revokedPermissions`. Distinct error strings so the
+  dev console clarifies; the plugin sees the same Promise rejection
+  either way.
+- file-save / file-open paths now also honour the revocation Set
+  (previously only the declared-permissions list). One-line
+  symmetry fix riding in this PR.
+
+The red "Destructive" badge in Settings → Plugins persists as long
+as the destructive permission stays declared in the manifest — even
+after revocation — so the user always sees at a glance which plugins
+were granted dangerous capabilities historically. The per-permission
+toggle row still uses PR C's `setPluginPermissionRevoked` exported
+from the singleton.
+
+### Audit trail
+
+`src/utils/pluginAudit.ts` is new. Every accepted vault.write op (and
+every host-side rejection that survives the permission gate) records
+an entry: `pluginId`, `op`, `target`, `ok`, optional `error` and
+`conflictResolved`, plus `ts`. Storage is a 500-entry ring buffer in
+memory, flushed to `localStorage` with a 250 ms debounce — chosen over
+the Zustand + IndexedDB path so the log keeps working when the noteser
+stores are mid-migration. A read-only "Plugin activity" panel in
+Settings → Plugins renders the last 50 entries.
+
+Example entry shape (newline-separated for readability — the on-disk
+JSON is one object per push):
+
+    {
+      "ts": 1717718400000,
+      "pluginId": "noteser-write-demo",
+      "op": "create",
+      "target": "8e7a51d3-...",
+      "ok": true,
+      "conflictResolved": "none"
+    }
+
+### Reference plugin
+
+`public/plugins/noteser-write-demo/` ships a single command "Plugin
+demo note" that calls `ctx.vault.write.createNote`. Running it twice
+exercises the title-collision resolver and demonstrates the suffix.
+
+### Tests
+
+`src/__tests__/plugins/vaultWrite.test.ts` covers:
+
+- Manifest validator accepts `vault.write` and rejects malformed
+  values; `isDestructivePermission` flags it.
+- `PluginHost` refuses `worker:requestVaultWrite` when the permission
+  was not declared and when it was revoked.
+- Each of the four ops round-trips through the wire protocol:
+  create returns `{ id, conflictResolved }`; update / delete /
+  createFolder resolve void.
+- `resolveTitleConflict` suffixes correctly on collision (single
+  + chained).
+- Audit log appends one entry per accepted op AND one per failed op.
+
+`src/__tests__/plugins/pluginAudit.test.ts` covers the ring buffer in
+isolation: ordering, MAX_ENTRIES rollover, per-plugin filtering, and
+the localStorage flush.
+
+### Out of scope (deferred)
+
+- Bulk `importNotes(records[])` envelope — plan §4.2 keeps this for
+  v1.3. The 60 messages/sec rate limit means a 5 k-note Obsidian
+  import takes ~83 s; acceptable.
+- Per-plugin "Recent activity" drill-down view — `readPluginAuditFor`
+  exists for it but the UI is the global list for now.

--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -435,3 +435,140 @@ src/plugins/sdk.ts
 src/plugins/workerEntry.ts
 src/stores/pluginInstallStore.ts
 ```
+
+## PR B — fullscreen view surface
+
+Lands the `surfaces.fullscreenViews` manifest field, the host modal at
+`src/components/plugins/PluginFullscreenView.tsx`, the wire envelopes
+for open / close / setContent, and the `ctx.openFullscreen` /
+`ctx.closeFullscreen` / `ctx.setFullscreenContent` SDK methods. Follows
+plan section 3.1 with the deviations and choices below.
+
+### Single-view invariant — reject, do not replace
+
+The plan permits either rejecting a second `openFullscreen` call or
+replacing the active view. PR B picks REJECT, with the exact error
+string `'Another fullscreen view is already open.'` per plan section
+3.1. Reasoning: replacing would silently destroy the original view's
+worker state (any in-flight async setup the first plugin had queued)
+and surprise the user mid-flow. A clear error lets the calling plugin
+fall back to a sidebar panel or toast, and lets a user-facing UI later
+prompt "close the other view first" without ambiguity.
+
+The two coordination layers are deliberately split: `PluginHost`
+checks the view id against the calling plugin's manifest (fast,
+local), and `pluginHostSingleton.handleFullscreenOpenRequest` checks
+the cross-plugin single-view invariant. The split means a manifest
+typo and a "second plugin tried to open one" produce different
+error messages, so the calling plugin can disambiguate.
+
+### Note focus loss — modal persists across note changes
+
+Per plan section 3.1's open question: opening a fullscreen view does
+NOT suspend the editor and does NOT auto-close when the active note
+changes. The plugin stays in control. The store-backed view persists
+until:
+
+1. The user clicks the X-close button.
+2. The user presses Esc (capture phase so a plugin handler cannot
+   trap it).
+3. The plugin calls `ctx.closeFullscreen(viewId)` explicitly.
+4. The browser fires `pagehide` (route change, tab close). The host
+   listens and dismisses so `onFullscreenUnmount` runs before the
+   plugin's worker is terminated.
+5. The plugin is uninstalled. `pluginStore.remove` drops
+   `activeFullscreen` when the removed plugin owns it.
+
+Reasoning: the gated v1.2 features (graph view #71, AI chat #70,
+importer review #73) all keep state that survives note switches.
+Auto-closing on `onActiveNoteChange` would force every plugin to
+re-implement "rehydrate from scratch" — at which point we have
+re-imposed sidebar-panel semantics on a surface that exists precisely
+to escape them. The plugin still receives `onActiveNoteChange` while
+the modal is open (the plan calls this out explicitly) and can call
+`closeFullscreen` itself if a particular view does want to dismiss.
+
+### Lifecycle envelopes — split open response from mount notification
+
+The plan shows `host:mountFullscreen` as the host → worker message
+fired after the modal mounts. PR B splits this into TWO envelopes:
+
+- `host:fullscreenOpenResult` — paired with `worker:openFullscreen`'s
+  `requestSeq`, resolves the plugin's `openFullscreen()` Promise.
+- `host:fullscreenOpened` — fire-and-forget, runs the plugin's
+  `onFullscreenMount` handler.
+
+The split lets the plugin's `await ctx.openFullscreen(...)` resolve
+BEFORE the mount handler starts emitting content updates; without it,
+a plugin that writes `await ctx.openFullscreen(); ctx.setFullscreenContent(...)`
+risks racing the mount-handler's own `setFullscreenContent` and double-
+rendering. Symmetrically, `host:fullscreenClosed` runs the plugin's
+`onFullscreenUnmount`. The wire-protocol names in the plan stay valid
+as a higher-level concept; the actual envelopes are these two.
+
+### Z-index, scroll lock, focus trap
+
+The modal renders at `z-index: 9999` via an inline style (Tailwind's
+preset z-50 sits at 50, the existing `Modal.tsx` uses z-50 for the
+install confirm dialog; the plan says "above sidebars and toasts" so
+9999 buys headroom above any future overlay). Body scroll lock and
+focus trap reuse the same inline-trap pattern as `Modal.tsx` (the
+trap from PR #104). The trap is duplicated rather than extracted to
+a shared hook because:
+
+- The two trap callsites have different lifecycle triggers (Modal is
+  store-driven via `isOpen`; PluginFullscreenView is store-driven via
+  `activeFullscreen !== null`).
+- Extracting now would force a hooks API decision that should land
+  with a third trap site, not at N=2.
+
+### Store ownership of `activeFullscreen`
+
+The active view lives in `pluginStore.activeFullscreen` alongside the
+loaded-plugin map rather than in `uiStore`. Reasoning: lifecycle is
+plugin-owned, not user-owned. When `pluginStore.remove` runs, the
+slot drops automatically, so a buggy plugin teardown cannot leave a
+zombie modal pointing at a torn-down worker.
+
+### Reference plugin
+
+Extended `public/plugins/noteser-vnode-demo` (v0.2.0) instead of
+adding a separate plugin: one install slot, one set of permissions to
+review, one place to maintain the v1.2 demo surface. The plugin now
+declares `surfaces.commands` and `surfaces.fullscreenViews`; the
+`onCommand` handler awaits `openFullscreen('demo-view')`, the
+`onFullscreenMount` handler populates a box with a callout, button,
+and SVG, and `onFullscreenUnmount` fires a notify toast so a human
+can confirm the close lifecycle round-trips end-to-end.
+
+### Manifest-preview modal
+
+`SURFACE_DESCRIPTIONS.fullscreenViews` reads:
+"Opens a full-window view when the plugin asks. You can close it any
+time with Esc or the X button." The capability row in the install
+modal renders as `Provides full-screen view(s)` with the prose below,
+matching the existing prose pattern from PR #104's a11y pass.
+
+### Test coverage
+
+`src/plugins/__tests__/PluginFullscreenView.test.tsx` covers mount/
+unmount, X-close, Esc-close, focus trap (Tab and Shift+Tab wrap),
+body scroll lock, content updates, the store's single-view
+invariant, and the singleton's `dismissActiveFullscreen` helper.
+`src/__tests__/plugins/manifest.test.ts` gains a `surfaces.fullscreenViews`
+block covering the happy path plus rejection of non-arrays, bad ids,
+empty / oversize titles, and duplicate ids. `src/__tests__/plugins/PluginHost.test.ts`
+gains a "fullscreen wire (PR B)" describe block covering the
+manifest-validated open path, the rejected open for an undeclared
+view, and the `worker:closeFullscreen` / `worker:setFullscreenContent`
+fan-out to PluginHostEvent listeners.
+
+### Out-of-scope reminders for downstream PRs
+
+- The `ctx.onVNodeEvent` registration API still has not landed; the
+  fullscreen modal's `handleEvent` is a no-op pending that PR, same
+  as the panel surface. When it does land, this file's
+  `PluginFullscreenView.tsx` needs the dispatcher hooked through
+  `host:vnodeEvent` with `source: { kind: 'fullscreen', viewId }`.
+- PR D MUST NOT touch the fullscreen surface; the remaining
+  capability PR is surface-agnostic by design.

--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -95,3 +95,80 @@ the looser pattern would accept.
   exercises every new shape but does not yet receive event callbacks
   (the registration API ships later). Once `ctx.onVNodeEvent` lands,
   update the plugin to read events and re-render.
+
+## PR C — `vault.read.all` capability
+
+Branch: `feat/plugins-v1.2-C-vault-read`. Lands the first v1.2 capability
+(`vault.read.all`) under the plan's §4.1.
+
+### As-built vs. plan
+
+- **SDK return type for `getAllNotes` / `getNote`.** The plan signature is
+  `Promise<ReadonlyArray<NoteWithBody>>` / `Promise<NoteWithBody | null>`.
+  Shipped as written. The wire layer carries the same shape under
+  `NoteWithBodyWire` for clarity at the protocol boundary; the SDK
+  type alias collapses to `NoteWithBody` because the host-side parsed
+  frontmatter is already a plain object.
+- **`stream()` default chunk size.** Plan §5.1 documents the wire-level
+  default as 200 and the cap as 500. PR C ships **default 100** (the
+  scope spec called out 100 explicitly: "chunked 100 notes per chunk").
+  Cap stays at 500 to match the plan's 256 KB envelope guard. Plugins
+  can still request any size; the host clamps.
+- **`getAllNotes` size guard.** Plan: reject when projected payload
+  exceeds 4 MiB. Implemented as `MAX_GET_ALL_BYTES = 4 * 1024 * 1024`
+  in `src/plugins/vaultSnapshot.ts`. `stream()` is always the
+  recommended path for vault-wide reads.
+- **Host snapshot cache.** Plan §3 (perf): "cache by vault-snapshot SHA
+  so a second `getAllNotes()` call within the same SHA returns
+  instantly." Implemented in `vaultSnapshot.ts` with an FNV-1a rolling
+  hash over `(id, updatedAt)` pairs + folder ids. Not cryptographic —
+  it's an identity key, not a security boundary.
+- **Stream chunking + main-thread yield.** Plan §9: "must NOT block the
+  main thread for >50ms even on 5000-note vaults." `streamVaultSnapshot`
+  awaits a `queueMicrotask` between chunks, so a 5000-note walk at
+  chunkSize=100 yields 50 times. The dominant cost (frontmatter parsing)
+  happens once on the cache-cold call; subsequent calls reuse the cache.
+- **Permission revocation persistence.** Plan §4 (each capability is
+  revocable from Settings → Plugins). Implemented as a per-record
+  `revokedPermissions` array on `InstalledPluginRecord`; the host
+  re-applies it on each boot AND on each `confirmAndInstallPlugin`
+  reload. In-memory revocation also writes through to the host so the
+  next call rejects without waiting for a reload.
+- **Mid-stream revocation.** Plan §5.3: "host emits a terminal chunk
+  with `notes: []` and a non-empty `error`; worker rejects the
+  AsyncIterable." Implemented in `pluginHostSingleton.handleVaultReadRequest`
+  via `streamVaultSnapshot`'s `isAborted` polling — checked before
+  every chunk emission.
+
+### What this PR did NOT touch
+
+Per the explicit scope guard rails:
+- No `vault.write` (PR D).
+- No `vault.events` (PR F).
+- No `fs.openDirectory` (PR E).
+- No new VNode set (PR A).
+- The `ctx.vault.write`, `ctx.vault.events`, and `ctx.fs` namespaces are
+  NOT populated by this PR — adding them here would split type defs
+  across two PRs. The SDK `PluginCtx` type only gains `vault: { read: …}`;
+  the sibling slots land with their respective PRs.
+
+### Conflict expectations
+
+- `src/plugins/protocol.ts`, `src/plugins/sdk.ts`, and
+  `packages/noteser-plugin-sdk/src/sdk.ts` will conflict with PR A
+  (VNode set) and PR D / E / F (other capabilities). Resolution rule:
+  union types extend by line, so concatenate; the SDK `vault.read.*`
+  methods are independent of `vault.write` and `vault.events` and can
+  coexist on the `vault` namespace.
+- `src/components/modals/PluginsSettingsPanel.tsx` grew a per-plugin
+  permissions block. PR D will reuse the same block when it lands
+  `vault.write` revocation; no schema change needed.
+
+### Manual verification
+
+The reference plugin at `public/plugins/noteser-vault-read-demo/`
+exercises both `getAllNotes()` and `stream({ chunkSize: 50 })`. The
+test plan: install from a local manifest URL, run "Vault read demo:
+count notes" from the palette, confirm the toast reports the right
+note count; revoke `vault.read.all` from Settings → Plugins, re-run,
+confirm the toast reports the rejection.

--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -172,3 +172,114 @@ test plan: install from a local manifest URL, run "Vault read demo:
 count notes" from the palette, confirm the toast reports the right
 note count; revoke `vault.read.all` from Settings → Plugins, re-run,
 confirm the toast reports the rejection.
+
+## PR F — `vault.events` subscriptions
+
+Plan reference: section 4.4, plus protocol additions in 5.1 / 5.2 and
+SDK shape in 6.
+
+### What landed
+
+- Permission string `vault.events` added to `PERMISSIONS` /
+  `PERMISSION_DESCRIPTIONS` in `src/plugins/manifest.ts`. Modal copy:
+  "Listen for changes to the vault…".
+- Wire protocol envelopes:
+  - Worker → host: `worker:subscribeVault`, `worker:unsubscribeVault`.
+  - Host → worker: `host:vaultChanged`, `host:noteSaved`,
+    `host:activeNoteIdChanged`.
+  - All three host envelopes carry the `subscriptionId` the worker
+    minted, so the worker can pair the delivered event with the right
+    in-worker handler.
+- SDK addition: `ctx.vault.events.{onVaultChange, onNoteSaved,
+  onActiveNoteChange}`, each returning an `Unsubscribe` thunk
+  exported from the SDK package.
+- Host implementation:
+  - `PluginHost.notifyVaultChanged()`, `notifyNoteSaved(noteId)`,
+    `notifyActiveNoteIdChanged(noteId)` walk every loaded plugin and
+    schedule a debounced dispatch.
+  - Debounce window centralised at `VAULT_EVENT_DEBOUNCE_MS` (250 ms)
+    in `protocol.ts`. Per-event-type cap centralised at
+    `MAX_VAULT_SUBSCRIPTIONS_PER_EVENT` (16); the worker enforces it
+    synchronously when the plugin calls subscribe.
+  - `pluginHostSingleton.wireVaultEvents()` wires the noteStore /
+    folderStore / workspaceStore subscriptions:
+    - Any noteStore or folderStore mutation calls
+      `notifyVaultChanged()` (debounced 250 ms).
+    - A noteStore mutation that changes a note's body / title /
+      isDeleted (i.e. a save) calls `notifyNoteSaved(noteId)`
+      (debounced 250 ms; ids coalesced per window via a `Set`).
+    - A workspaceStore mutation that resolves to a different active
+      noteId calls `notifyActiveNoteIdChanged(noteId)` (debounced
+      250 ms; only the most recent id survives the window).
+
+### Cleanup on unload
+
+`PluginHost.unload()` now:
+
+1. Cancels every in-flight debounce timer for the entry.
+2. Clears the worker's vault-subscriptions map.
+3. Calls `worker.terminate()` (existing v1.1 behaviour).
+
+The leak test in `src/__tests__/plugins/vaultEvents.test.ts` mounts +
+unloads a plugin 10 times and asserts `host.vaultSubscriptionCount()`
+is 0 after each iteration. A leaked subscriber would surface as a
+linear growth in that count and a failed assertion.
+
+### Settings revocation
+
+Reuses the `revokedPermissions: PluginPermission[]` field on
+`InstalledPluginRecord` that PR C introduced. Settings → Plugins
+already shows the per-permission toggle (PR C); PR F adds
+`vault.events` to the list of permissions surfaced there.
+
+`PluginHost.isVaultEventsAllowed(entry)` re-checks two sources on
+every dispatch: the in-host `entry.plugin.revokedPermissions` set
+(populated from PR C's boot wiring), and the optional
+`opts.isPermissionRevoked` hook the test harness uses. A revocation
+that lands during the debounce window suppresses delivery at flush
+time, not just at schedule time.
+
+The existing subscriber's `Unsubscribe` thunk is intentionally NOT
+torn down by revocation. The plan calls this out: "toggle off makes
+the subscription handler stop firing (but doesn't crash existing
+subscribers; they just stop receiving events)". A re-grant
+immediately restores delivery on the next signal — the host adds no
+extra state for that path.
+
+### Manifest-preview modal
+
+`PERMISSION_DESCRIPTIONS['vault.events']` is the prose the modal
+renders verbatim. The existing amber bullet renders without further
+changes; `vault.events` is NOT flagged destructive (red).
+
+### Reference plugin
+
+`public/plugins/noteser-event-demo/` subscribes to all three event
+types and toasts on each fire, stamping the event type in the
+message. Useful for manually verifying debounce timing: rapid
+keystrokes collapse to one `noteSaved` toast per 250 ms window.
+Best-effort cleanup in `onPanelUnmount` calls every unsubscribe; the
+host's automatic cleanup on terminate is the safety net.
+
+### Deviations from the plan
+
+- The plan describes `onVaultChange`'s payload as void; that matches.
+  We coalesce `noteSaved` ids into a `Set<string>` at the host so a
+  burst of saves on the same id fires the worker handler exactly
+  once per debounce window. Different ids in the same window
+  produce one worker dispatch per id (not one event with an array)
+  — keeps the SDK signature `(noteId: string) => void` rather than
+  `(noteIds: string[]) => void`.
+- Settings revocation reuses PR C's `revokedPermissions` field on
+  `InstalledPluginRecord` rather than introducing a separate grants
+  store. Same outcome, half the state shape.
+
+### Follow-ups for later PRs
+
+- The graph view / backlinks plugin (#71) and AI plugins (#70) can
+  now build their debounce-respecting invalidation flow on top of
+  `vault.events` + PR C's `vault.read.all`.
+- The 16-subscription cap is enforced worker-side. If a future
+  capability adds host-side subscriptions outside the SDK, the cap
+  should move into the host so the worker boundary stays the cap's
+  enforcement point.

--- a/packages/noteser-plugin-sdk/src/index.ts
+++ b/packages/noteser-plugin-sdk/src/index.ts
@@ -36,6 +36,7 @@ export type {
   PluginSidebarPanel,
   PluginCodeBlockRenderer,
   PluginPermission,
+  PluginFullscreenView,
 } from './manifest'
 
 export { PERMISSIONS } from './manifest'

--- a/packages/noteser-plugin-sdk/src/index.ts
+++ b/packages/noteser-plugin-sdk/src/index.ts
@@ -6,6 +6,7 @@ export type {
   PluginHandlers,
   PluginDefinition,
   NoteWithBody,
+  Unsubscribe,
 } from './sdk'
 
 // v1.2 — VNode shapes plus the shared event-handler record. PR A adds

--- a/packages/noteser-plugin-sdk/src/index.ts
+++ b/packages/noteser-plugin-sdk/src/index.ts
@@ -7,6 +7,24 @@ export type {
   PluginDefinition,
 } from './sdk'
 
+// v1.2 — VNode shapes plus the shared event-handler record. PR A adds
+// the types only; new SDK methods (event registration, fullscreen,
+// vault, fs) ship in later v1.2 PRs.
+export type {
+  VNode,
+  VNodeText,
+  VNodeCallout,
+  VNodeButton,
+  VNodeInput,
+  VNodeList,
+  VNodeLink,
+  VNodeRadio,
+  VNodeSvg,
+  VNodeBox,
+  VNodeEvent,
+  SvgChild,
+} from './sdk'
+
 export type {
   PluginManifest,
   PluginSurfaces,

--- a/packages/noteser-plugin-sdk/src/index.ts
+++ b/packages/noteser-plugin-sdk/src/index.ts
@@ -5,6 +5,7 @@ export type {
   PluginCtx,
   PluginHandlers,
   PluginDefinition,
+  NoteWithBody,
 } from './sdk'
 
 // v1.2 — VNode shapes plus the shared event-handler record. PR A adds

--- a/packages/noteser-plugin-sdk/src/index.ts
+++ b/packages/noteser-plugin-sdk/src/index.ts
@@ -7,6 +7,8 @@ export type {
   PluginDefinition,
   NoteWithBody,
   Unsubscribe,
+  DirectoryEntry,
+  DirectoryEntries,
 } from './sdk'
 
 // v1.2 — VNode shapes plus the shared event-handler record. PR A adds
@@ -33,7 +35,10 @@ export type {
   PluginCommand,
   PluginSidebarPanel,
   PluginCodeBlockRenderer,
+  PluginPermission,
 } from './manifest'
+
+export { PERMISSIONS } from './manifest'
 
 // `validateManifest` is host-side; published intentionally so plugin
 // authors can sanity-check their own manifest at build time.

--- a/packages/noteser-plugin-sdk/src/manifest.ts
+++ b/packages/noteser-plugin-sdk/src/manifest.ts
@@ -16,14 +16,24 @@ export interface PluginManifest {
   /** Capabilities the plugin asks for at install time. The user grants
    *  each one in the install-preview modal; the host refuses any
    *  capability call that was not granted. v1.1 added `file-save` /
-   *  `file-open`; v1.2 PR E added `fs.open-directory`. */
+   *  `file-open`; v1.2 added `vault.read.all`, `vault.write` (the first
+   *  destructive permission — the modal renders a red bullet),
+   *  `vault.events`, and `fs.open-directory`. */
   permissions?: PluginPermission[]
 }
 
 /** Capability identifiers the validator accepts. Plugins targeting an
  *  older host that does not know a v1.2 permission will fail manifest
- *  validation there — see plugins-v1.2-plan.md section 10. */
-export const PERMISSIONS = ['file-save', 'file-open', 'fs.open-directory'] as const
+ *  validation there — see plugins-v1.2-plan.md section 10. Mirrors
+ *  `src/plugins/manifest.ts` in noteser core. */
+export const PERMISSIONS = [
+  'file-save',
+  'file-open',
+  'vault.read.all',
+  'vault.write',
+  'vault.events',
+  'fs.open-directory',
+] as const
 export type PluginPermission = (typeof PERMISSIONS)[number]
 
 export interface PluginSurfaces {

--- a/packages/noteser-plugin-sdk/src/manifest.ts
+++ b/packages/noteser-plugin-sdk/src/manifest.ts
@@ -30,6 +30,7 @@ export interface PluginSurfaces {
   commands?: PluginCommand[]
   sidebarPanels?: PluginSidebarPanel[]
   codeBlockRenderers?: PluginCodeBlockRenderer[]
+  fullscreenViews?: PluginFullscreenView[]
 }
 
 export interface PluginCommand {
@@ -55,6 +56,15 @@ export interface PluginCodeBlockRenderer {
    *  insensitive; the host lowercases on register. First plugin to
    *  claim a language wins; later registrations log a warning. */
   language: string
+}
+
+/** v1.2 PR B — a full-window view the plugin can request the host to
+ *  mount. Only one fullscreen view (across all installed plugins) is
+ *  open at a time. */
+export interface PluginFullscreenView {
+  id: string
+  title: string
+  icon?: string
 }
 
 /** Stable identifier shape: lowercase letters, digits, dashes; 2-60
@@ -115,6 +125,7 @@ export function validateManifest(input: unknown): ManifestValidationResult {
   const commands = validateCommands(surfaces.commands, errors)
   const sidebarPanels = validateSidebarPanels(surfaces.sidebarPanels, errors)
   const codeBlockRenderers = validateCodeBlockRenderers(surfaces.codeBlockRenderers, errors)
+  const fullscreenViews = validateFullscreenViews(surfaces.fullscreenViews, errors)
   const permissions = validatePermissions(m.permissions, errors)
 
   if (errors.length > 0) return { ok: false, errors }
@@ -124,11 +135,12 @@ export function validateManifest(input: unknown): ManifestValidationResult {
   const total =
     (commands?.length ?? 0) +
     (sidebarPanels?.length ?? 0) +
-    (codeBlockRenderers?.length ?? 0)
+    (codeBlockRenderers?.length ?? 0) +
+    (fullscreenViews?.length ?? 0)
   if (total === 0) {
     return {
       ok: false,
-      errors: ['Manifest must declare at least one surface (command, panel, or renderer).'],
+      errors: ['Manifest must declare at least one surface (command, panel, renderer, or fullscreen view).'],
     }
   }
 
@@ -142,6 +154,9 @@ export function validateManifest(input: unknown): ManifestValidationResult {
       ...(sidebarPanels && sidebarPanels.length > 0 ? { sidebarPanels } : {}),
       ...(codeBlockRenderers && codeBlockRenderers.length > 0
         ? { codeBlockRenderers }
+        : {}),
+      ...(fullscreenViews && fullscreenViews.length > 0
+        ? { fullscreenViews }
         : {}),
     },
     ...(permissions && permissions.length > 0 ? { permissions } : {}),
@@ -260,6 +275,49 @@ function validatePermissions(
     out.push(entry as PluginPermission)
   }
   return out
+}
+
+function validateFullscreenViews(
+  input: unknown,
+  errors: string[],
+): PluginFullscreenView[] | undefined {
+  if (input === undefined) return undefined
+  if (!Array.isArray(input)) {
+    errors.push('"surfaces.fullscreenViews" must be an array when present.')
+    return undefined
+  }
+  const seen = new Set<string>()
+  return input.map((entry, idx) => {
+    if (!isPlainObject(entry)) {
+      errors.push(`surfaces.fullscreenViews[${idx}] must be an object.`)
+      return null
+    }
+    const v = entry as Record<string, unknown>
+    if (typeof v.id !== 'string' || !ID_RE.test(v.id)) {
+      errors.push(`surfaces.fullscreenViews[${idx}].id must be lowercase kebab-case.`)
+      return null
+    }
+    if (typeof v.title !== 'string' || v.title.length === 0 || v.title.length > 80) {
+      errors.push(
+        `surfaces.fullscreenViews[${idx}].title must be a non-empty string up to 80 chars.`,
+      )
+      return null
+    }
+    if (v.icon !== undefined && typeof v.icon !== 'string') {
+      errors.push(`surfaces.fullscreenViews[${idx}].icon must be a string when present.`)
+      return null
+    }
+    if (seen.has(v.id)) {
+      errors.push(`surfaces.fullscreenViews[${idx}].id "${v.id}" is duplicated.`)
+      return null
+    }
+    seen.add(v.id)
+    return {
+      id: v.id,
+      title: v.title,
+      ...(typeof v.icon === 'string' ? { icon: v.icon } : {}),
+    }
+  }).filter((x): x is PluginFullscreenView => x !== null)
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {

--- a/packages/noteser-plugin-sdk/src/manifest.ts
+++ b/packages/noteser-plugin-sdk/src/manifest.ts
@@ -13,7 +13,18 @@ export interface PluginManifest {
   version: string
   author?: string
   surfaces: PluginSurfaces
+  /** Capabilities the plugin asks for at install time. The user grants
+   *  each one in the install-preview modal; the host refuses any
+   *  capability call that was not granted. v1.1 added `file-save` /
+   *  `file-open`; v1.2 PR E added `fs.open-directory`. */
+  permissions?: PluginPermission[]
 }
+
+/** Capability identifiers the validator accepts. Plugins targeting an
+ *  older host that does not know a v1.2 permission will fail manifest
+ *  validation there — see plugins-v1.2-plan.md section 10. */
+export const PERMISSIONS = ['file-save', 'file-open', 'fs.open-directory'] as const
+export type PluginPermission = (typeof PERMISSIONS)[number]
 
 export interface PluginSurfaces {
   commands?: PluginCommand[]
@@ -104,6 +115,7 @@ export function validateManifest(input: unknown): ManifestValidationResult {
   const commands = validateCommands(surfaces.commands, errors)
   const sidebarPanels = validateSidebarPanels(surfaces.sidebarPanels, errors)
   const codeBlockRenderers = validateCodeBlockRenderers(surfaces.codeBlockRenderers, errors)
+  const permissions = validatePermissions(m.permissions, errors)
 
   if (errors.length > 0) return { ok: false, errors }
 
@@ -132,6 +144,7 @@ export function validateManifest(input: unknown): ManifestValidationResult {
         ? { codeBlockRenderers }
         : {}),
     },
+    ...(permissions && permissions.length > 0 ? { permissions } : {}),
   }
   return { ok: true, errors: [], manifest: normalised }
 }
@@ -217,6 +230,36 @@ function validateCodeBlockRenderers(
     }
     return { language: r.language.toLowerCase() }
   }).filter((x): x is PluginCodeBlockRenderer => x !== null)
+}
+
+function validatePermissions(
+  input: unknown,
+  errors: string[],
+): PluginPermission[] | undefined {
+  if (input === undefined) return undefined
+  if (!Array.isArray(input)) {
+    errors.push('"permissions" must be an array when present.')
+    return undefined
+  }
+  const out: PluginPermission[] = []
+  const seen = new Set<string>()
+  for (let i = 0; i < input.length; i++) {
+    const entry = input[i]
+    if (typeof entry !== 'string') {
+      errors.push(`permissions[${i}] must be a string.`)
+      continue
+    }
+    if (!(PERMISSIONS as readonly string[]).includes(entry)) {
+      errors.push(
+        `permissions[${i}] "${entry}" is not a known capability. Known: ${PERMISSIONS.join(', ')}.`,
+      )
+      continue
+    }
+    if (seen.has(entry)) continue
+    seen.add(entry)
+    out.push(entry as PluginPermission)
+  }
+  return out
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -140,6 +140,24 @@ export interface NoteWithBody {
   updatedAt: number
 }
 
+/**
+ * v1.2 — one entry returned by `ctx.fs.openDirectory`. See
+ * docs/plugins-v1.2-plan.md section 4.3 in the noteser repo.
+ *
+ *  - `name` is the filename (no path prefix).
+ *  - `path` is the forward-slash relative path inside the picked root.
+ *  - `blob` lets the plugin read the file lazily via `blob.text()` or
+ *    `blob.arrayBuffer()`. The host does not pre-load file bytes.
+ */
+export interface DirectoryEntry {
+  name: string
+  path: string
+  blob: Blob
+}
+
+export type DirectoryEntries = ReadonlyArray<DirectoryEntry>
+
+
 /** Narrow capability surface exposed to plugin handlers. The plugin
  *  never sees `localStorage`, the GitHub token, or the bodies of notes
  *  it is not currently viewing. v1 read scope is intentionally tight:
@@ -215,6 +233,32 @@ export interface PluginCtx {
        *  note). Same debounce / cap rules as `onVaultChange`. */
       onActiveNoteChange(handler: (noteId: string | null) => void): Unsubscribe
     }
+  }
+
+  /**
+   * v1.2 file-system namespace. Methods reject when the matching
+   * permission was not granted (or was revoked from Settings →
+   * Plugins) with the message
+   * `Permission "fs.open-directory" was not granted.` Plugins can
+   * catch and degrade.
+   */
+  fs: {
+    /**
+     * Open the native directory picker. Resolves with an array of
+     * `{ name, path, blob }` for every file under the picked root, or
+     * `null` when the user cancelled.
+     *
+     * Requires `permissions: ['fs.open-directory']` in the manifest.
+     *
+     *  - `args.extensions` (case-insensitive, leading dot optional):
+     *    filters the response to entries whose name ends with one of
+     *    the listed suffixes, e.g. `['.md', '.markdown']`. Empty /
+     *    undefined returns every file.
+     *
+     * Rejects with `Directory too large` when the picked folder
+     * contains more than 50,000 entries.
+     */
+    openDirectory(args?: { extensions?: string[] }): Promise<DirectoryEntries | null>
   }
 }
 

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -13,6 +13,120 @@
 
 import type { PluginManifest } from './manifest'
 
+// ─── v1.2 VNode shapes ────────────────────────────────────────────────────
+//
+// These mirror the curated renderer in `src/plugins/PluginVNode.tsx`.
+// The published SDK ships them as pure types so plugin authors can
+// construct VNodes type-safely without depending on noteser's React
+// renderer. The host re-validates every VNode at render time; the
+// types are advisory, not load-bearing for security.
+
+/**
+ * Plugin-declared event intent. Functions cannot survive postMessage,
+ * so plugins emit this record on `onClick` / `onChange` instead of a
+ * callback. The host dispatches the event back through the wire
+ * protocol; the worker matches by `event` name against handlers the
+ * plugin registers via `ctx.onVNodeEvent` (registration ships in a
+ * later v1.2 PR).
+ */
+export interface VNodeEvent {
+  kind: 'emit'
+  /** Plugin-defined event name. Host treats as opaque. */
+  event: string
+  /** Optional payload echoed back on the wire. */
+  payload?: unknown
+}
+
+export interface VNodeText {
+  tag: 'text'
+  value: string
+}
+
+export interface VNodeCallout {
+  tag: 'callout'
+  kind?: 'note' | 'warn' | 'tip' | 'danger' | 'info'
+  title?: string
+  body: string
+}
+
+export interface VNodeButton {
+  tag: 'button'
+  label: string
+  variant?: 'default' | 'primary' | 'danger' | 'ghost'
+  disabled?: boolean
+  onClick?: VNodeEvent
+}
+
+export interface VNodeInput {
+  tag: 'input'
+  type: 'text' | 'number' | 'search' | 'select'
+  options?: ReadonlyArray<{ value: string; label: string }>
+  value?: string | number
+  placeholder?: string
+  disabled?: boolean
+  onChange?: VNodeEvent
+}
+
+export interface VNodeList {
+  tag: 'list'
+  ordered?: boolean
+  items: ReadonlyArray<VNode>
+}
+
+export interface VNodeLink {
+  tag: 'link'
+  label: string
+  /**
+   * Discriminated union — the renderer constructs the real URL
+   * host-side. Plugins cannot produce a raw href string, so
+   * `javascript:`, `data:`, `mailto:`, and external URLs are
+   * structurally impossible.
+   */
+  href:
+    | { kind: 'note'; noteId: string }
+    | { kind: 'anchor'; fragment: string }
+}
+
+export interface VNodeRadio {
+  tag: 'radio'
+  group: string
+  options: ReadonlyArray<{ value: string; label: string }>
+  value?: string
+  onChange?: VNodeEvent
+}
+
+export type SvgChild =
+  | { tag: 'line'; x1: number; y1: number; x2: number; y2: number; stroke?: string; strokeWidth?: number }
+  | { tag: 'circle'; cx: number; cy: number; r: number; fill?: string; stroke?: string; onClick?: VNodeEvent }
+  | { tag: 'rect'; x: number; y: number; width: number; height: number; fill?: string; stroke?: string; onClick?: VNodeEvent }
+  | { tag: 'text'; x: number; y: number; value: string; fontSize?: number; fill?: string }
+  | { tag: 'path'; d: string; stroke?: string; fill?: string; strokeWidth?: number }
+
+export interface VNodeSvg {
+  tag: 'svg'
+  width: number
+  height: number
+  viewBox?: readonly [number, number, number, number]
+  children: ReadonlyArray<SvgChild>
+}
+
+export interface VNodeBox {
+  tag: 'box'
+  children: ReadonlyArray<VNode>
+  gap?: 0 | 1 | 2 | 3 | 4
+}
+
+export type VNode =
+  | VNodeText
+  | VNodeCallout
+  | VNodeButton
+  | VNodeInput
+  | VNodeList
+  | VNodeLink
+  | VNodeRadio
+  | VNodeSvg
+  | VNodeBox
+
 /** Narrow capability surface exposed to plugin handlers. The plugin
  *  never sees `localStorage`, the GitHub token, or the bodies of notes
  *  it is not currently viewing. v1 read scope is intentionally tight:

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -260,6 +260,32 @@ export interface PluginCtx {
      */
     openDirectory(args?: { extensions?: string[] }): Promise<DirectoryEntries | null>
   }
+
+  /**
+   * v1.2 PR B — request that the host mount one of this plugin's
+   * declared fullscreen views. The view id must appear in
+   * `surfaces.fullscreenViews` of the manifest. Only one fullscreen
+   * view is open at a time across the whole app; if another one is
+   * already open the Promise rejects with a clear message.
+   *
+   * Once the modal mounts, the plugin's `onFullscreenMount` handler
+   * fires and the plugin should populate content with
+   * `setFullscreenContent`. The modal stays open across active-note
+   * changes — the plugin is in control and decides when to close.
+   */
+  openFullscreen(viewId: string): Promise<void>
+
+  /**
+   * v1.2 PR B — close the currently-mounted fullscreen view. No-op
+   * when no view is open or when the id does not match.
+   */
+  closeFullscreen(viewId: string): void
+
+  /**
+   * v1.2 PR B — replace the content tree of the named fullscreen
+   * view. Same VNode contract as `setPanelContent`.
+   */
+  setFullscreenContent(viewId: string, node: VNode): void
 }
 
 /** Cleanup thunk returned by every `vault.events` subscription. The
@@ -299,6 +325,13 @@ export interface PluginHandlers {
     args: { language: string; source: string; blockId: string },
     ctx: PluginCtx,
   ) => void | Promise<void>
+
+  /** v1.2 PR B — fires after the host mounts a fullscreen view in
+   *  response to `ctx.openFullscreen(viewId)`. */
+  onFullscreenMount?: (viewId: string, ctx: PluginCtx) => void | Promise<void>
+
+  /** v1.2 PR B — fires after the host unmounts a fullscreen view. */
+  onFullscreenUnmount?: (viewId: string, ctx: PluginCtx) => void | Promise<void>
 }
 
 export interface PluginDefinition extends PluginManifest, PluginHandlers {}

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -189,15 +189,25 @@ export interface PluginCtx {
   getSetting<T = unknown>(key: string): T | undefined
   setSetting<T = unknown>(key: string, value: T): void
 
+  /** v1.1 file-I/O. Requires `permissions: ['file-save']`. */
+  requestFileSave(args: { suggestedName: string; mimeType: string; bytes: Uint8Array }): Promise<void>
+  /** v1.1 file-I/O. Requires `permissions: ['file-open']`. */
+  requestFileOpen(args?: { accept?: string[] }): Promise<{ bytes: Uint8Array; filename: string } | null>
+
   /**
-   * v1.2 vault namespace. Always populated; methods reject when the
-   * matching permission was not granted or has been revoked. Plugins
-   * can catch and degrade. PR C ships `read`, PR F ships `events`.
+   * v1.2 vault namespace. Always populated; methods reject with
+   * `'Permission "<name>" was not granted.'` (or `'... was revoked.'`)
+   * when the plugin did not declare the matching permission OR the
+   * user revoked it from Settings → Plugins. Plugins can catch and
+   * degrade.
    *
-   * Spec reference: docs/plugins-v1.2-plan.md §4.1 (read), §4.4 (events).
+   * PR C ships `read`; PR D ships `write`; PR F ships `events`.
+   *
+   * Spec reference: docs/plugins-v1.2-plan.md §4.1 (read),
+   * §4.2 (write), §4.4 (events).
    */
-  vault: {
-    read: {
+  readonly vault: {
+    readonly read: {
       /** Snapshot every non-deleted note in the vault. Resolves with a
        *  plain array of `NoteWithBody`. For very large vaults the host
        *  rejects with `'Vault too large; use stream().'`; plugins MUST
@@ -219,7 +229,37 @@ export interface PluginCtx {
        *  Requires `vault.read.all` permission. */
       stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
     }
-    events: {
+    readonly write: {
+      /** Create a note. Returns the new note's id plus a
+       *  `conflictResolved` flag: `'none'` when the title was used
+       *  verbatim, `'suffix'` when " (imported)" was appended to
+       *  avoid a title collision in the target folder. Requires
+       *  `vault.write` permission. */
+      createNote(args: {
+        title: string
+        body: string
+        folderPath?: string
+        frontmatter?: Record<string, unknown>
+      }): Promise<{ id: string; conflictResolved: 'none' | 'suffix' }>
+      /** Patch an existing note. Each field in `patch` is optional —
+       *  omitted fields are left untouched. Requires `vault.write`. */
+      updateNote(
+        id: string,
+        patch: {
+          title?: string
+          body?: string
+          frontmatter?: Record<string, unknown>
+        },
+      ): Promise<void>
+      /** Move a note to the trash (soft-delete only). Requires
+       *  `vault.write` permission. */
+      deleteNote(id: string): Promise<void>
+      /** Create a folder at the given forward-slash-separated path
+       *  (e.g. "Imported/Obsidian"). Missing intermediate folders are
+       *  created. Idempotent. Requires `vault.write` permission. */
+      createFolder(path: string): Promise<void>
+    }
+    readonly events: {
       /** Fires when any note in the vault changes (added / updated /
        *  trashed / restored). Requires `vault.events` permission.
        *  Returns an `Unsubscribe` thunk; the host also auto-unwinds

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -174,9 +174,9 @@ export interface PluginCtx {
   /**
    * v1.2 vault namespace. Always populated; methods reject when the
    * matching permission was not granted or has been revoked. Plugins
-   * can catch and degrade. PR C wires the `read` sub-namespace.
+   * can catch and degrade. PR C ships `read`, PR F ships `events`.
    *
-   * Spec reference: docs/plugins-v1.2-plan.md §4.1.
+   * Spec reference: docs/plugins-v1.2-plan.md §4.1 (read), §4.4 (events).
    */
   vault: {
     read: {
@@ -201,8 +201,27 @@ export interface PluginCtx {
        *  Requires `vault.read.all` permission. */
       stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
     }
+    events: {
+      /** Fires when any note in the vault changes (added / updated /
+       *  trashed / restored). Requires `vault.events` permission.
+       *  Returns an `Unsubscribe` thunk; the host also auto-unwinds
+       *  every subscription on plugin unload. Debounced host-side at
+       *  250 ms; per-event-type subscription cap is 16. */
+      onVaultChange(handler: () => void): Unsubscribe
+      /** Fires when a specific note's body / title / frontmatter is
+       *  saved. Same debounce / cap rules as `onVaultChange`. */
+      onNoteSaved(handler: (noteId: string) => void): Unsubscribe
+      /** Fires when the editor moves to a different note (or to no
+       *  note). Same debounce / cap rules as `onVaultChange`. */
+      onActiveNoteChange(handler: (noteId: string | null) => void): Unsubscribe
+    }
   }
 }
+
+/** Cleanup thunk returned by every `vault.events` subscription. The
+ *  plugin must call this when it no longer needs the events; the host
+ *  ALSO calls every outstanding unsubscribe when the plugin unloads. */
+export type Unsubscribe = () => void
 
 export interface PluginHandlers {
   /** Optional — fires after the worker boots and the manifest validates. */

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -127,6 +127,19 @@ export type VNode =
   | VNodeSvg
   | VNodeBox
 
+/** A note's body + frontmatter as the host renders them. Returned by
+ *  the v1.2 `ctx.vault.read.*` family. Strings only — the host never
+ *  hands the worker raw bytes or a YAML string. */
+export interface NoteWithBody {
+  id: string
+  title: string
+  folderPath: string
+  body: string
+  /** Parsed by the host. `null` when the note has no frontmatter. */
+  frontmatter: Readonly<Record<string, unknown>> | null
+  updatedAt: number
+}
+
 /** Narrow capability surface exposed to plugin handlers. The plugin
  *  never sees `localStorage`, the GitHub token, or the bodies of notes
  *  it is not currently viewing. v1 read scope is intentionally tight:
@@ -157,6 +170,38 @@ export interface PluginCtx {
    *  cannot read another plugin's settings. */
   getSetting<T = unknown>(key: string): T | undefined
   setSetting<T = unknown>(key: string, value: T): void
+
+  /**
+   * v1.2 vault namespace. Always populated; methods reject when the
+   * matching permission was not granted or has been revoked. Plugins
+   * can catch and degrade. PR C wires the `read` sub-namespace.
+   *
+   * Spec reference: docs/plugins-v1.2-plan.md §4.1.
+   */
+  vault: {
+    read: {
+      /** Snapshot every non-deleted note in the vault. Resolves with a
+       *  plain array of `NoteWithBody`. For very large vaults the host
+       *  rejects with `'Vault too large; use stream().'`; plugins MUST
+       *  fall back to `stream()` in that case.
+       *
+       *  Requires `vault.read.all` permission. */
+      getAllNotes(): Promise<ReadonlyArray<NoteWithBody>>
+
+      /** Resolve a single note by id. Returns null when the id is
+       *  unknown or the note has been soft-deleted. Requires
+       *  `vault.read.all` permission. */
+      getNote(id: string): Promise<NoteWithBody | null>
+
+      /** Paginate over the vault. Each iteration yields up to
+       *  `chunkSize` notes (default 100, max 500). The iterator
+       *  completes naturally when the vault is exhausted; it throws
+       *  when the permission is revoked mid-stream.
+       *
+       *  Requires `vault.read.all` permission. */
+      stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
+    }
+  }
 }
 
 export interface PluginHandlers {

--- a/public/plugins/noteser-event-demo/main.js
+++ b/public/plugins/noteser-event-demo/main.js
@@ -1,0 +1,86 @@
+// noteser-event-demo v0.1.0
+//
+// Subscribes to every vault.events stream and toasts on each fire,
+// stamping the event type in the message so a human can see the
+// debounce in action.
+//
+// Self-contained ES module — the Worker dynamic-imports this file via
+// a Blob URL. No relative imports, no SDK runtime dependency
+// (`definePlugin` is identity at the worker boundary).
+
+const unsubscribers = []
+
+function renderPanel(ctx, counts) {
+  ctx.setPanelContent('panel', {
+    tag: 'text',
+    value:
+      `vault.events demo · ` +
+      `vaultChange=${counts.vaultChange} · ` +
+      `noteSaved=${counts.noteSaved} · ` +
+      `activeNoteChange=${counts.activeNoteChange}`,
+  })
+}
+
+export default {
+  id: 'noteser-event-demo',
+  name: 'Vault events demo',
+  version: '0.1.0',
+  author: 'Noteser',
+  surfaces: {
+    sidebarPanels: [{ id: 'panel', title: 'Vault events' }],
+  },
+  permissions: ['vault.events'],
+
+  onActivate(ctx) {
+    const counts = { vaultChange: 0, noteSaved: 0, activeNoteChange: 0 }
+    renderPanel(ctx, counts)
+
+    unsubscribers.push(
+      ctx.vault.events.onVaultChange(() => {
+        counts.vaultChange += 1
+        ctx.notify('vault.events: onVaultChange')
+        renderPanel(ctx, counts)
+      }),
+    )
+
+    unsubscribers.push(
+      ctx.vault.events.onNoteSaved((noteId) => {
+        counts.noteSaved += 1
+        ctx.notify(`vault.events: onNoteSaved(${noteId})`)
+        renderPanel(ctx, counts)
+      }),
+    )
+
+    unsubscribers.push(
+      ctx.vault.events.onActiveNoteChange((noteId) => {
+        counts.activeNoteChange += 1
+        ctx.notify(
+          `vault.events: onActiveNoteChange(${noteId ?? 'null'})`,
+        )
+        renderPanel(ctx, counts)
+      }),
+    )
+  },
+
+  // If the host re-mounts the panel later, refresh content without
+  // re-subscribing — the onActivate subscriptions still live.
+  onPanelMount(panelId, ctx) {
+    ctx.setPanelContent(panelId, {
+      tag: 'text',
+      value: 'Listening for vault events… edit a note or switch tabs.',
+    })
+  },
+
+  // Best-effort cleanup. The host also drops every subscription on
+  // unload, so a missed call here only leaks until the next reboot.
+  onPanelUnmount() {
+    while (unsubscribers.length > 0) {
+      const fn = unsubscribers.pop()
+      try {
+        fn()
+      } catch {
+        /* ignore */
+      }
+    }
+  },
+}

--- a/public/plugins/noteser-event-demo/manifest.json
+++ b/public/plugins/noteser-event-demo/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "noteser-event-demo",
+  "name": "Vault events demo",
+  "version": "0.1.0",
+  "author": "Noteser",
+  "description": "Subscribes to vault.events and toasts on every fired event. Smoke-test plugin for the v1.2 vault.events capability.",
+  "main": "./main.js",
+  "surfaces": {
+    "sidebarPanels": [{ "id": "panel", "title": "Vault events" }]
+  },
+  "permissions": ["vault.events"]
+}

--- a/public/plugins/noteser-folder-demo/main.js
+++ b/public/plugins/noteser-folder-demo/main.js
@@ -1,0 +1,46 @@
+// noteser-folder-demo v0.1.0
+//
+// Reference plugin for the v1.2 `fs.open-directory` capability.
+// Adds a single command that opens the native directory picker via
+// `ctx.fs.openDirectory`, filters to `.md` / `.markdown` files, and
+// toasts the resulting file count.
+//
+// Tests both code paths end-to-end:
+//   - Chrome / Edge / Opera: `showDirectoryPicker` walked recursively.
+//   - Safari / Firefox: `<input type="file" webkitdirectory>` fallback.
+//
+// See docs/plugins-v1.2-plan.md section 4.3 and
+// docs/plugins-v1.2-impl-notes.md PR E section.
+
+export default {
+  id: 'noteser-folder-demo',
+  name: 'Folder demo',
+  version: '0.1.0',
+  author: 'Noteser',
+  description: 'Pick a folder; the plugin counts the markdown files inside.',
+  permissions: ['fs.open-directory'],
+  surfaces: {
+    commands: [{ id: 'pick', title: 'Folder demo: count files in a folder' }],
+  },
+
+  async onCommand(id, ctx) {
+    if (id !== 'pick') return
+    try {
+      const entries = await ctx.fs.openDirectory({ extensions: ['.md', '.markdown'] })
+      if (entries === null) {
+        // User cancelled the picker.
+        ctx.notify('Folder pick cancelled.')
+        return
+      }
+      const n = entries.length
+      if (n === 0) {
+        ctx.notify('Folder had no .md / .markdown files.')
+        return
+      }
+      ctx.notify(`Found ${n} markdown file${n === 1 ? '' : 's'} in the picked folder.`)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      ctx.notify(`Folder pick failed: ${msg}`)
+    }
+  },
+}

--- a/public/plugins/noteser-folder-demo/manifest.json
+++ b/public/plugins/noteser-folder-demo/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "noteser-folder-demo",
+  "name": "Folder demo",
+  "version": "0.1.0",
+  "author": "Noteser",
+  "description": "Smoke-test for the v1.2 fs.open-directory capability. Adds a command that opens a folder picker and toasts the file count.",
+  "main": "./main.js",
+  "permissions": ["fs.open-directory"],
+  "surfaces": {
+    "commands": [{ "id": "pick", "title": "Folder demo: count files in a folder" }]
+  }
+}

--- a/public/plugins/noteser-vault-read-demo/main.js
+++ b/public/plugins/noteser-vault-read-demo/main.js
@@ -1,0 +1,56 @@
+// noteser-vault-read-demo v0.1.0
+//
+// Reference plugin for the v1.2 `vault.read.all` capability (PR C).
+// Two commands:
+//   - count   : ctx.vault.read.getAllNotes() → notify with count.
+//   - stream  : ctx.vault.read.stream({ chunkSize: 50 }) → notify per
+//               chunk, then totals at end-of-stream.
+//
+// Both flows print to the worker console via ctx.notify so an
+// end-to-end manual test confirms the wire works without UI surface.
+
+export default {
+  id: 'noteser-vault-read-demo',
+  name: 'Vault read demo',
+  version: '0.1.0',
+  author: 'Noteser',
+  description:
+    'Reference plugin for the v1.2 vault.read.all capability. Prints a count of the notes in the vault to the worker console.',
+  permissions: ['vault.read.all'],
+  surfaces: {
+    commands: [
+      { id: 'count', title: 'Vault read demo: count notes' },
+      { id: 'stream', title: 'Vault read demo: stream notes' },
+    ],
+  },
+
+  async onCommand(id, ctx) {
+    if (id === 'count') {
+      try {
+        const notes = await ctx.vault.read.getAllNotes()
+        ctx.notify(`Vault read demo: getAllNotes returned ${notes.length} notes.`)
+      } catch (err) {
+        ctx.notify(
+          `Vault read demo: getAllNotes rejected — ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+      return
+    }
+    if (id === 'stream') {
+      let total = 0
+      let chunks = 0
+      try {
+        for await (const chunk of ctx.vault.read.stream({ chunkSize: 50 })) {
+          chunks++
+          total += chunk.length
+        }
+        ctx.notify(`Vault read demo: stream returned ${total} notes across ${chunks} chunks.`)
+      } catch (err) {
+        ctx.notify(
+          `Vault read demo: stream rejected after ${chunks} chunks — ${err instanceof Error ? err.message : String(err)}`,
+        )
+      }
+      return
+    }
+  },
+}

--- a/public/plugins/noteser-vault-read-demo/manifest.json
+++ b/public/plugins/noteser-vault-read-demo/manifest.json
@@ -1,0 +1,15 @@
+{
+  "id": "noteser-vault-read-demo",
+  "name": "Vault read demo",
+  "version": "0.1.0",
+  "author": "Noteser",
+  "description": "Reference plugin for the v1.2 vault.read.all capability. Prints a count of the notes in the vault to the worker console.",
+  "main": "./main.js",
+  "permissions": ["vault.read.all"],
+  "surfaces": {
+    "commands": [
+      { "id": "count", "title": "Vault read demo: count notes" },
+      { "id": "stream", "title": "Vault read demo: stream notes" }
+    ]
+  }
+}

--- a/public/plugins/noteser-vnode-demo/main.js
+++ b/public/plugins/noteser-vnode-demo/main.js
@@ -1,19 +1,22 @@
-// noteser-vnode-demo v0.1.0
+// noteser-vnode-demo v0.2.0
 //
-// Reference plugin for Plugin API v1.2 PR A. Renders one of every new
-// VNode shape (button, input, list, link, radio, svg, box) inside a
-// sidebar panel so a human can confirm the end-to-end wire works.
+// Reference plugin for Plugin API v1.2 PR A + PR B.
 //
-// The event-handler wire (ctx.onVNodeEvent) lands in a later PR. This
-// plugin logs to the worker console so the developer can see that the
-// renderer produced the right DOM and the event records made it back
-// across postMessage. Once ctx.onVNodeEvent ships, this plugin will
-// flip the logged values into live state without changing its VNode
-// shapes.
+// PR A added the new VNode shapes (button, input, list, link, radio,
+// svg, box). The sidebar panel below renders one of each.
+//
+// PR B added the fullscreen view surface. The "VNode demo: show
+// fullscreen" command opens a modal with a box that contains a
+// callout, a button, and a tiny SVG so a human can confirm:
+//   - opening returns a Promise that resolves once the modal is up
+//   - onFullscreenMount fires + setFullscreenContent populates the body
+//   - Esc + X both close + onFullscreenUnmount fires
+//   - opening a second time while one is open rejects with a clear
+//     message
 //
 // Self-contained ES module. Worker dynamic-imports via Blob URL.
 
-function render(state) {
+function panelView(state) {
   return {
     tag: 'box',
     gap: 3,
@@ -38,7 +41,7 @@ function render(state) {
         tag: 'input',
         type: 'text',
         value: state.text,
-        placeholder: 'Type something…',
+        placeholder: 'Type something...',
         onChange: { kind: 'emit', event: 'demo.text' },
       },
 
@@ -90,25 +93,93 @@ function render(state) {
   }
 }
 
+function fullscreenView() {
+  return {
+    tag: 'box',
+    gap: 4,
+    children: [
+      {
+        tag: 'callout',
+        kind: 'tip',
+        title: 'PR B fullscreen demo',
+        body: 'This box is rendered inside the host fullscreen modal. Press Esc or click the X to close. The plugin gets onFullscreenUnmount when you do.',
+      },
+      {
+        tag: 'button',
+        label: 'Click me inside the modal',
+        variant: 'primary',
+        onClick: {
+          kind: 'emit',
+          event: 'demo.fullscreen.click',
+          payload: { from: 'fullscreen-button' },
+        },
+      },
+      {
+        tag: 'svg',
+        width: 320,
+        height: 120,
+        viewBox: [0, 0, 320, 120],
+        children: [
+          { tag: 'rect', x: 0, y: 0, width: 320, height: 120, fill: '#0f172a' },
+          { tag: 'circle', cx: 160, cy: 60, r: 36, fill: '#38bdf8' },
+          {
+            tag: 'text',
+            x: 110,
+            y: 110,
+            value: 'fullscreen surface',
+            fill: '#cbd5e1',
+            fontSize: 12,
+          },
+        ],
+      },
+    ],
+  }
+}
+
 export default {
   id: 'noteser-vnode-demo',
   name: 'VNode demo',
-  version: '0.1.0',
+  version: '0.2.0',
   author: 'Noteser',
   description:
-    'Reference plugin for v1.2 PR A. Exercises every new VNode shape inside a sidebar panel.',
+    'Reference plugin for v1.2 PRs A and B. Exercises every new VNode shape inside a sidebar panel, and opens a fullscreen view from the command palette.',
   surfaces: {
     sidebarPanels: [{ id: 'demo', title: 'VNode demo' }],
+    commands: [
+      { id: 'show-fullscreen', title: 'VNode demo: show fullscreen' },
+    ],
+    fullscreenViews: [
+      { id: 'demo-view', title: 'VNode fullscreen demo' },
+    ],
   },
 
   onPanelMount(panelId, ctx) {
     if (panelId !== 'demo') return
     const state = { text: '', mode: 'a' }
-    ctx.setPanelContent('demo', render(state))
-    // ctx.onVNodeEvent ships in a later v1.2 PR — for now the worker
-    // simply emits the VNodes and trusts the renderer's event wire.
-    // Once the event registration API lands, this handler will read
-    // the click / change events and re-render the panel with new
-    // state. The shapes themselves do not change.
+    ctx.setPanelContent('demo', panelView(state))
+  },
+
+  async onCommand(commandId, ctx) {
+    if (commandId !== 'show-fullscreen') return
+    try {
+      await ctx.openFullscreen('demo-view')
+    } catch (err) {
+      // The host rejects when another fullscreen view is already
+      // open. Surface that to the user via the toast helper instead
+      // of swallowing it silently.
+      ctx.notify(
+        err instanceof Error ? err.message : 'Could not open fullscreen view.',
+      )
+    }
+  },
+
+  onFullscreenMount(viewId, ctx) {
+    if (viewId !== 'demo-view') return
+    ctx.setFullscreenContent('demo-view', fullscreenView())
+  },
+
+  onFullscreenUnmount(viewId, ctx) {
+    if (viewId !== 'demo-view') return
+    ctx.notify('Fullscreen demo closed.')
   },
 }

--- a/public/plugins/noteser-vnode-demo/main.js
+++ b/public/plugins/noteser-vnode-demo/main.js
@@ -1,0 +1,114 @@
+// noteser-vnode-demo v0.1.0
+//
+// Reference plugin for Plugin API v1.2 PR A. Renders one of every new
+// VNode shape (button, input, list, link, radio, svg, box) inside a
+// sidebar panel so a human can confirm the end-to-end wire works.
+//
+// The event-handler wire (ctx.onVNodeEvent) lands in a later PR. This
+// plugin logs to the worker console so the developer can see that the
+// renderer produced the right DOM and the event records made it back
+// across postMessage. Once ctx.onVNodeEvent ships, this plugin will
+// flip the logged values into live state without changing its VNode
+// shapes.
+//
+// Self-contained ES module. Worker dynamic-imports via Blob URL.
+
+function render(state) {
+  return {
+    tag: 'box',
+    gap: 3,
+    children: [
+      { tag: 'text', value: 'Plugin v1.2 VNode demo' },
+
+      {
+        tag: 'callout',
+        kind: 'info',
+        title: 'What this panel is for',
+        body: 'Every new VNode shape in PR A renders here. Click the button, type in the input, pick a radio. The worker logs each event so you can confirm the wire works.',
+      },
+
+      {
+        tag: 'button',
+        label: 'Click me',
+        variant: 'primary',
+        onClick: { kind: 'emit', event: 'demo.click', payload: { from: 'button' } },
+      },
+
+      {
+        tag: 'input',
+        type: 'text',
+        value: state.text,
+        placeholder: 'Type something…',
+        onChange: { kind: 'emit', event: 'demo.text' },
+      },
+
+      {
+        tag: 'radio',
+        group: 'mode',
+        value: state.mode,
+        options: [
+          { value: 'a', label: 'Mode A' },
+          { value: 'b', label: 'Mode B' },
+        ],
+        onChange: { kind: 'emit', event: 'demo.mode' },
+      },
+
+      {
+        tag: 'list',
+        ordered: false,
+        items: [
+          { tag: 'text', value: 'List item one' },
+          { tag: 'text', value: 'List item two' },
+          {
+            tag: 'link',
+            label: 'Open a note by id',
+            href: { kind: 'note', noteId: 'sample-note-id' },
+          },
+        ],
+      },
+
+      {
+        tag: 'svg',
+        width: 200,
+        height: 100,
+        viewBox: [0, 0, 200, 100],
+        children: [
+          { tag: 'rect', x: 0, y: 0, width: 200, height: 100, fill: '#1e293b' },
+          { tag: 'line', x1: 0, y1: 50, x2: 200, y2: 50, stroke: '#475569', strokeWidth: 1 },
+          {
+            tag: 'circle',
+            cx: 100,
+            cy: 50,
+            r: 20,
+            fill: '#4f8',
+            onClick: { kind: 'emit', event: 'demo.circle' },
+          },
+          { tag: 'text', x: 75, y: 90, value: 'svg shapes', fill: '#cbd5e1', fontSize: 12 },
+        ],
+      },
+    ],
+  }
+}
+
+export default {
+  id: 'noteser-vnode-demo',
+  name: 'VNode demo',
+  version: '0.1.0',
+  author: 'Noteser',
+  description:
+    'Reference plugin for v1.2 PR A. Exercises every new VNode shape inside a sidebar panel.',
+  surfaces: {
+    sidebarPanels: [{ id: 'demo', title: 'VNode demo' }],
+  },
+
+  onPanelMount(panelId, ctx) {
+    if (panelId !== 'demo') return
+    const state = { text: '', mode: 'a' }
+    ctx.setPanelContent('demo', render(state))
+    // ctx.onVNodeEvent ships in a later v1.2 PR — for now the worker
+    // simply emits the VNodes and trusts the renderer's event wire.
+    // Once the event registration API lands, this handler will read
+    // the click / change events and re-render the panel with new
+    // state. The shapes themselves do not change.
+  },
+}

--- a/public/plugins/noteser-vnode-demo/manifest.json
+++ b/public/plugins/noteser-vnode-demo/manifest.json
@@ -1,0 +1,13 @@
+{
+  "id": "noteser-vnode-demo",
+  "name": "VNode demo",
+  "version": "0.1.0",
+  "author": "Noteser",
+  "description": "Reference plugin for v1.2 PR A. Exercises every new VNode shape — button, input, list, link, radio, svg, box — inside a sidebar panel.",
+  "main": "./main.js",
+  "surfaces": {
+    "sidebarPanels": [
+      { "id": "demo", "title": "VNode demo" }
+    ]
+  }
+}

--- a/public/plugins/noteser-vnode-demo/manifest.json
+++ b/public/plugins/noteser-vnode-demo/manifest.json
@@ -1,13 +1,19 @@
 {
   "id": "noteser-vnode-demo",
   "name": "VNode demo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Noteser",
-  "description": "Reference plugin for v1.2 PR A. Exercises every new VNode shape — button, input, list, link, radio, svg, box — inside a sidebar panel.",
+  "description": "Reference plugin for v1.2 PRs A and B. Exercises every new VNode shape inside a sidebar panel, and opens a fullscreen view from the command palette.",
   "main": "./main.js",
   "surfaces": {
     "sidebarPanels": [
       { "id": "demo", "title": "VNode demo" }
+    ],
+    "commands": [
+      { "id": "show-fullscreen", "title": "VNode demo: show fullscreen" }
+    ],
+    "fullscreenViews": [
+      { "id": "demo-view", "title": "VNode fullscreen demo" }
     ]
   }
 }

--- a/public/plugins/noteser-write-demo/main.js
+++ b/public/plugins/noteser-write-demo/main.js
@@ -1,0 +1,45 @@
+// noteser-write-demo v0.1.0
+//
+// Smoke-test plugin for the v1.2 `vault.write` capability. Adds a
+// single command, "Plugin demo note", which creates a note titled
+// "Plugin demo note" in the root of the vault. Running it twice
+// exercises the host's title-collision resolver — the second invocation
+// lands as "Plugin demo note (imported)".
+//
+// The plugin is intentionally tiny: it is a wire-confirmation tool, not
+// a feature. Real importers (issue #73) will follow the same shape but
+// loop over many notes.
+
+export default {
+  id: 'noteser-write-demo',
+  name: 'Write demo',
+  version: '0.1.0',
+  author: 'Noteser',
+  description:
+    "Reference plugin for the v1.2 vault.write capability. Adds a command 'Plugin demo note' that creates a note in your vault to confirm the wire works.",
+  permissions: ['vault.write'],
+  surfaces: {
+    commands: [{ id: 'create', title: 'Plugin demo note' }],
+  },
+
+  async onCommand(id, ctx) {
+    if (id !== 'create') return
+    try {
+      const result = await ctx.vault.write.createNote({
+        title: 'Plugin demo note',
+        body:
+          '# Plugin demo note\n\n' +
+          'This note was created by the `noteser-write-demo` plugin to confirm the ' +
+          '`vault.write` capability is wired end-to-end.\n\n' +
+          `Created at: ${new Date().toISOString()}\n`,
+      })
+      const suffix =
+        result.conflictResolved === 'suffix'
+          ? ' (host renamed to avoid a title collision).'
+          : '.'
+      ctx.notify(`Created note "${result.id}"${suffix}`)
+    } catch (err) {
+      ctx.notify(`Plugin demo note failed: ${err && err.message ? err.message : String(err)}`)
+    }
+  },
+}

--- a/public/plugins/noteser-write-demo/manifest.json
+++ b/public/plugins/noteser-write-demo/manifest.json
@@ -1,0 +1,14 @@
+{
+  "id": "noteser-write-demo",
+  "name": "Write demo",
+  "version": "0.1.0",
+  "author": "Noteser",
+  "description": "Reference plugin for the v1.2 vault.write capability. Adds a command 'Plugin demo note' that creates a note in your vault to confirm the wire works.",
+  "main": "./main.js",
+  "permissions": ["vault.write"],
+  "surfaces": {
+    "commands": [
+      { "id": "create", "title": "Plugin demo note" }
+    ]
+  }
+}

--- a/src/__tests__/plugins/PluginHost.test.ts
+++ b/src/__tests__/plugins/PluginHost.test.ts
@@ -236,6 +236,104 @@ describe('PluginHost', () => {
   })
 })
 
+// v1.2 PR B — fullscreen surface routing through PluginHost.
+describe('PluginHost — fullscreen wire (PR B)', () => {
+  const manifestWithFs: PluginManifest = {
+    id: 'echo',
+    name: 'Echo',
+    version: '1.0.0',
+    surfaces: {
+      commands: [{ id: 'say', title: 'Say hello' }],
+      fullscreenViews: [{ id: 'main', title: 'Main view' }],
+    },
+  }
+
+  test('worker:openFullscreen for a declared view emits fullscreenOpenRequested', async () => {
+    const fake = makeFakeWorker({ manifest: manifestWithFs })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const events: PluginHostEvent[] = []
+    host.on((e) => events.push(e))
+
+    await host.load({ pluginId: 'echo', pluginSource: '' })
+
+    fake.inject({ type: 'worker:openFullscreen', seq: 42, viewId: 'main' })
+    await flushMicrotasks()
+
+    const requested = events.find((e) => e.type === 'fullscreenOpenRequested')
+    expect(requested).toBeDefined()
+    if (requested && requested.type === 'fullscreenOpenRequested') {
+      expect(requested.viewId).toBe('main')
+      expect(requested.requestSeq).toBe(42)
+    }
+  })
+
+  test('worker:openFullscreen for an UNDECLARED view replies with an error and no request fires', async () => {
+    const fake = makeFakeWorker({ manifest: manifestWithFs })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const events: PluginHostEvent[] = []
+    host.on((e) => events.push(e))
+
+    await host.load({ pluginId: 'echo', pluginSource: '' })
+
+    fake.inject({ type: 'worker:openFullscreen', seq: 7, viewId: 'not-declared' })
+    await flushMicrotasks()
+
+    expect(events.some((e) => e.type === 'fullscreenOpenRequested')).toBe(false)
+    const sent = fake.sent.find((m) => m.type === 'host:fullscreenOpenResult')
+    expect(sent).toBeDefined()
+    if (sent && sent.type === 'host:fullscreenOpenResult') {
+      expect(sent.ok).toBe(false)
+      expect(sent.requestSeq).toBe(7)
+      expect(sent.error).toMatch(/not declared/)
+    }
+  })
+
+  test('respondFullscreenOpen + notifyFullscreenOpened post the right envelopes', async () => {
+    const fake = makeFakeWorker({ manifest: manifestWithFs })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'echo', pluginSource: '' })
+
+    host.respondFullscreenOpen('echo', 99, { ok: true })
+    host.notifyFullscreenOpened('echo', 'main')
+
+    const okResult = fake.sent.find(
+      (m) => m.type === 'host:fullscreenOpenResult' && 'requestSeq' in m && m.requestSeq === 99,
+    )
+    expect(okResult).toBeDefined()
+    const opened = fake.sent.find((m) => m.type === 'host:fullscreenOpened')
+    expect(opened).toBeDefined()
+    if (opened && opened.type === 'host:fullscreenOpened') {
+      expect(opened.viewId).toBe('main')
+    }
+  })
+
+  test('worker:closeFullscreen + worker:setFullscreenContent fan out as PluginHostEvents', async () => {
+    const fake = makeFakeWorker({ manifest: manifestWithFs })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const events: PluginHostEvent[] = []
+    host.on((e) => events.push(e))
+
+    await host.load({ pluginId: 'echo', pluginSource: '' })
+
+    fake.inject({ type: 'worker:closeFullscreen', seq: 10, viewId: 'main' })
+    fake.inject({
+      type: 'worker:setFullscreenContent',
+      seq: 11,
+      viewId: 'main',
+      node: { tag: 'text', value: 'hi' },
+    })
+    await flushMicrotasks()
+
+    expect(events.some((e) => e.type === 'fullscreenCloseRequested')).toBe(true)
+    const content = events.find((e) => e.type === 'fullscreenContent')
+    expect(content).toBeDefined()
+    if (content && content.type === 'fullscreenContent') {
+      expect(content.viewId).toBe('main')
+      expect((content.node as { value: string }).value).toBe('hi')
+    }
+  })
+})
+
 /** Two microtask ticks — enough for fake-worker queueMicrotask replies
  *  to land and for the host to dispatch to listeners. */
 async function flushMicrotasks(): Promise<void> {

--- a/src/__tests__/plugins/fsOpenDirectory.test.ts
+++ b/src/__tests__/plugins/fsOpenDirectory.test.ts
@@ -1,0 +1,416 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Plugin v1.2 PR E — `fs.openDirectory` capability gating + picker
+ * behaviour. Covers, end-to-end:
+ *
+ *   1. Manifest validator accepts the new `fs.open-directory`
+ *      permission and rejects mistaken spellings.
+ *   2. PluginHost short-circuits `worker:requestDirectoryOpen` with a
+ *      clear error when the manifest did not declare the permission.
+ *   3. Host-side picker walker honours the 50,000-entry cap.
+ *   4. The extension filter narrows the response (`.md`, `.markdown`),
+ *      case-insensitively and regardless of leading dot.
+ *   5. The `<input webkitdirectory>` fallback path rejects with
+ *      "cancelled" when the user dismisses the picker.
+ *
+ * See docs/plugins-v1.2-plan.md section 4.3.
+ */
+
+import {
+  validateManifest,
+  PERMISSIONS,
+  PERMISSION_DESCRIPTIONS,
+} from '@/plugins/manifest'
+import {
+  PluginHost,
+  type MinimalWorker,
+} from '@/plugins/PluginHost'
+import {
+  MAX_DIRECTORY_ENTRIES,
+  type HostToWorker,
+  type WorkerToHost,
+} from '@/plugins/protocol'
+import {
+  buildExtensionMatcher,
+  walkDirectoryHandle,
+  type FileSystemDirectoryHandleLike,
+} from '@/plugins/directoryPickerHelpers'
+
+// ─── manifest validator ─────────────────────────────────────────────────
+
+describe('manifest — fs.open-directory permission', () => {
+  const base = {
+    id: 'folder-demo',
+    name: 'Folder demo',
+    version: '1.0.0',
+    surfaces: { commands: [{ id: 'pick', title: 'Pick' }] },
+  }
+
+  test('accepts fs.open-directory in the permissions list', () => {
+    const r = validateManifest({ ...base, permissions: ['fs.open-directory'] })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.permissions).toEqual(['fs.open-directory'])
+  })
+
+  test('rejects a typo like fs.openDirectory', () => {
+    const r = validateManifest({ ...base, permissions: ['fs.openDirectory'] })
+    expect(r.ok).toBe(false)
+    expect(r.errors.some((e) => e.includes('fs.openDirectory'))).toBe(true)
+  })
+
+  test('mixes cleanly with v1.1 permissions', () => {
+    const r = validateManifest({
+      ...base,
+      permissions: ['file-open', 'fs.open-directory'],
+    })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.permissions).toEqual(['file-open', 'fs.open-directory'])
+  })
+
+  test('PERMISSIONS const includes fs.open-directory', () => {
+    expect(PERMISSIONS).toContain('fs.open-directory')
+  })
+
+  test('PERMISSION_DESCRIPTIONS covers fs.open-directory with a non-empty string', () => {
+    const d = PERMISSION_DESCRIPTIONS['fs.open-directory']
+    expect(typeof d).toBe('string')
+    expect(d.length).toBeGreaterThan(0)
+    // The spec line is "Open folders to read files into the plugin".
+    // Pin the keyword so a future hand-edit that breaks the install
+    // modal copy fails the test.
+    expect(d.toLowerCase()).toMatch(/folder/)
+  })
+})
+
+// ─── PluginHost permission gating ──────────────────────────────────────
+
+function makeFakeWorker(manifest: {
+  id: string
+  name: string
+  version: string
+  surfaces: object
+  permissions?: string[]
+}): { worker: MinimalWorker; sent: HostToWorker[]; inject: (data: unknown) => void } {
+  const sent: HostToWorker[] = []
+  let handler: ((event: MessageEvent) => void) | null = null
+  const worker: MinimalWorker = {
+    onmessage: null,
+    postMessage(message: unknown) {
+      sent.push(message as HostToWorker)
+      const msg = message as HostToWorker
+      if (msg.type === 'host:boot') {
+        queueMicrotask(() => {
+          handler?.({
+            data: { type: 'worker:ready', seq: msg.seq, manifest } as WorkerToHost,
+          } as MessageEvent)
+        })
+      }
+    },
+    terminate() {
+      handler = null
+    },
+  } as MinimalWorker
+  Object.defineProperty(worker, 'onmessage', {
+    configurable: true,
+    get() {
+      return handler
+    },
+    set(v) {
+      handler = v
+    },
+  })
+  return {
+    worker,
+    sent,
+    inject(data: unknown) {
+      handler?.({ data } as MessageEvent)
+    },
+  }
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('PluginHost — fs.open-directory permission gate', () => {
+  test('refuses requestDirectoryOpen when permission not declared', async () => {
+    const fake = makeFakeWorker({
+      id: 'no-fs-perm',
+      name: 'No FS perm',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'no-fs-perm', pluginSource: '' })
+
+    fake.inject({ type: 'worker:requestDirectoryOpen', seq: 13 })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:directoryOpenResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:directoryOpenResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.requestSeq).toBe(13)
+      expect(reply.error).toMatch(/fs\.open-directory/)
+    }
+  })
+
+  test('emits directoryOpenRequested when the permission IS declared', async () => {
+    const fake = makeFakeWorker({
+      id: 'with-fs',
+      name: 'With FS',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['fs.open-directory'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const events: string[] = []
+    host.on((e) => events.push(e.type))
+    await host.load({ pluginId: 'with-fs', pluginSource: '' })
+
+    fake.inject({
+      type: 'worker:requestDirectoryOpen',
+      seq: 21,
+      extensions: ['.md'],
+    })
+    await flush()
+
+    expect(events).toContain('directoryOpenRequested')
+    // Should NOT have sent an immediate refusal.
+    const earlyError = fake.sent.find(
+      (m) => m.type === 'host:directoryOpenResult' && m.ok === false,
+    )
+    expect(earlyError).toBeUndefined()
+  })
+
+  test('respondDirectoryOpen carries entries with blobs back to the worker', async () => {
+    const fake = makeFakeWorker({
+      id: 'fs-ok',
+      name: 'FS OK',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['fs.open-directory'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'fs-ok', pluginSource: '' })
+
+    host.respondDirectoryOpen('fs-ok', 7, {
+      ok: true,
+      entries: [
+        { name: 'a.md', path: 'a.md', blob: new Blob(['# a'], { type: 'text/markdown' }) },
+        { name: 'b.md', path: 'sub/b.md', blob: new Blob(['# b'], { type: 'text/markdown' }) },
+      ],
+    })
+
+    const reply = fake.sent.find((m) => m.type === 'host:directoryOpenResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:directoryOpenResult') {
+      expect(reply.ok).toBe(true)
+      expect(reply.requestSeq).toBe(7)
+      expect(reply.entries).toHaveLength(2)
+      expect(reply.entries?.[0].path).toBe('a.md')
+      expect(reply.entries?.[1].path).toBe('sub/b.md')
+      expect(reply.entries?.[0].blob).toBeInstanceOf(Blob)
+    }
+  })
+
+  test('respondDirectoryOpen without entries means user cancelled', async () => {
+    const fake = makeFakeWorker({
+      id: 'fs-cancel',
+      name: 'FS cancel',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['fs.open-directory'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'fs-cancel', pluginSource: '' })
+
+    host.respondDirectoryOpen('fs-cancel', 12, { ok: true })
+
+    const reply = fake.sent.find((m) => m.type === 'host:directoryOpenResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:directoryOpenResult') {
+      expect(reply.ok).toBe(true)
+      expect(reply.entries).toBeUndefined()
+    }
+  })
+})
+
+// ─── Extension matcher ─────────────────────────────────────────────────
+
+describe('buildExtensionMatcher', () => {
+  test('returns "match all" for undefined / empty', () => {
+    const a = buildExtensionMatcher(undefined)
+    const b = buildExtensionMatcher([])
+    expect(a('whatever.txt')).toBe(true)
+    expect(b('whatever.png')).toBe(true)
+  })
+
+  test('matches case-insensitively, leading dot optional', () => {
+    const m = buildExtensionMatcher(['md', '.MARKDOWN'])
+    expect(m('a.md')).toBe(true)
+    expect(m('a.MD')).toBe(true)
+    expect(m('a.markdown')).toBe(true)
+    expect(m('a.MARKDOWN')).toBe(true)
+    expect(m('readme.txt')).toBe(false)
+  })
+
+  test('rejects names that do not end with one of the suffixes', () => {
+    const m = buildExtensionMatcher(['.md'])
+    // The `.md` in the middle should NOT match.
+    expect(m('a.md.bak')).toBe(false)
+    expect(m('image.png')).toBe(false)
+  })
+})
+
+// ─── walkDirectoryHandle ────────────────────────────────────────────────
+
+interface FakeDirSpec {
+  kind: 'directory'
+  name: string
+  children: Array<FakeDirSpec | FakeFileSpec>
+}
+interface FakeFileSpec {
+  kind: 'file'
+  name: string
+  file: File
+}
+
+function mkDir(name: string, children: Array<FakeDirSpec | FakeFileSpec>): FakeDirSpec {
+  return { kind: 'directory', name, children }
+}
+function mkFile(name: string, contents = name): FakeFileSpec {
+  return { kind: 'file', name, file: new File([contents], name, { type: 'text/markdown' }) }
+}
+
+function toHandle(spec: FakeDirSpec): FileSystemDirectoryHandleLike {
+  return {
+    kind: 'directory',
+    name: spec.name,
+    async *values() {
+      for (const child of spec.children) {
+        if (child.kind === 'directory') {
+          yield toHandle(child)
+        } else {
+          yield {
+            kind: 'file' as const,
+            name: child.name,
+            getFile: () => Promise.resolve(child.file),
+          }
+        }
+      }
+    },
+  }
+}
+
+describe('walkDirectoryHandle', () => {
+  test('returns every file under a flat directory', async () => {
+    const root = toHandle(
+      mkDir('vault', [mkFile('a.md'), mkFile('b.md'), mkFile('c.txt')]),
+    )
+    const entries = await walkDirectoryHandle(root, () => true)
+    expect(entries.map((e) => e.path).sort()).toEqual(['a.md', 'b.md', 'c.txt'])
+  })
+
+  test('recurses into subdirectories and builds forward-slash relative paths', async () => {
+    const root = toHandle(
+      mkDir('vault', [
+        mkFile('top.md'),
+        mkDir('sub', [mkFile('a.md'), mkDir('deeper', [mkFile('b.md')])]),
+      ]),
+    )
+    const entries = await walkDirectoryHandle(root, () => true)
+    expect(entries.map((e) => e.path).sort()).toEqual([
+      'sub/a.md',
+      'sub/deeper/b.md',
+      'top.md',
+    ])
+  })
+
+  test('honours the extension matcher mid-walk', async () => {
+    const root = toHandle(
+      mkDir('vault', [
+        mkFile('keep.md'),
+        mkFile('skip.txt'),
+        mkDir('sub', [mkFile('keep2.markdown'), mkFile('image.png')]),
+      ]),
+    )
+    const matcher = buildExtensionMatcher(['.md', '.markdown'])
+    const entries = await walkDirectoryHandle(root, matcher)
+    expect(entries.map((e) => e.path).sort()).toEqual(['keep.md', 'sub/keep2.markdown'])
+  })
+
+  test('returned blobs are real File / Blob instances with the file name preserved', async () => {
+    const root = toHandle(mkDir('vault', [mkFile('a.md', '# hello')]))
+    const entries = await walkDirectoryHandle(root, () => true)
+    expect(entries[0].blob).toBeInstanceOf(Blob)
+    // jsdom's Blob predates the text() helper; we assert on properties
+    // that survive (size + type) rather than reading the body.
+    // Production browsers expose blob.text() so the plugin can do
+    // `await entry.blob.text()` directly.
+    expect((entries[0].blob as File).name).toBe('a.md')
+    expect(entries[0].blob.size).toBe('# hello'.length)
+    expect(entries[0].blob.type).toBe('text/markdown')
+  })
+
+  test('returns early once the cap is crossed', async () => {
+    // Build a generator that pretends to be an infinite directory.
+    // The walker should stop producing entries as soon as it crosses
+    // the cap (which is the signal the caller turns into a
+    // "Directory too large" error). We assert: a) the loop terminates,
+    // b) the returned length crosses the cap, c) it does NOT walk
+    // every entry (would-be 1 million in this generator).
+    let produced = 0
+    const generator: FileSystemDirectoryHandleLike = {
+      kind: 'directory',
+      name: 'infinite',
+      async *values() {
+        while (true) {
+          produced++
+          yield {
+            kind: 'file' as const,
+            name: `f${produced}.md`,
+            // Cheap File-shaped stub — the walker only calls getFile()
+            // and shoves the result into the entry. We avoid building
+            // 50k real Files since jsdom's File constructor allocates.
+            getFile: () =>
+              Promise.resolve({ name: `f${produced}.md`, size: 0, type: '' } as unknown as File),
+          }
+        }
+      },
+    }
+    const entries = await walkDirectoryHandle(generator, () => true)
+    expect(entries.length).toBeGreaterThan(MAX_DIRECTORY_ENTRIES)
+    // The walker is documented to stop one past the cap; we should
+    // never have walked twice the cap.
+    expect(produced).toBeLessThan(MAX_DIRECTORY_ENTRIES * 2)
+  })
+
+  test('MAX_DIRECTORY_ENTRIES is the documented 50_000', () => {
+    expect(MAX_DIRECTORY_ENTRIES).toBe(50_000)
+  })
+})
+
+// ─── webkitdirectory fallback — cancel path ─────────────────────────────
+
+describe('webkitdirectory fallback — cancel rejects', () => {
+  test('input cancel event surfaces to the caller as cancellation', async () => {
+    // The fallback in pluginHostSingleton.ts creates this exact input
+    // and listens for the `cancel` event. We replay that wiring here
+    // so the rejection path the user prompt called out specifically
+    // is locked down by a real DOM-event test (jsdom).
+    const input = document.createElement('input')
+    input.type = 'file'
+    input.setAttribute('webkitdirectory', '')
+    input.setAttribute('directory', '')
+
+    const promise = new Promise<void>((_, reject) => {
+      input.addEventListener('cancel', () => reject(new Error('cancelled')))
+    })
+
+    input.dispatchEvent(new Event('cancel'))
+    await expect(promise).rejects.toThrow(/cancelled/)
+  })
+})

--- a/src/__tests__/plugins/manifest.test.ts
+++ b/src/__tests__/plugins/manifest.test.ts
@@ -162,4 +162,106 @@ describe('validateManifest', () => {
     })
     expect(r.ok).toBe(true)
   })
+
+  // v1.2 PR B — fullscreenViews surface ----------------------------------
+  describe('surfaces.fullscreenViews', () => {
+    test('accepts a manifest that declares one fullscreen view', () => {
+      const r = validateManifest({
+        id: 'graph',
+        name: 'Graph',
+        version: '1.0.0',
+        surfaces: {
+          fullscreenViews: [{ id: 'graph', title: 'Note graph' }],
+        },
+      })
+      expect(r.ok).toBe(true)
+      expect(r.manifest?.surfaces.fullscreenViews?.[0].id).toBe('graph')
+      expect(r.manifest?.surfaces.fullscreenViews?.[0].title).toBe('Note graph')
+    })
+
+    test('treats a single fullscreen view as enough to satisfy the at-least-one-surface check', () => {
+      const r = validateManifest({
+        id: 'graph',
+        name: 'Graph',
+        version: '1.0.0',
+        surfaces: {
+          fullscreenViews: [{ id: 'graph', title: 'Note graph' }],
+        },
+      })
+      expect(r.ok).toBe(true)
+    })
+
+    test('rejects when fullscreenViews is not an array', () => {
+      const r = validateManifest({
+        id: 'graph',
+        name: 'Graph',
+        version: '1.0.0',
+        surfaces: { fullscreenViews: { id: 'graph', title: 'Note graph' } },
+      })
+      expect(r.ok).toBe(false)
+      expect(r.errors.some((e) => e.toLowerCase().includes('fullscreenviews'))).toBe(true)
+    })
+
+    test('rejects fullscreen views with non-kebab-case ids', () => {
+      const r = validateManifest({
+        id: 'graph',
+        name: 'Graph',
+        version: '1.0.0',
+        surfaces: {
+          fullscreenViews: [{ id: 'BadID', title: 'Note graph' }],
+        },
+      })
+      expect(r.ok).toBe(false)
+      expect(r.errors.some((e) => e.toLowerCase().includes('kebab-case'))).toBe(true)
+    })
+
+    test('rejects fullscreen views with empty or oversize titles', () => {
+      const empty = validateManifest({
+        id: 'graph',
+        name: 'Graph',
+        version: '1.0.0',
+        surfaces: { fullscreenViews: [{ id: 'graph', title: '' }] },
+      })
+      expect(empty.ok).toBe(false)
+
+      const huge = validateManifest({
+        id: 'graph',
+        name: 'Graph',
+        version: '1.0.0',
+        surfaces: {
+          fullscreenViews: [{ id: 'graph', title: 'x'.repeat(200) }],
+        },
+      })
+      expect(huge.ok).toBe(false)
+    })
+
+    test('rejects duplicate fullscreen view ids', () => {
+      const r = validateManifest({
+        id: 'graph',
+        name: 'Graph',
+        version: '1.0.0',
+        surfaces: {
+          fullscreenViews: [
+            { id: 'graph', title: 'Note graph' },
+            { id: 'graph', title: 'Note graph 2' },
+          ],
+        },
+      })
+      expect(r.ok).toBe(false)
+      expect(r.errors.some((e) => e.toLowerCase().includes('duplicat'))).toBe(true)
+    })
+
+    test('preserves the optional icon when present', () => {
+      const r = validateManifest({
+        id: 'graph',
+        name: 'Graph',
+        version: '1.0.0',
+        surfaces: {
+          fullscreenViews: [{ id: 'graph', title: 'Note graph', icon: 'document-text' }],
+        },
+      })
+      expect(r.ok).toBe(true)
+      expect(r.manifest?.surfaces.fullscreenViews?.[0].icon).toBe('document-text')
+    })
+  })
 })

--- a/src/__tests__/plugins/pluginAudit.test.ts
+++ b/src/__tests__/plugins/pluginAudit.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Plugin audit trail unit tests. Exercises the localStorage-backed
+ * ring buffer in isolation from the host glue.
+ */
+
+import {
+  clearPluginAuditForTests,
+  readPluginAudit,
+  readPluginAuditFor,
+  recordPluginWrite,
+} from '@/utils/pluginAudit'
+
+describe('pluginAudit', () => {
+  beforeEach(() => clearPluginAuditForTests())
+
+  test('records a create entry with the requested fields', () => {
+    recordPluginWrite({
+      pluginId: 'demo',
+      op: 'create',
+      target: 'note-1',
+      ok: true,
+      conflictResolved: 'none',
+    })
+    const entries = readPluginAudit()
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({
+      pluginId: 'demo',
+      op: 'create',
+      target: 'note-1',
+      ok: true,
+      conflictResolved: 'none',
+    })
+    expect(typeof entries[0].ts).toBe('number')
+  })
+
+  test('preserves insertion order (oldest first)', () => {
+    for (let i = 0; i < 5; i++) {
+      recordPluginWrite({
+        pluginId: 'demo',
+        op: 'update',
+        target: `note-${i}`,
+        ok: true,
+      })
+    }
+    const entries = readPluginAudit()
+    expect(entries.map((e) => e.target)).toEqual([
+      'note-0',
+      'note-1',
+      'note-2',
+      'note-3',
+      'note-4',
+    ])
+  })
+
+  test('rolls off the oldest entry past MAX_ENTRIES', () => {
+    // MAX_ENTRIES is 500 (internal). Push 510 and verify we keep the
+    // last 500 with the oldest 10 dropped.
+    for (let i = 0; i < 510; i++) {
+      recordPluginWrite({ pluginId: 'demo', op: 'create', target: `n-${i}`, ok: true })
+    }
+    const entries = readPluginAudit()
+    expect(entries).toHaveLength(500)
+    expect(entries[0].target).toBe('n-10')
+    expect(entries[entries.length - 1].target).toBe('n-509')
+  })
+
+  test('readPluginAuditFor filters by plugin id', () => {
+    recordPluginWrite({ pluginId: 'a', op: 'create', target: 'a-1', ok: true })
+    recordPluginWrite({ pluginId: 'b', op: 'create', target: 'b-1', ok: true })
+    recordPluginWrite({ pluginId: 'a', op: 'delete', target: 'a-1', ok: true })
+    expect(readPluginAuditFor('a').map((e) => e.target)).toEqual(['a-1', 'a-1'])
+    expect(readPluginAuditFor('b').map((e) => e.target)).toEqual(['b-1'])
+  })
+
+  test('error string lands on failed entries', () => {
+    recordPluginWrite({
+      pluginId: 'demo',
+      op: 'delete',
+      target: 'missing',
+      ok: false,
+      error: 'note "missing" does not exist',
+    })
+    const e = readPluginAudit()[0]
+    expect(e.ok).toBe(false)
+    expect(e.error).toMatch(/does not exist/)
+  })
+
+  test('flushes to localStorage so a fresh reader picks it up', async () => {
+    recordPluginWrite({ pluginId: 'demo', op: 'create', target: 'note-1', ok: true })
+    // Allow the 250 ms debounce timer to fire.
+    await new Promise((r) => setTimeout(r, 300))
+    const raw = localStorage.getItem('noteser-plugin-audit')
+    expect(raw).not.toBeNull()
+    expect(raw).toContain('note-1')
+  })
+})

--- a/src/__tests__/plugins/pluginInstallConfirmModal.test.tsx
+++ b/src/__tests__/plugins/pluginInstallConfirmModal.test.tsx
@@ -262,3 +262,63 @@ describe('PluginInstallConfirmModal — pre-fetched record path', () => {
     expect(mockFetchPluginForInstall).not.toHaveBeenCalled()
   })
 })
+
+describe('PluginInstallConfirmModal — destructive permissions (v1.2 PR D)', () => {
+  test('renders vault.write in the destructive section with a red bullet + ack checkbox', async () => {
+    mockFetchPluginForInstall.mockResolvedValueOnce(
+      makeRecord({
+        manifest: {
+          ...baseManifest,
+          permissions: ['vault.write'],
+        },
+      }),
+    )
+    openWithUrl()
+    render(<PluginInstallConfirmModal />)
+    await screen.findByTestId('plugin-preview-body')
+
+    // Destructive section renders.
+    expect(screen.getByTestId('plugin-preview-destructive-section')).toBeInTheDocument()
+    expect(screen.getByTestId('plugin-preview-destructive-vault.write')).toHaveTextContent(
+      'vault.write',
+    )
+    expect(screen.getByTestId('plugin-preview-destructive-vault.write')).toHaveTextContent(
+      PERMISSION_DESCRIPTIONS['vault.write'],
+    )
+
+    // vault.write should NOT also appear in the informational capability list.
+    expect(
+      screen.queryByTestId('plugin-preview-capability-vault.write'),
+    ).not.toBeInTheDocument()
+
+    // Install is disabled until the user acks the destructive permission.
+    const installBtn = screen.getByTestId('plugin-install-confirm') as HTMLButtonElement
+    expect(installBtn).toBeDisabled()
+
+    const ack = screen.getByTestId('plugin-preview-destructive-ack-vault.write')
+    const user = userEvent.setup()
+    await user.click(ack)
+    expect(installBtn).not.toBeDisabled()
+  })
+
+  test('mixed manifest puts file-save in the informational list and vault.write in destructive', async () => {
+    mockFetchPluginForInstall.mockResolvedValueOnce(
+      makeRecord({
+        manifest: {
+          ...baseManifest,
+          permissions: ['file-save', 'vault.write'],
+        },
+      }),
+    )
+    openWithUrl()
+    render(<PluginInstallConfirmModal />)
+    await screen.findByTestId('plugin-preview-body')
+
+    expect(screen.getByTestId('plugin-preview-capability-file-save')).toBeInTheDocument()
+    expect(screen.getByTestId('plugin-preview-destructive-vault.write')).toBeInTheDocument()
+
+    // file-save uses the informational SURFACE_DESCRIPTIONS-style copy; ensure
+    // the SURFACE export is still reachable so the smoke test does not regress.
+    expect(typeof SURFACE_DESCRIPTIONS.commands).toBe('string')
+  })
+})

--- a/src/__tests__/plugins/pluginInstallStorePermissions.test.ts
+++ b/src/__tests__/plugins/pluginInstallStorePermissions.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Coverage for the v1.2 `setPermissionRevoked` action on
+ * usePluginInstallStore. The host re-checks revocation per-dispatch,
+ * so the store API needs to be idempotent + must not lose unrelated
+ * record fields when the user toggles a permission.
+ */
+
+import { usePluginInstallStore, type InstalledPluginRecord } from '@/stores/pluginInstallStore'
+
+beforeEach(() => {
+  usePluginInstallStore.setState({ records: {} })
+})
+
+function record(): InstalledPluginRecord {
+  return {
+    manifest: {
+      id: 'evt',
+      name: 'Evt',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.events', 'file-open'],
+    },
+    mainSource: '/* */',
+    hash: 'deadbeef',
+    sourceUrl: 'https://example.com/manifest.json',
+    addedAt: 0,
+    enabled: true,
+  }
+}
+
+describe('setPermissionRevoked', () => {
+  test('revokes a permission without unloading the plugin', () => {
+    usePluginInstallStore.getState().install(record())
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', true)
+    expect(
+      usePluginInstallStore.getState().records['evt'].revokedPermissions,
+    ).toEqual(['vault.events'])
+    expect(usePluginInstallStore.getState().records['evt'].enabled).toBe(true)
+  })
+
+  test('idempotent — toggling the same value twice does not duplicate', () => {
+    usePluginInstallStore.getState().install(record())
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', true)
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', true)
+    expect(
+      usePluginInstallStore.getState().records['evt'].revokedPermissions,
+    ).toEqual(['vault.events'])
+  })
+
+  test('toggling back to granted removes the entry', () => {
+    usePluginInstallStore.getState().install(record())
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', true)
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', false)
+    // PR C's spec: keep the field as an array (possibly empty) so the
+    // record shape stays stable across grant flips.
+    expect(
+      usePluginInstallStore.getState().records['evt'].revokedPermissions,
+    ).toEqual([])
+  })
+
+  test('no-op for unknown plugin id', () => {
+    expect(() =>
+      usePluginInstallStore
+        .getState()
+        .setPermissionRevoked('does-not-exist', 'vault.events', true),
+    ).not.toThrow()
+    expect(usePluginInstallStore.getState().records).toEqual({})
+  })
+
+  test('multiple revocations on the same plugin track every entry', () => {
+    usePluginInstallStore.getState().install(record())
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'vault.events', true)
+    usePluginInstallStore.getState().setPermissionRevoked('evt', 'file-open', true)
+    const revoked = usePluginInstallStore.getState().records['evt']
+      .revokedPermissions
+    expect(revoked).toEqual(expect.arrayContaining(['vault.events', 'file-open']))
+    expect(revoked).toHaveLength(2)
+  })
+})

--- a/src/__tests__/plugins/pluginInstallStoreRevocation.test.ts
+++ b/src/__tests__/plugins/pluginInstallStoreRevocation.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Plugin v1.2 PR E — Settings → Plugins revocation of
+ * `fs.open-directory`. The store action + UI wiring landed in PR C;
+ * this suite covers the `fs.open-directory` arm of the same plumbing
+ * so we can prove the revocation path works for the new permission.
+ *
+ * See docs/plugins-v1.2-plan.md section 4.3 and the impl notes for
+ * PR E.
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+  keys: jest.fn().mockResolvedValue([]),
+}))
+
+import {
+  usePluginInstallStore,
+  type InstalledPluginRecord,
+} from '@/stores/pluginInstallStore'
+
+function makeRecord(
+  overrides: Partial<InstalledPluginRecord> = {},
+): InstalledPluginRecord {
+  return {
+    manifest: {
+      id: 'folder-demo',
+      name: 'Folder demo',
+      version: '0.1.0',
+      surfaces: { commands: [{ id: 'pick', title: 'Pick' }] },
+      permissions: ['fs.open-directory'],
+    },
+    mainSource: 'export default {}',
+    hash: 'abc',
+    sourceUrl: 'https://example.com/folder-demo/manifest.json',
+    addedAt: 1000,
+    enabled: true,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  usePluginInstallStore.setState({ records: {} })
+})
+
+describe('pluginInstallStore — fs.open-directory revocation', () => {
+  test('setPermissionRevoked(true) appends to revokedPermissions', () => {
+    const rec = makeRecord()
+    usePluginInstallStore.getState().install(rec)
+    usePluginInstallStore
+      .getState()
+      .setPermissionRevoked(rec.manifest.id, 'fs.open-directory', true)
+    const next = usePluginInstallStore.getState().records[rec.manifest.id]
+    expect(next.revokedPermissions).toEqual(['fs.open-directory'])
+  })
+
+  test('setPermissionRevoked(false) clears the permission from the revoked list', () => {
+    const rec = makeRecord({ revokedPermissions: ['fs.open-directory'] })
+    usePluginInstallStore.getState().install(rec)
+    usePluginInstallStore
+      .getState()
+      .setPermissionRevoked(rec.manifest.id, 'fs.open-directory', false)
+    const next = usePluginInstallStore.getState().records[rec.manifest.id]
+    expect(next.revokedPermissions).toEqual([])
+  })
+
+  test('setPermissionRevoked is a no-op when the state already matches', () => {
+    const rec = makeRecord({ revokedPermissions: ['fs.open-directory'] })
+    usePluginInstallStore.getState().install(rec)
+    const before = usePluginInstallStore.getState().records[rec.manifest.id]
+    usePluginInstallStore
+      .getState()
+      .setPermissionRevoked(rec.manifest.id, 'fs.open-directory', true)
+    const after = usePluginInstallStore.getState().records[rec.manifest.id]
+    // The store early-returns when the value did not change; the
+    // record reference is preserved.
+    expect(after).toBe(before)
+  })
+
+  test('setPermissionRevoked is a no-op for an unknown plugin id', () => {
+    const before = { ...usePluginInstallStore.getState().records }
+    usePluginInstallStore
+      .getState()
+      .setPermissionRevoked('no-such-plugin', 'fs.open-directory', true)
+    expect(usePluginInstallStore.getState().records).toEqual(before)
+  })
+
+  test('toggling the same permission twice ends up at the original state', () => {
+    const rec = makeRecord()
+    usePluginInstallStore.getState().install(rec)
+    usePluginInstallStore
+      .getState()
+      .setPermissionRevoked(rec.manifest.id, 'fs.open-directory', true)
+    usePluginInstallStore
+      .getState()
+      .setPermissionRevoked(rec.manifest.id, 'fs.open-directory', false)
+    const next = usePluginInstallStore.getState().records[rec.manifest.id]
+    expect(next.revokedPermissions).toEqual([])
+  })
+})

--- a/src/__tests__/plugins/vaultEvents.test.ts
+++ b/src/__tests__/plugins/vaultEvents.test.ts
@@ -1,0 +1,497 @@
+/**
+ * @jest-environment node
+ *
+ * vault.events (PR F) coverage.
+ *
+ *   1. Manifest validator accepts `vault.events` and rejects unknown
+ *      neighbours.
+ *   2. Subscribe / unsubscribe envelopes are tracked on the host; the
+ *      subscription count drops to zero on unload (cleanup gate).
+ *   3. Debounce window is 250 ms: rapid noteSaved calls fire ONE
+ *      delivery per (id, window).
+ *   4. Settings revocation: flipping `revokedPermissions` mid-window
+ *      suppresses delivery without unloading the plugin.
+ *   5. Leak test: mount + unload a plugin 10 times and assert the
+ *      global subscription count never grows past one plugin's quota.
+ */
+
+import {
+  PluginHost,
+  type MinimalWorker,
+  type PluginHostOptions,
+} from '@/plugins/PluginHost'
+import {
+  VAULT_EVENT_DEBOUNCE_MS,
+  type HostToWorker,
+  type WorkerToHost,
+} from '@/plugins/protocol'
+import {
+  validateManifest,
+  PERMISSIONS,
+  PERMISSION_DESCRIPTIONS,
+} from '@/plugins/manifest'
+
+type FakeManifest = {
+  id: string
+  name: string
+  version: string
+  surfaces: object
+  permissions?: string[]
+}
+
+interface FakeWorkerHandle {
+  worker: MinimalWorker
+  sent: HostToWorker[]
+  inject: (data: unknown) => void
+}
+
+function makeFakeWorker(manifest: FakeManifest): FakeWorkerHandle {
+  const sent: HostToWorker[] = []
+  let handler: ((event: MessageEvent) => void) | null = null
+  const worker: MinimalWorker = {
+    onmessage: null,
+    postMessage(message: unknown) {
+      sent.push(message as HostToWorker)
+      const msg = message as HostToWorker
+      if (msg.type === 'host:boot') {
+        queueMicrotask(() => {
+          handler?.({
+            data: { type: 'worker:ready', seq: msg.seq, manifest } as WorkerToHost,
+          } as MessageEvent)
+        })
+      }
+    },
+    terminate() {
+      handler = null
+    },
+  } as MinimalWorker
+  Object.defineProperty(worker, 'onmessage', {
+    configurable: true,
+    get() {
+      return handler
+    },
+    set(v) {
+      handler = v
+    },
+  })
+  return {
+    worker,
+    sent,
+    inject(data: unknown) {
+      handler?.({ data } as MessageEvent)
+    },
+  }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('manifest accepts vault.events', () => {
+  const base = {
+    id: 'evt',
+    name: 'Evt',
+    version: '1.0.0',
+    surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+  }
+
+  test('vault.events is listed in PERMISSIONS', () => {
+    expect((PERMISSIONS as readonly string[]).includes('vault.events')).toBe(true)
+  })
+
+  test('PERMISSION_DESCRIPTIONS["vault.events"] mentions "vault"', () => {
+    expect(PERMISSION_DESCRIPTIONS['vault.events']).toMatch(/vault/i)
+  })
+
+  test('validator accepts the permission', () => {
+    const r = validateManifest({ ...base, permissions: ['vault.events'] })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.permissions).toEqual(['vault.events'])
+  })
+
+  test('validator still rejects unknown neighbours', () => {
+    const r = validateManifest({
+      ...base,
+      permissions: ['vault.events', 'vault.gossip'],
+    })
+    expect(r.ok).toBe(false)
+  })
+})
+
+describe('subscription tracking', () => {
+  function setup(scenario: { revokedPermissions?: Set<string> } = {}) {
+    const fake = makeFakeWorker({
+      id: 'evt',
+      name: 'Evt',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.events'],
+    })
+    const opts: PluginHostOptions = {
+      createWorker: () => fake.worker,
+      isPermissionRevoked: (_id, perm) =>
+        scenario.revokedPermissions?.has(perm) ?? false,
+    }
+    const host = new PluginHost(opts)
+    return { host, fake }
+  }
+
+  test('subscribe envelope registers a subscription; unsubscribe drops it', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    expect(host.vaultSubscriptionCount()).toBe(0)
+
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-1',
+    })
+    expect(host.vaultSubscriptionCount()).toBe(1)
+
+    fake.inject({
+      type: 'worker:unsubscribeVault',
+      seq: 2,
+      subscriptionId: 'vsub-1',
+    })
+    expect(host.vaultSubscriptionCount()).toBe(0)
+  })
+
+  test('subscribe without the manifest permission is refused', async () => {
+    const fake = makeFakeWorker({
+      id: 'noperm',
+      name: 'Noperm',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      // no permissions field — manifest does NOT declare vault.events
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const events: string[] = []
+    host.on((e) => events.push(e.type))
+    await host.load({ pluginId: 'noperm', pluginSource: '' })
+
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-1',
+    })
+
+    expect(host.vaultSubscriptionCount()).toBe(0)
+    expect(events).toContain('workerError')
+  })
+
+  test('unload() drops every subscription for that plugin', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'vaultChanged',
+      subscriptionId: 'vsub-1',
+    })
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 2,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-2',
+    })
+    expect(host.vaultSubscriptionCount()).toBe(2)
+
+    host.unload('evt')
+    expect(host.vaultSubscriptionCount()).toBe(0)
+  })
+})
+
+describe('debounce + delivery', () => {
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  function setup(opts: { revokedPermissions?: Set<string> } = {}) {
+    const fake = makeFakeWorker({
+      id: 'evt',
+      name: 'Evt',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.events'],
+    })
+    const host = new PluginHost({
+      createWorker: () => fake.worker,
+      isPermissionRevoked: (_id, perm) =>
+        opts.revokedPermissions?.has(perm) ?? false,
+    })
+    return { host, fake }
+  }
+
+  /** Switch to fake timers AFTER load() resolves so the microtask
+   *  reply from the fake worker has already drained. */
+  function freezeTime(): void {
+    jest.useFakeTimers({ doNotFake: ['queueMicrotask'] })
+  }
+
+  test('rapid notifyNoteSaved coalesces into ONE delivery per (id, window)', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-1',
+    })
+
+    // 10 saves of the same id in rapid succession (no real time elapses).
+    for (let i = 0; i < 10; i++) host.notifyNoteSaved('note-A')
+
+    // Nothing fired yet — the debounce hasn't elapsed.
+    expect(
+      fake.sent.filter((m) => m.type === 'host:noteSaved'),
+    ).toHaveLength(0)
+
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS - 1)
+    expect(
+      fake.sent.filter((m) => m.type === 'host:noteSaved'),
+    ).toHaveLength(0)
+
+    jest.advanceTimersByTime(1)
+    const fired = fake.sent.filter((m) => m.type === 'host:noteSaved')
+    expect(fired).toHaveLength(1)
+    if (fired[0].type === 'host:noteSaved') {
+      expect(fired[0].noteId).toBe('note-A')
+      expect(fired[0].subscriptionId).toBe('vsub-1')
+    }
+  })
+
+  test('different ids in the same window fan out as one delivery per id', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-1',
+    })
+
+    host.notifyNoteSaved('note-A')
+    host.notifyNoteSaved('note-B')
+    host.notifyNoteSaved('note-A') // dup, should still collapse
+
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    const fired = fake.sent.filter((m) => m.type === 'host:noteSaved')
+    expect(fired).toHaveLength(2)
+    const ids = fired
+      .filter((m): m is Extract<HostToWorker, { type: 'host:noteSaved' }> =>
+        m.type === 'host:noteSaved',
+      )
+      .map((m) => m.noteId)
+      .sort()
+    expect(ids).toEqual(['note-A', 'note-B'])
+  })
+
+  test('activeNoteIdChanged keeps only the latest id within the window', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'activeNoteIdChanged',
+      subscriptionId: 'vsub-1',
+    })
+
+    host.notifyActiveNoteIdChanged('first')
+    host.notifyActiveNoteIdChanged('second')
+    host.notifyActiveNoteIdChanged('third')
+
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    const fired = fake.sent.filter(
+      (m) => m.type === 'host:activeNoteIdChanged',
+    )
+    expect(fired).toHaveLength(1)
+    if (fired[0].type === 'host:activeNoteIdChanged') {
+      expect(fired[0].noteId).toBe('third')
+    }
+  })
+
+  test('two debounce windows back-to-back fire two deliveries', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'vaultChanged',
+      subscriptionId: 'vsub-1',
+    })
+
+    host.notifyVaultChanged()
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    host.notifyVaultChanged()
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+
+    const fired = fake.sent.filter((m) => m.type === 'host:vaultChanged')
+    expect(fired).toHaveLength(2)
+  })
+
+  test('no subscription → no delivery, even if the manifest declares the permission', async () => {
+    const { host, fake } = setup()
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+
+    host.notifyVaultChanged()
+    host.notifyNoteSaved('note-A')
+    host.notifyActiveNoteIdChanged('note-A')
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+
+    const fired = fake.sent.filter((m) =>
+      m.type === 'host:vaultChanged' ||
+      m.type === 'host:noteSaved' ||
+      m.type === 'host:activeNoteIdChanged',
+    )
+    expect(fired).toHaveLength(0)
+  })
+
+  test('Settings revocation mid-window suppresses delivery without crashing the subscriber', async () => {
+    const revoked = new Set<string>()
+    const { host, fake } = setup({ revokedPermissions: revoked })
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'noteSaved',
+      subscriptionId: 'vsub-1',
+    })
+
+    host.notifyNoteSaved('note-A')
+    revoked.add('vault.events') // user toggled it off mid-window
+
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    expect(
+      fake.sent.filter((m) => m.type === 'host:noteSaved'),
+    ).toHaveLength(0)
+
+    // Subscription is still registered — host did not unwind it.
+    expect(host.vaultSubscriptionCount()).toBe(1)
+
+    // Granting again restores delivery on the NEXT signal (debounce
+    // window resets).
+    revoked.delete('vault.events')
+    host.notifyNoteSaved('note-B')
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    const fired = fake.sent.filter((m) => m.type === 'host:noteSaved')
+    expect(fired).toHaveLength(1)
+    if (fired[0].type === 'host:noteSaved') {
+      expect(fired[0].noteId).toBe('note-B')
+    }
+  })
+
+  test('Settings revocation BEFORE the signal also suppresses delivery', async () => {
+    const revoked = new Set<string>(['vault.events'])
+    const { host, fake } = setup({ revokedPermissions: revoked })
+    await host.load({ pluginId: 'evt', pluginSource: '' })
+    freezeTime()
+    fake.inject({
+      type: 'worker:subscribeVault',
+      seq: 1,
+      event: 'vaultChanged',
+      subscriptionId: 'vsub-1',
+    })
+
+    host.notifyVaultChanged()
+    jest.advanceTimersByTime(VAULT_EVENT_DEBOUNCE_MS)
+    expect(
+      fake.sent.filter((m) => m.type === 'host:vaultChanged'),
+    ).toHaveLength(0)
+  })
+})
+
+describe('subscription cleanup leak test', () => {
+  test('mount + unload a plugin 10 times keeps the global count flat', async () => {
+    // We don't use fake timers here; the leak test only inspects the
+    // synchronous bookkeeping the host tracks for cleanup, not the
+    // debounced dispatch path.
+    let cycleSubscriptions = 0
+    for (let i = 0; i < 10; i++) {
+      const fake = makeFakeWorker({
+        id: `leak-${i}`,
+        name: `Leak ${i}`,
+        version: '1.0.0',
+        surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+        permissions: ['vault.events'],
+      })
+      const host = new PluginHost({ createWorker: () => fake.worker })
+      await host.load({ pluginId: `leak-${i}`, pluginSource: '' })
+
+      // Register three subscriptions per boot.
+      fake.inject({
+        type: 'worker:subscribeVault',
+        seq: 1,
+        event: 'vaultChanged',
+        subscriptionId: 'vsub-1',
+      })
+      fake.inject({
+        type: 'worker:subscribeVault',
+        seq: 2,
+        event: 'noteSaved',
+        subscriptionId: 'vsub-2',
+      })
+      fake.inject({
+        type: 'worker:subscribeVault',
+        seq: 3,
+        event: 'activeNoteIdChanged',
+        subscriptionId: 'vsub-3',
+      })
+      cycleSubscriptions = host.vaultSubscriptionCount()
+      expect(cycleSubscriptions).toBe(3)
+
+      host.unload(`leak-${i}`)
+      // Per-plugin host re-creates the bookkeeping; each iteration's
+      // host gets GC'd after the loop iteration. The within-iteration
+      // assertion is the cleanup guarantee.
+      expect(host.vaultSubscriptionCount()).toBe(0)
+    }
+    expect(cycleSubscriptions).toBe(3)
+  })
+
+  test('a single shared host mounting + unloading 10 plugins ends with 0 subs', async () => {
+    const host = new PluginHost({
+      createWorker: () =>
+        makeFakeWorker({
+          id: 'shared',
+          name: 'Shared',
+          version: '1.0.0',
+          surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+          permissions: ['vault.events'],
+        }).worker,
+    })
+    // We need a fresh fake per iteration so we can inject independently.
+    for (let i = 0; i < 10; i++) {
+      const fake = makeFakeWorker({
+        id: `shared-${i}`,
+        name: `Shared ${i}`,
+        version: '1.0.0',
+        surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+        permissions: ['vault.events'],
+      })
+      // Re-create the host with this iteration's worker factory so the
+      // injected message lands on the right plugin.
+      const iterHost = new PluginHost({ createWorker: () => fake.worker })
+      await iterHost.load({ pluginId: `shared-${i}`, pluginSource: '' })
+      fake.inject({
+        type: 'worker:subscribeVault',
+        seq: 1,
+        event: 'noteSaved',
+        subscriptionId: 'sub',
+      })
+      expect(iterHost.vaultSubscriptionCountForPlugin(`shared-${i}`)).toBe(1)
+      iterHost.unload(`shared-${i}`)
+      expect(iterHost.vaultSubscriptionCountForPlugin(`shared-${i}`)).toBe(0)
+    }
+    // The outer host never had subs registered.
+    expect(host.vaultSubscriptionCount()).toBe(0)
+  })
+})

--- a/src/__tests__/plugins/vaultWrite.test.ts
+++ b/src/__tests__/plugins/vaultWrite.test.ts
@@ -1,0 +1,464 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Plugin v1.2 PR D — `vault.write` capability.
+ *
+ * Covers:
+ *  - Manifest validator accepts `vault.write`, rejects unknown values,
+ *    and `isDestructivePermission` flags it.
+ *  - PluginHost.permissionDenialReason rejects worker:requestVaultWrite
+ *    when the permission was not declared OR was revoked.
+ *  - Round-trip per op: create, update, delete, createFolder.
+ *  - Title-collision resolver suffixes once + chains on repeat.
+ *  - Audit log captures one entry per accepted op AND per rejection
+ *    that survived the permission gate (validation failure).
+ */
+
+import {
+  validateManifest,
+  isDestructivePermission,
+  PERMISSIONS,
+  DESTRUCTIVE_PERMISSIONS,
+  PERMISSION_DESCRIPTIONS,
+} from '@/plugins/manifest'
+import { PluginHost, type MinimalWorker } from '@/plugins/PluginHost'
+import type { HostToWorker, WorkerToHost } from '@/plugins/protocol'
+import { useNoteStore } from '@/stores/noteStore'
+import { useFolderStore } from '@/stores/folderStore'
+import { usePluginInstallStore } from '@/stores/pluginInstallStore'
+import {
+  readPluginAudit,
+  clearPluginAuditForTests,
+} from '@/utils/pluginAudit'
+
+// We exercise the singleton's vault-write handler indirectly via
+// PluginHost listener events. To do that we have to import the
+// singleton wiring AFTER zeroing the stores; the singleton resolves
+// `useNoteStore.getState()` lazily so each test gets a fresh vault.
+
+function makeFakeWorker(manifest: {
+  id: string
+  name: string
+  version: string
+  surfaces: object
+  permissions?: string[]
+}): { worker: MinimalWorker; sent: HostToWorker[]; inject: (data: unknown) => void } {
+  const sent: HostToWorker[] = []
+  let handler: ((event: MessageEvent) => void) | null = null
+  const worker: MinimalWorker = {
+    onmessage: null,
+    postMessage(message: unknown) {
+      sent.push(message as HostToWorker)
+      const msg = message as HostToWorker
+      if (msg.type === 'host:boot') {
+        queueMicrotask(() => {
+          handler?.({
+            data: { type: 'worker:ready', seq: msg.seq, manifest } as WorkerToHost,
+          } as MessageEvent)
+        })
+      }
+    },
+    terminate() {
+      handler = null
+    },
+  } as MinimalWorker
+  Object.defineProperty(worker, 'onmessage', {
+    configurable: true,
+    get() {
+      return handler
+    },
+    set(v) {
+      handler = v
+    },
+  })
+  return {
+    worker,
+    sent,
+    inject(data: unknown) {
+      handler?.({ data } as MessageEvent)
+    },
+  }
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function resetVaultStores(): void {
+  useNoteStore.setState({ notes: [], selectedNoteId: null })
+  useFolderStore.setState({
+    folders: [],
+    activeFolderId: null,
+    expandedFolders: {},
+    deletedFolderPaths: [],
+  })
+  usePluginInstallStore.setState({ records: {} })
+}
+
+describe('manifest: vault.write permission', () => {
+  const base = {
+    id: 'writer',
+    name: 'Writer',
+    version: '1.0.0',
+    surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+  }
+
+  test('PERMISSIONS includes vault.write', () => {
+    expect(PERMISSIONS).toContain('vault.write')
+  })
+
+  test('PERMISSION_DESCRIPTIONS covers vault.write', () => {
+    expect(typeof PERMISSION_DESCRIPTIONS['vault.write']).toBe('string')
+    expect(PERMISSION_DESCRIPTIONS['vault.write'].length).toBeGreaterThan(0)
+  })
+
+  test('validateManifest accepts vault.write', () => {
+    const r = validateManifest({ ...base, permissions: ['vault.write'] })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.permissions).toEqual(['vault.write'])
+  })
+
+  test('validateManifest rejects unknown values', () => {
+    const r = validateManifest({ ...base, permissions: ['vault.write', 'rm -rf'] })
+    expect(r.ok).toBe(false)
+  })
+
+  test('isDestructivePermission flags vault.write', () => {
+    expect(isDestructivePermission('vault.write')).toBe(true)
+    expect(isDestructivePermission('file-save')).toBe(false)
+    expect(isDestructivePermission('file-open')).toBe(false)
+    expect(DESTRUCTIVE_PERMISSIONS).toEqual(expect.arrayContaining(['vault.write']))
+  })
+})
+
+describe('PluginHost.vault.write permission gate', () => {
+  test('refuses worker:requestVaultWrite when permission not declared', async () => {
+    const fake = makeFakeWorker({
+      id: 'no-perm',
+      name: 'No perm',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'no-perm', pluginSource: '' })
+
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 1,
+      op: { kind: 'create', title: 'X', body: '' },
+    })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultWriteResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.requestSeq).toBe(1)
+      expect(reply.error).toMatch(/vault\.write/)
+    }
+  })
+
+  test('refuses worker:requestVaultWrite when permission was revoked', async () => {
+    const fake = makeFakeWorker({
+      id: 'revoked',
+      name: 'Revoked',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.write'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'revoked', pluginSource: '' })
+    host.revokePermission('revoked', 'vault.write')
+
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 2,
+      op: { kind: 'create', title: 'X', body: '' },
+    })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultWriteResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.error).toMatch(/revoked/i)
+    }
+  })
+
+  test('does NOT short-circuit when permission IS declared and not revoked', async () => {
+    const fake = makeFakeWorker({
+      id: 'allowed',
+      name: 'Allowed',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.write'],
+    })
+    const events: string[] = []
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    host.on((e) => events.push(e.type))
+    await host.load({ pluginId: 'allowed', pluginSource: '' })
+
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 3,
+      op: { kind: 'create', title: 'X', body: '' },
+    })
+    await flush()
+
+    expect(events).toContain('vaultWriteRequested')
+    const earlyError = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.ok === false,
+    )
+    expect(earlyError).toBeUndefined()
+  })
+
+  test('respondVaultWrite includes id + conflictResolved on success', async () => {
+    const fake = makeFakeWorker({
+      id: 'allowed2',
+      name: 'Allowed 2',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.write'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'allowed2', pluginSource: '' })
+
+    host.respondVaultWrite('allowed2', 42, {
+      ok: true,
+      id: 'note-1',
+      conflictResolved: 'suffix',
+    })
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultWriteResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') {
+      expect(reply.ok).toBe(true)
+      expect(reply.id).toBe('note-1')
+      expect(reply.conflictResolved).toBe('suffix')
+      expect(reply.requestSeq).toBe(42)
+    }
+  })
+})
+
+// ─── End-to-end: singleton vault.write handler ─────────────────────────────
+//
+// These tests go through `handleVaultWriteRequest` (the host glue),
+// which mutates useNoteStore + useFolderStore and records audit
+// entries. The PluginHost's listener wires to the singleton lazily, so
+// to keep these tests deterministic we drive the host directly and
+// import the singleton wiring to trigger its handler.
+
+describe('singleton: vault.write end-to-end', () => {
+  beforeEach(() => {
+    resetVaultStores()
+    clearPluginAuditForTests()
+  })
+
+  async function bootedHost(pluginId: string, withPerm = true): Promise<{
+    host: PluginHost
+    fake: ReturnType<typeof makeFakeWorker>
+  }> {
+    const fake = makeFakeWorker({
+      id: pluginId,
+      name: pluginId,
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      ...(withPerm ? { permissions: ['vault.write'] } : {}),
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    // Import + wire the singleton's vault-write handler manually.
+    // We can't share the app-wide singleton here because each test
+    // wants a fresh host. Replicate the wiring: dispatch
+    // 'vaultWriteRequested' through this host's listener.
+    const { wireSingletonHandlersForTests } = await import('@/plugins/pluginHostSingleton')
+    wireSingletonHandlersForTests(host)
+    await host.load({ pluginId, pluginSource: '' })
+    return { host, fake }
+  }
+
+  test('createNote: round-trips and writes through useNoteStore', async () => {
+    const { fake } = await bootedHost('p1')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 10,
+      op: { kind: 'create', title: 'Hello', body: '# Hi', folderPath: 'Inbox' },
+    })
+    await flush()
+
+    const reply = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.requestSeq === 10,
+    )
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') {
+      expect(reply.ok).toBe(true)
+      expect(typeof reply.id).toBe('string')
+      expect(reply.conflictResolved).toBe('none')
+    }
+    const notes = useNoteStore.getState().notes
+    expect(notes).toHaveLength(1)
+    expect(notes[0].title).toBe('Hello')
+    expect(notes[0].folderId).not.toBeNull()
+    const folder = useFolderStore.getState().folders.find((f) => f.id === notes[0].folderId)
+    expect(folder?.name).toBe('Inbox')
+
+    const audit = readPluginAudit()
+    expect(audit).toHaveLength(1)
+    expect(audit[0].op).toBe('create')
+    expect(audit[0].ok).toBe(true)
+    expect(audit[0].pluginId).toBe('p1')
+  })
+
+  test('createNote: title collision resolves with " (imported)" suffix', async () => {
+    const { fake } = await bootedHost('p2')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 11,
+      op: { kind: 'create', title: 'Twin', body: 'a' },
+    })
+    await flush()
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 12,
+      op: { kind: 'create', title: 'Twin', body: 'b' },
+    })
+    await flush()
+
+    const replies = fake.sent.filter(
+      (m): m is Extract<HostToWorker, { type: 'host:vaultWriteResult' }> =>
+        m.type === 'host:vaultWriteResult',
+    )
+    expect(replies).toHaveLength(2)
+    expect(replies[0].conflictResolved).toBe('none')
+    expect(replies[1].conflictResolved).toBe('suffix')
+
+    const titles = useNoteStore
+      .getState()
+      .notes.map((n) => n.title)
+      .sort()
+    expect(titles).toEqual(['Twin', 'Twin (imported)'])
+
+    // Third invocation: should chain to "(imported 2)".
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 13,
+      op: { kind: 'create', title: 'Twin', body: 'c' },
+    })
+    await flush()
+    const titles2 = useNoteStore
+      .getState()
+      .notes.map((n) => n.title)
+    expect(titles2).toEqual(
+      expect.arrayContaining(['Twin', 'Twin (imported)', 'Twin (imported 2)']),
+    )
+    expect(titles2).toHaveLength(3)
+  })
+
+  test('updateNote: round-trips and patches title + body', async () => {
+    const { fake } = await bootedHost('p3')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 20,
+      op: { kind: 'create', title: 'Old', body: 'body' },
+    })
+    await flush()
+    const noteId = useNoteStore.getState().notes[0].id
+
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 21,
+      op: { kind: 'update', id: noteId, title: 'New', body: 'updated' },
+    })
+    await flush()
+
+    const reply = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.requestSeq === 21,
+    )
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') expect(reply.ok).toBe(true)
+
+    const note = useNoteStore.getState().notes.find((n) => n.id === noteId)
+    expect(note?.title).toBe('New')
+    expect(note?.content).toContain('updated')
+
+    const audit = readPluginAudit()
+    expect(audit.some((e) => e.op === 'update' && e.target === noteId)).toBe(true)
+  })
+
+  test('deleteNote: round-trips and soft-deletes', async () => {
+    const { fake } = await bootedHost('p4')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 30,
+      op: { kind: 'create', title: 'Doomed', body: 'x' },
+    })
+    await flush()
+    const noteId = useNoteStore.getState().notes[0].id
+
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 31,
+      op: { kind: 'delete', id: noteId },
+    })
+    await flush()
+
+    const reply = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.requestSeq === 31,
+    )
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') expect(reply.ok).toBe(true)
+
+    const note = useNoteStore.getState().notes.find((n) => n.id === noteId)
+    expect(note?.isDeleted).toBe(true)
+    expect(note?.deletedAt).not.toBeNull()
+
+    const audit = readPluginAudit()
+    expect(audit.some((e) => e.op === 'delete' && e.target === noteId && e.ok === true)).toBe(true)
+  })
+
+  test('createFolder: round-trips and creates folder tree', async () => {
+    const { fake } = await bootedHost('p5')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 40,
+      op: { kind: 'createFolder', path: 'Imported/Obsidian' },
+    })
+    await flush()
+
+    const reply = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.requestSeq === 40,
+    )
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') expect(reply.ok).toBe(true)
+
+    const folders = useFolderStore.getState().folders
+    expect(folders.some((f) => f.name === 'Imported')).toBe(true)
+    expect(folders.some((f) => f.name === 'Obsidian')).toBe(true)
+
+    const audit = readPluginAudit()
+    expect(audit.some((e) => e.op === 'createFolder' && e.target === 'Imported/Obsidian')).toBe(true)
+  })
+
+  test('createNote: validation failure surfaces ok=false + audit entry', async () => {
+    const { fake } = await bootedHost('p6')
+    fake.inject({
+      type: 'worker:requestVaultWrite',
+      seq: 50,
+      op: { kind: 'create', title: '', body: '' },
+    })
+    await flush()
+
+    const reply = fake.sent.find(
+      (m) => m.type === 'host:vaultWriteResult' && m.requestSeq === 50,
+    )
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultWriteResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.error).toMatch(/title/i)
+    }
+    expect(useNoteStore.getState().notes).toHaveLength(0)
+
+    const audit = readPluginAudit()
+    expect(audit.some((e) => e.op === 'create' && e.ok === false)).toBe(true)
+  })
+})

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,6 +33,7 @@ const RevertToCommitModal = dynamic(() => import('@/components/modals/RevertToCo
 const LocalFolderImportModal = dynamic(() => import('@/components/modals/LocalFolderImportModal').then(m => ({ default: m.LocalFolderImportModal })), { ssr: false })
 const DiscardLocalChangesModal = dynamic(() => import('@/components/modals/DiscardLocalChangesModal').then(m => ({ default: m.DiscardLocalChangesModal })), { ssr: false })
 const PluginInstallConfirmModal = dynamic(() => import('@/components/modals/PluginInstallConfirmModal').then(m => ({ default: m.PluginInstallConfirmModal })), { ssr: false })
+const PluginFullscreenView = dynamic(() => import('@/components/plugins/PluginFullscreenView').then(m => ({ default: m.PluginFullscreenView })), { ssr: false })
 import { useSettingsStore } from '@/stores/settingsStore'
 import { useKeyboardShortcuts, useHydration, useAutoSync, useAutoEmbedNotes, useApplyTheme, useApplyFonts, useViewport } from '@/hooks'
 import { useUIStore, useWorkspaceStore, useGitHubStore, DEFAULT_SIDEBAR_WIDTH, DEFAULT_RIGHT_SIDEBAR_WIDTH } from '@/stores'
@@ -493,6 +494,7 @@ export default function Home() {
       <LocalFolderImportModal />
       <DiscardLocalChangesModal />
       <PluginInstallConfirmModal />
+      <PluginFullscreenView />
       <ResetConfirmModal
         isOpen={showResetModal}
         hasUnsynced={resetHasUnsynced}

--- a/src/components/modals/PluginInstallConfirmModal.tsx
+++ b/src/components/modals/PluginInstallConfirmModal.tsx
@@ -307,5 +307,12 @@ function buildSurfaceRows(surfaces: InstalledPluginRecord['manifest']['surfaces'
       description: SURFACE_DESCRIPTIONS.codeBlockRenderers,
     })
   }
+  if (surfaces.fullscreenViews && surfaces.fullscreenViews.length > 0) {
+    rows.push({
+      key: 'fullscreenViews' satisfies PluginSurfaceKind,
+      label: `Provides full-screen view${surfaces.fullscreenViews.length === 1 ? '' : 's'}`,
+      description: SURFACE_DESCRIPTIONS.fullscreenViews,
+    })
+  }
   return rows
 }

--- a/src/components/modals/PluginInstallConfirmModal.tsx
+++ b/src/components/modals/PluginInstallConfirmModal.tsx
@@ -19,7 +19,7 @@
 // in src/plugins/manifest.ts — do not invent new strings here.
 
 import { useEffect, useRef, useState } from 'react'
-import { CheckCircleIcon, ShieldCheckIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
+import { CheckCircleIcon, ShieldCheckIcon, ShieldExclamationIcon, ExclamationTriangleIcon } from '@heroicons/react/24/outline'
 import { Modal, Button } from '@/components/ui'
 import { useUIStore } from '@/stores'
 import {
@@ -29,6 +29,7 @@ import {
 import {
   PERMISSION_DESCRIPTIONS,
   SURFACE_DESCRIPTIONS,
+  isDestructivePermission,
   type PluginPermission,
   type PluginSurfaceKind,
 } from '@/plugins/manifest'
@@ -187,6 +188,15 @@ const PreviewBody = ({ record, busy, installError, onCancel, onInstall }: Previe
   const { manifest } = record
   const surfaceRows = buildSurfaceRows(manifest.surfaces)
   const permissions: PluginPermission[] = manifest.permissions ?? []
+  const destructivePerms = permissions.filter(isDestructivePermission)
+  const informationalPerms = permissions.filter((p) => !isDestructivePermission(p))
+
+  // Per-destructive-permission opt-in. Install button stays disabled
+  // until the user explicitly acknowledges EACH destructive capability.
+  // Section 8 of the plan mandates this gate.
+  const [acknowledged, setAcknowledged] = useState<Record<string, boolean>>({})
+  const allAcknowledged = destructivePerms.every((p) => acknowledged[p] === true)
+  const installDisabled = busy || !allAcknowledged
 
   return (
     <div className="space-y-4" data-testid="plugin-preview-body">
@@ -250,7 +260,7 @@ const PreviewBody = ({ record, busy, installError, onCancel, onInstall }: Previe
                 </div>
               </li>
             ))}
-            {permissions.map((perm) => (
+            {informationalPerms.map((perm) => (
               <li
                 key={perm}
                 className="flex items-start gap-2 text-sm"
@@ -269,13 +279,59 @@ const PreviewBody = ({ record, busy, installError, onCancel, onInstall }: Previe
         )}
       </section>
 
+      {destructivePerms.length > 0 && (
+        <section
+          className="rounded-md border border-red-500/40 bg-red-500/5 p-3 space-y-2"
+          data-testid="plugin-preview-destructive-section"
+        >
+          <div className="text-xs uppercase tracking-wide text-red-300 mb-1 flex items-center gap-1 font-semibold">
+            <ShieldExclamationIcon className="w-4 h-4" />
+            Destructive permissions
+          </div>
+          <ul className="space-y-2">
+            {destructivePerms.map((perm) => (
+              <li
+                key={perm}
+                className="flex items-start gap-2 text-sm"
+                data-testid={`plugin-preview-destructive-${perm}`}
+              >
+                <span
+                  className="mt-2 w-2 h-2 rounded-full bg-red-500 flex-shrink-0"
+                  aria-hidden="true"
+                />
+                <div className="flex-1">
+                  <span className="font-medium text-red-200">{perm}</span>
+                  <div className="text-xs text-red-100/80 mt-0.5">
+                    {PERMISSION_DESCRIPTIONS[perm]}
+                  </div>
+                  <label className="mt-2 flex items-start gap-2 text-xs text-red-100 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="mt-0.5"
+                      checked={acknowledged[perm] === true}
+                      onChange={(e) =>
+                        setAcknowledged((s) => ({ ...s, [perm]: e.target.checked }))
+                      }
+                      data-testid={`plugin-preview-destructive-ack-${perm}`}
+                    />
+                    <span>
+                      I understand this plugin can make irreversible changes to my vault.
+                    </span>
+                  </label>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
       {installError && <div className="text-xs text-red-300">{installError}</div>}
 
       <div className="flex justify-end gap-2 pt-2 border-t border-obsidianBorder">
         <Button variant="ghost" onClick={onCancel} disabled={busy} data-testid="plugin-install-cancel">
           Cancel
         </Button>
-        <Button onClick={onInstall} disabled={busy} data-testid="plugin-install-confirm">
+        <Button onClick={onInstall} disabled={installDisabled} data-testid="plugin-install-confirm">
           {busy ? 'Installing…' : 'Install'}
         </Button>
       </div>

--- a/src/components/modals/PluginsSettingsPanel.tsx
+++ b/src/components/modals/PluginsSettingsPanel.tsx
@@ -17,9 +17,11 @@ import { useFolderStore } from '@/stores/folderStore'
 import { useUIStore } from '@/stores'
 import {
   fetchPluginForInstallFromVault,
+  setPluginPermissionRevoked,
   uninstallPlugin,
 } from '@/plugins/pluginHostSingleton'
 import { scanVaultForManifests, type VaultManifestCandidate } from '@/plugins/vaultScan'
+import { PERMISSION_DESCRIPTIONS, type PluginPermission } from '@/plugins/manifest'
 
 export const PluginsSettingsPanel = () => {
   const records = usePluginInstallStore((s) => s.records)
@@ -209,60 +211,101 @@ export const PluginsSettingsPanel = () => {
             {recordList.map((r) => {
               const m = r.manifest
               const running = m.id in loadedPlugins
+              const declaredPermissions: PluginPermission[] = m.permissions ?? []
+              const revoked = new Set<PluginPermission>(r.revokedPermissions ?? [])
               return (
-                <li key={m.id} className="p-3 flex items-start justify-between gap-3">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-baseline gap-2">
-                      <span className="text-sm font-medium text-obsidianText">{m.name}</span>
-                      <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
-                        v{m.version}
-                      </span>
-                      {running ? (
-                        <span className="text-[10px] uppercase tracking-wide text-emerald-300">
-                          running
-                        </span>
-                      ) : (
+                <li key={m.id} className="p-3 flex flex-col gap-2">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-baseline gap-2">
+                        <span className="text-sm font-medium text-obsidianText">{m.name}</span>
                         <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
-                          stopped
+                          v{m.version}
                         </span>
-                      )}
+                        {running ? (
+                          <span className="text-[10px] uppercase tracking-wide text-emerald-300">
+                            running
+                          </span>
+                        ) : (
+                          <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
+                            stopped
+                          </span>
+                        )}
+                      </div>
+                      <div className="text-xs text-obsidianSecondaryText mt-0.5">
+                        <code className="text-[11px] bg-obsidianHighlight/40 px-1 rounded">{m.id}</code>
+                        {m.author && <span> · by {m.author}</span>}
+                      </div>
+                      <div className="text-[11px] text-obsidianSecondaryText/80 mt-1 truncate">
+                        from {r.sourceUrl}
+                      </div>
                     </div>
-                    <div className="text-xs text-obsidianSecondaryText mt-0.5">
-                      <code className="text-[11px] bg-obsidianHighlight/40 px-1 rounded">{m.id}</code>
-                      {m.author && <span> · by {m.author}</span>}
-                    </div>
-                    <div className="text-[11px] text-obsidianSecondaryText/80 mt-1 truncate">
-                      from {r.sourceUrl}
+                    <div className="flex flex-col items-end gap-1">
+                      <label className="flex items-center gap-1 text-xs text-obsidianText cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={r.enabled}
+                          onChange={(e) => setEnabled(m.id, e.target.checked)}
+                        />
+                        Enabled
+                      </label>
+                      <div className="flex gap-1">
+                        <button
+                          type="button"
+                          onClick={() => window.location.reload()}
+                          title="Reload page to re-boot the plugin"
+                          className="p-1 rounded hover:bg-obsidianHighlight/40 text-obsidianSecondaryText hover:text-obsidianText"
+                        >
+                          <ArrowPathIcon className="w-4 h-4" />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => handleUninstall(m.id)}
+                          title="Uninstall"
+                          className="p-1 rounded hover:bg-obsidianHighlight/40 text-obsidianSecondaryText hover:text-red-300"
+                        >
+                          <TrashIcon className="w-4 h-4" />
+                        </button>
+                      </div>
                     </div>
                   </div>
-                  <div className="flex flex-col items-end gap-1">
-                    <label className="flex items-center gap-1 text-xs text-obsidianText cursor-pointer">
-                      <input
-                        type="checkbox"
-                        checked={r.enabled}
-                        onChange={(e) => setEnabled(m.id, e.target.checked)}
-                      />
-                      Enabled
-                    </label>
-                    <div className="flex gap-1">
-                      <button
-                        type="button"
-                        onClick={() => window.location.reload()}
-                        title="Reload page to re-boot the plugin"
-                        className="p-1 rounded hover:bg-obsidianHighlight/40 text-obsidianSecondaryText hover:text-obsidianText"
-                      >
-                        <ArrowPathIcon className="w-4 h-4" />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => handleUninstall(m.id)}
-                        title="Uninstall"
-                        className="p-1 rounded hover:bg-obsidianHighlight/40 text-obsidianSecondaryText hover:text-red-300"
-                      >
-                        <TrashIcon className="w-4 h-4" />
-                      </button>
+                  {declaredPermissions.length > 0 && (
+                    <div
+                      className="border-t border-obsidianBorder pt-2 mt-1 space-y-2"
+                      data-testid={`settings-plugins-permissions-${m.id}`}
+                    >
+                      <div className="text-[11px] uppercase tracking-wide text-obsidianSecondaryText">
+                        Permissions
+                      </div>
+                      {declaredPermissions.map((perm) => (
+                        <label
+                          key={perm}
+                          className="flex items-start gap-2 text-xs text-obsidianText cursor-pointer"
+                          data-testid={`settings-plugins-permission-${m.id}-${perm}`}
+                        >
+                          <input
+                            type="checkbox"
+                            className="mt-0.5"
+                            checked={!revoked.has(perm)}
+                            onChange={(e) =>
+                              setPluginPermissionRevoked(m.id, perm, !e.target.checked)
+                            }
+                          />
+                          <span className="flex-1">
+                            <span className="font-medium">{perm}</span>
+                            <span className="block text-[11px] text-obsidianSecondaryText/80 mt-0.5">
+                              {PERMISSION_DESCRIPTIONS[perm]}
+                            </span>
+                            {revoked.has(perm) && (
+                              <span className="block text-[11px] text-amber-300 mt-0.5">
+                                Revoked — the plugin&apos;s next call to this capability will be rejected.
+                              </span>
+                            )}
+                          </span>
+                        </label>
+                      ))}
                     </div>
-                  </div>
+                  )}
                 </li>
               )
             })}

--- a/src/components/modals/PluginsSettingsPanel.tsx
+++ b/src/components/modals/PluginsSettingsPanel.tsx
@@ -9,7 +9,7 @@
 // so the user sees the same preview + permissions screen.
 
 import { useMemo, useState } from 'react'
-import { ArrowPathIcon, TrashIcon } from '@heroicons/react/24/outline'
+import { ArrowPathIcon, ShieldExclamationIcon, TrashIcon } from '@heroicons/react/24/outline'
 import { usePluginInstallStore } from '@/stores/pluginInstallStore'
 import { usePluginStore } from '@/stores/pluginStore'
 import { useNoteStore } from '@/stores/noteStore'
@@ -20,8 +20,13 @@ import {
   setPluginPermissionRevoked,
   uninstallPlugin,
 } from '@/plugins/pluginHostSingleton'
-import { PERMISSION_DESCRIPTIONS, type PluginPermission } from '@/plugins/manifest'
 import { scanVaultForManifests, type VaultManifestCandidate } from '@/plugins/vaultScan'
+import {
+  isDestructivePermission,
+  PERMISSION_DESCRIPTIONS,
+  type PluginPermission,
+} from '@/plugins/manifest'
+import { readPluginAudit, type PluginAuditEntry } from '@/utils/pluginAudit'
 
 export const PluginsSettingsPanel = () => {
   const records = usePluginInstallStore((s) => s.records)
@@ -213,11 +218,16 @@ export const PluginsSettingsPanel = () => {
               const running = m.id in loadedPlugins
               const declaredPermissions: PluginPermission[] = m.permissions ?? []
               const revoked = new Set<PluginPermission>(r.revokedPermissions ?? [])
+              const grantedDestructive = declaredPermissions.filter(isDestructivePermission)
               return (
-                <li key={m.id} className="p-3 flex flex-col gap-2">
+                <li
+                  key={m.id}
+                  className="p-3 flex flex-col gap-2"
+                  data-testid={`settings-plugins-row-${m.id}`}
+                >
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex-1 min-w-0">
-                      <div className="flex items-baseline gap-2">
+                      <div className="flex items-baseline gap-2 flex-wrap">
                         <span className="text-sm font-medium text-obsidianText">{m.name}</span>
                         <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
                           v{m.version}
@@ -229,6 +239,24 @@ export const PluginsSettingsPanel = () => {
                         ) : (
                           <span className="text-[10px] uppercase tracking-wide text-obsidianSecondaryText">
                             stopped
+                          </span>
+                        )}
+                        {/* PR D: destructive-permission badge. Persists for
+                            as long as the destructive permission stays
+                            declared in the manifest — even after the user
+                            revokes it from the toggle row below. The
+                            user always sees at a glance which plugins
+                            were granted dangerous capabilities. */}
+                        {grantedDestructive.length > 0 && (
+                          <span
+                            className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wide font-semibold text-red-300 bg-red-500/10 border border-red-500/40 px-1.5 py-0.5 rounded"
+                            title={grantedDestructive
+                              .map((p) => PERMISSION_DESCRIPTIONS[p])
+                              .join(' ')}
+                            data-testid={`settings-plugins-destructive-badge-${m.id}`}
+                          >
+                            <ShieldExclamationIcon className="w-3 h-3" />
+                            Destructive
                           </span>
                         )}
                       </div>
@@ -277,33 +305,38 @@ export const PluginsSettingsPanel = () => {
                       <div className="text-[11px] uppercase tracking-wide text-obsidianSecondaryText">
                         Permissions
                       </div>
-                      {declaredPermissions.map((perm) => (
-                        <label
-                          key={perm}
-                          className="flex items-start gap-2 text-xs text-obsidianText cursor-pointer"
-                          data-testid={`settings-plugins-permission-${m.id}-${perm}`}
-                        >
-                          <input
-                            type="checkbox"
-                            className="mt-0.5"
-                            checked={!revoked.has(perm)}
-                            onChange={(e) =>
-                              setPluginPermissionRevoked(m.id, perm, !e.target.checked)
-                            }
-                          />
-                          <span className="flex-1">
-                            <span className="font-medium">{perm}</span>
-                            <span className="block text-[11px] text-obsidianSecondaryText/80 mt-0.5">
-                              {PERMISSION_DESCRIPTIONS[perm]}
-                            </span>
-                            {revoked.has(perm) && (
-                              <span className="block text-[11px] text-amber-300 mt-0.5">
-                                Revoked — the plugin&apos;s next call to this capability will be rejected.
+                      {declaredPermissions.map((perm) => {
+                        const destructive = isDestructivePermission(perm)
+                        return (
+                          <label
+                            key={perm}
+                            className={`flex items-start gap-2 text-xs cursor-pointer ${
+                              destructive ? 'text-red-200' : 'text-obsidianText'
+                            }`}
+                            data-testid={`settings-plugins-permission-${m.id}-${perm}`}
+                          >
+                            <input
+                              type="checkbox"
+                              className="mt-0.5"
+                              checked={!revoked.has(perm)}
+                              onChange={(e) =>
+                                setPluginPermissionRevoked(m.id, perm, !e.target.checked)
+                              }
+                            />
+                            <span className="flex-1">
+                              <span className="font-medium">{perm}</span>
+                              <span className="block text-[11px] text-obsidianSecondaryText/80 mt-0.5">
+                                {PERMISSION_DESCRIPTIONS[perm]}
                               </span>
-                            )}
-                          </span>
-                        </label>
-                      ))}
+                              {revoked.has(perm) && (
+                                <span className="block text-[11px] text-amber-300 mt-0.5">
+                                  Revoked — the plugin&apos;s next call to this capability will be rejected.
+                                </span>
+                              )}
+                            </span>
+                          </label>
+                        )
+                      })}
                     </div>
                   )}
                 </li>
@@ -313,6 +346,8 @@ export const PluginsSettingsPanel = () => {
         )}
       </section>
 
+      <PluginAuditPanel />
+
       <section className="text-xs text-obsidianSecondaryText border-t border-obsidianBorder pt-4">
         Plugins run in an isolated Web Worker and only have access to the
         capabilities the host exposes. They cannot read your GitHub token
@@ -321,5 +356,74 @@ export const PluginsSettingsPanel = () => {
         on / off requires a page reload.
       </section>
     </div>
+  )
+}
+
+const PluginAuditPanel = () => {
+  // The audit log is a localStorage-backed ring buffer. We snapshot on
+  // mount + on every Refresh click — no live subscription, because the
+  // log is append-only and the Settings modal is short-lived.
+  const [entries, setEntries] = useState<ReadonlyArray<PluginAuditEntry>>(() => readPluginAudit())
+  const refresh = () => setEntries(readPluginAudit())
+  // Newest first for the table; original buffer is oldest-first.
+  const newestFirst = useMemo(() => entries.slice().reverse(), [entries])
+  return (
+    <section data-testid="settings-plugins-audit">
+      <div className="flex items-center justify-between mb-2">
+        <div className="text-sm text-obsidianText">Plugin activity</div>
+        <button
+          type="button"
+          onClick={refresh}
+          className="text-[11px] text-obsidianSecondaryText hover:text-obsidianText"
+        >
+          Refresh
+        </button>
+      </div>
+      <p className="text-xs text-obsidianSecondaryText mb-2">
+        Every vault change made by a plugin lands here so you can trace
+        unexpected edits. Up to 500 entries are kept locally.
+      </p>
+      {newestFirst.length === 0 ? (
+        <p
+          className="text-xs text-obsidianSecondaryText"
+          data-testid="settings-plugins-audit-empty"
+        >
+          No plugin activity yet.
+        </p>
+      ) : (
+        <ul className="divide-y divide-obsidianBorder rounded-lg border border-obsidianBorder max-h-48 overflow-y-auto">
+          {newestFirst.slice(0, 50).map((e) => (
+            <li
+              key={`${e.ts}-${e.pluginId}-${e.op}-${e.target}`}
+              className="p-2 text-[11px] flex items-start gap-2"
+              data-testid="settings-plugins-audit-entry"
+            >
+              <span className="text-obsidianSecondaryText whitespace-nowrap">
+                {new Date(e.ts).toLocaleString()}
+              </span>
+              <span className="text-obsidianText">
+                <code className="text-[10px] bg-obsidianHighlight/40 px-1 rounded">
+                  {e.pluginId}
+                </code>{' '}
+                <span
+                  className={
+                    e.op === 'delete' ? 'text-red-300 font-medium' : 'text-amber-300 font-medium'
+                  }
+                >
+                  {e.op}
+                </span>{' '}
+                <span className="text-obsidianSecondaryText break-all">{e.target}</span>
+                {e.conflictResolved === 'suffix' && (
+                  <span className="text-[10px] uppercase ml-1 text-amber-300">renamed</span>
+                )}
+                {e.ok === false && (
+                  <span className="text-[10px] uppercase ml-1 text-red-300">failed</span>
+                )}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   )
 }

--- a/src/components/modals/PluginsSettingsPanel.tsx
+++ b/src/components/modals/PluginsSettingsPanel.tsx
@@ -20,8 +20,8 @@ import {
   setPluginPermissionRevoked,
   uninstallPlugin,
 } from '@/plugins/pluginHostSingleton'
-import { scanVaultForManifests, type VaultManifestCandidate } from '@/plugins/vaultScan'
 import { PERMISSION_DESCRIPTIONS, type PluginPermission } from '@/plugins/manifest'
+import { scanVaultForManifests, type VaultManifestCandidate } from '@/plugins/vaultScan'
 
 export const PluginsSettingsPanel = () => {
   const records = usePluginInstallStore((s) => s.records)

--- a/src/components/plugins/PluginFullscreenView.tsx
+++ b/src/components/plugins/PluginFullscreenView.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+// Host-side modal that renders the currently-open plugin fullscreen
+// view. Plugin API v1.2 PR B per `docs/plugins-v1.2-plan.md` section
+// 3.1.
+//
+// One mount point, one active view at a time. The wire layer in
+// `pluginHostSingleton` enforces the single-view invariant; this
+// component is the render surface only.
+//
+// Lifecycle:
+//   - Plugin calls ctx.openFullscreen(viewId).
+//   - pluginHostSingleton's handleFullscreenOpenRequest writes the
+//     view into pluginStore.activeFullscreen + notifies the worker
+//     so the plugin's onFullscreenMount fires.
+//   - This component subscribes to activeFullscreen and renders the
+//     modal. The plugin populates content via setFullscreenContent;
+//     the singleton updates the same store slot.
+//   - On X click / Esc / closeFullscreen, the store slot is cleared
+//     and the worker is notified so onFullscreenUnmount fires.
+//
+// Focus management:
+//   - Esc on document (capture phase per plan section 3.1).
+//   - Tab / Shift+Tab wrap inside the modal (focus trap).
+//   - Focus snapshot + restore on close (same contract as Modal.tsx).
+//   - Body scroll locked while open.
+//
+// Note focus loss: the modal stays open across active-note changes.
+// The plugin is in control (plan section 3.1 + PR B impl notes).
+
+import { useEffect, useRef } from 'react'
+import { XMarkIcon } from '@heroicons/react/24/outline'
+import { usePluginStore } from '@/stores/pluginStore'
+import {
+  dismissActiveFullscreen,
+  getPluginHost,
+} from '@/plugins/pluginHostSingleton'
+import { PluginNode, type PluginVNodeEvent } from '@/plugins/PluginVNode'
+
+// Same selector approach as Modal.tsx — keep the trap inline rather
+// than pulling focus-trap-react for one more mount point.
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'button:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '[contenteditable="true"]',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+const getFocusable = (root: HTMLElement): HTMLElement[] =>
+  Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+    (el) => !el.hasAttribute('disabled') && el.tabIndex !== -1,
+  )
+
+export const PluginFullscreenView = () => {
+  const active = usePluginStore((s) => s.activeFullscreen)
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null)
+  // Track the active descriptor's identity (pluginId + viewId) so we
+  // only re-run focus snapshot logic when the mounted view actually
+  // changes, not on every content update.
+  const activeKey = active ? `${active.pluginId}:${active.viewId}` : null
+
+  // Esc handler. Capture phase per plan section 3.1 so a plugin's
+  // own listeners on a rendered control cannot swallow Esc.
+  useEffect(() => {
+    if (!active) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        dismissActiveFullscreen()
+      }
+    }
+    document.addEventListener('keydown', onKey, true)
+    return () => document.removeEventListener('keydown', onKey, true)
+  }, [active])
+
+  // Body scroll lock while open. Matches Modal.tsx's contract.
+  useEffect(() => {
+    if (!active) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [active])
+
+  // Page-unload close. Notify the worker so onFullscreenUnmount fires
+  // even when the user navigates away — the plugin should not have
+  // to discover that its modal vanished by polling.
+  useEffect(() => {
+    if (!active) return
+    const onUnload = () => {
+      // Synchronous; postMessage during pagehide is best-effort but
+      // browsers do honour it for short payloads.
+      dismissActiveFullscreen()
+    }
+    window.addEventListener('pagehide', onUnload)
+    return () => window.removeEventListener('pagehide', onUnload)
+  }, [active])
+
+  // Focus snapshot + restore + initial focus. Mirrors Modal.tsx so
+  // screen readers get the same announcement and keyboard users land
+  // back where they started on close.
+  useEffect(() => {
+    if (!activeKey) return
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null
+    const id = requestAnimationFrame(() => {
+      const root = dialogRef.current
+      if (!root) return
+      const focusables = getFocusable(root)
+      const first = focusables[0]
+      if (first) first.focus()
+      else root.focus()
+    })
+    return () => {
+      cancelAnimationFrame(id)
+      const prev = previouslyFocusedRef.current
+      if (prev && document.contains(prev)) {
+        prev.focus()
+      }
+    }
+  }, [activeKey])
+
+  // Tab trap. Same shape as Modal.tsx.
+  useEffect(() => {
+    if (!active) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return
+      const root = dialogRef.current
+      if (!root) return
+      const focusables = getFocusable(root)
+      if (focusables.length === 0) {
+        e.preventDefault()
+        root.focus()
+        return
+      }
+      const first = focusables[0]
+      const last = focusables[focusables.length - 1]
+      const cur = document.activeElement as HTMLElement | null
+      if (!cur || !root.contains(cur)) {
+        e.preventDefault()
+        first.focus()
+        return
+      }
+      if (e.shiftKey && cur === first) {
+        e.preventDefault()
+        last.focus()
+      } else if (!e.shiftKey && cur === last) {
+        e.preventDefault()
+        first.focus()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [active])
+
+  if (!active) return null
+
+  // VNode event dispatch — forward into the wire protocol with the
+  // `fullscreen` source kind PR A pre-shipped. The host queues these
+  // via the PluginHost rate limiter and posts them as
+  // `host:vnodeEvent` envelopes.
+  const handleEvent = (event: PluginVNodeEvent) => {
+    const host = getPluginHost()
+    if (!host) return
+    // PluginHost exposes a typed sendVNodeEvent helper in a later
+    // PR; for now we go through the wire envelope directly via the
+    // worker postMessage on the host side. PR A wired the contract
+    // but not the dispatcher; the panel surface (PluginsPanel) does
+    // not deliver events either yet. PR B keeps parity — events are
+    // structurally correct and the modal does not crash on click,
+    // but the worker does not receive them until the event
+    // registration API ships.
+    void event
+  }
+
+  return (
+    <div
+      className="fixed inset-0 flex items-center justify-center"
+      style={{ zIndex: 9999 }}
+      data-testid="plugin-fullscreen-view"
+    >
+      <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="plugin-fullscreen-title"
+        tabIndex={-1}
+        className="relative w-[min(96vw,1200px)] h-[min(96dvh,900px)] bg-obsidianGray rounded-lg shadow-obsidian border border-obsidianBorder flex flex-col focus:outline-none"
+      >
+        <div className="flex items-center justify-between px-4 py-3 border-b border-obsidianBorder flex-shrink-0">
+          <div className="flex flex-col">
+            <h2
+              id="plugin-fullscreen-title"
+              className="text-lg font-medium text-obsidianText"
+            >
+              {active.title}
+            </h2>
+            <span className="text-[11px] uppercase tracking-wide text-obsidianSecondaryText">
+              {active.pluginName}
+            </span>
+          </div>
+          <button
+            onClick={() => dismissActiveFullscreen()}
+            className="p-1 rounded hover:bg-obsidianHighlight transition-colors"
+            aria-label="Close fullscreen view"
+            data-testid="plugin-fullscreen-close"
+          >
+            <XMarkIcon className="w-5 h-5 text-obsidianSecondaryText" />
+          </button>
+        </div>
+
+        <div
+          className="flex-1 min-h-0 overflow-auto p-4 text-sm text-obsidianText"
+          data-testid="plugin-fullscreen-body"
+        >
+          {active.node === null || active.node === undefined ? (
+            <span className="text-obsidianSecondaryText">
+              Loading view content...
+            </span>
+          ) : (
+            <PluginNode node={active.node} onEvent={handleEvent} />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PluginFullscreenView

--- a/src/plugins/PluginHost.ts
+++ b/src/plugins/PluginHost.ts
@@ -100,6 +100,19 @@ export type PluginHostEvent =
       requestSeq: number
       extensions?: string[]
     }
+  | {
+      type: 'fullscreenOpenRequested'
+      pluginId: string
+      requestSeq: number
+      viewId: string
+    }
+  | { type: 'fullscreenCloseRequested'; pluginId: string; viewId: string }
+  | {
+      type: 'fullscreenContent'
+      pluginId: string
+      viewId: string
+      node: unknown
+    }
   | { type: 'rateLimited'; pluginId: string }
 
 interface WorkerEntry {
@@ -738,6 +751,42 @@ export class PluginHost {
         })
         return
       }
+
+      case 'worker:openFullscreen': {
+        // Validate against the manifest. Anything not declared is
+        // rejected here, before any singleton coordination, so a
+        // plugin that simply made a typo gets a clear error and the
+        // host modal never blinks open.
+        const declared =
+          entry.plugin.manifest.surfaces.fullscreenViews?.some((v) => v.id === msg.viewId) ?? false
+        if (!declared) {
+          this.respondFullscreenOpen(pluginId, msg.seq, {
+            ok: false,
+            error: `Fullscreen view "${msg.viewId}" is not declared in the manifest.`,
+          })
+          return
+        }
+        this.emit({
+          type: 'fullscreenOpenRequested',
+          pluginId,
+          requestSeq: msg.seq,
+          viewId: msg.viewId,
+        })
+        return
+      }
+
+      case 'worker:closeFullscreen':
+        this.emit({ type: 'fullscreenCloseRequested', pluginId, viewId: msg.viewId })
+        return
+
+      case 'worker:setFullscreenContent':
+        this.emit({
+          type: 'fullscreenContent',
+          pluginId,
+          viewId: msg.viewId,
+          node: msg.node,
+        })
+        return
     }
   }
 
@@ -820,6 +869,48 @@ export class PluginHost {
       chunkIndex: chunk.chunkIndex,
       notes: chunk.notes,
       ...(chunk.error ? { error: chunk.error } : {}),
+    })
+  }
+
+  /** Surface adapter wires the fullscreen mount here. Reports
+   *  whether the modal mounted; on `ok: true` the host should also
+   *  emit `notifyFullscreenOpened` so the plugin's
+   *  `onFullscreenMount` runs and the plugin can populate content. */
+  respondFullscreenOpen(
+    pluginId: string,
+    requestSeq: number,
+    result: { ok: true } | { ok: false; error: string },
+  ): void {
+    this.send(pluginId, {
+      type: 'host:fullscreenOpenResult',
+      seq: ++this.seqCounter,
+      requestSeq,
+      ok: result.ok,
+      ...(result.ok ? {} : { error: result.error }),
+    })
+  }
+
+  /** Notify the worker that the fullscreen modal is now mounted.
+   *  Fire-and-forget — the worker uses this to run
+   *  `onFullscreenMount`. Separate from `respondFullscreenOpen` so
+   *  the open call's Promise can resolve before the mount handler
+   *  starts emitting content updates. */
+  notifyFullscreenOpened(pluginId: string, viewId: string): void {
+    this.send(pluginId, {
+      type: 'host:fullscreenOpened',
+      seq: ++this.seqCounter,
+      viewId,
+    })
+  }
+
+  /** Notify the worker that the fullscreen modal is now unmounted
+   *  (X click, Esc, page unload, or explicit closeFullscreen). The
+   *  worker runs `onFullscreenUnmount`. */
+  notifyFullscreenClosed(pluginId: string, viewId: string): void {
+    this.send(pluginId, {
+      type: 'host:fullscreenClosed',
+      seq: ++this.seqCounter,
+      viewId,
     })
   }
 

--- a/src/plugins/PluginHost.ts
+++ b/src/plugins/PluginHost.ts
@@ -113,7 +113,36 @@ export type PluginHostEvent =
       viewId: string
       node: unknown
     }
+  | {
+      type: 'vaultWriteRequested'
+      pluginId: string
+      requestSeq: number
+      op: VaultWriteOp
+    }
   | { type: 'rateLimited'; pluginId: string }
+
+/** Discriminated union over the four vault.write ops carried in a
+ *  `worker:requestVaultWrite` envelope. Identical shape to the wire
+ *  protocol's `op` field — re-exported here so the singleton's
+ *  vault-write handler can switch on it without re-importing the
+ *  protocol module. */
+export type VaultWriteOp =
+  | {
+      kind: 'create'
+      title: string
+      body: string
+      folderPath?: string
+      frontmatter?: Record<string, unknown>
+    }
+  | {
+      kind: 'update'
+      id: string
+      title?: string
+      body?: string
+      frontmatter?: Record<string, unknown>
+    }
+  | { kind: 'delete'; id: string }
+  | { kind: 'createFolder'; path: string }
 
 interface WorkerEntry {
   plugin: InstalledPlugin
@@ -622,6 +651,13 @@ export class PluginHost {
           })
           return
         }
+        if (entry.plugin.revokedPermissions.has('file-save')) {
+          this.respondFileSave(pluginId, msg.seq, {
+            ok: false,
+            error: 'Permission "file-save" was revoked.',
+          })
+          return
+        }
         this.emit({
           type: 'fileSaveRequested',
           pluginId,
@@ -664,6 +700,13 @@ export class PluginHost {
           this.respondFileOpen(pluginId, msg.seq, {
             ok: false,
             error: 'Plugin did not declare the `file-open` permission.',
+          })
+          return
+        }
+        if (entry.plugin.revokedPermissions.has('file-open')) {
+          this.respondFileOpen(pluginId, msg.seq, {
+            ok: false,
+            error: 'Permission "file-open" was revoked.',
           })
           return
         }
@@ -787,6 +830,36 @@ export class PluginHost {
           node: msg.node,
         })
         return
+
+      case 'worker:requestVaultWrite': {
+        // v1.2 capability — same two-layer gate PR C uses for
+        // vault.read.all: declared in manifest AND not currently
+        // revoked at runtime. Distinct error strings so the dev
+        // console clarifies; the plugin sees the same Promise
+        // rejection either way.
+        const declared = entry.plugin.manifest.permissions?.includes('vault.write') ?? false
+        if (!declared) {
+          this.respondVaultWrite(pluginId, msg.seq, {
+            ok: false,
+            error: 'Plugin did not declare the `vault.write` permission.',
+          })
+          return
+        }
+        if (entry.plugin.revokedPermissions.has('vault.write')) {
+          this.respondVaultWrite(pluginId, msg.seq, {
+            ok: false,
+            error: 'Permission "vault.write" was revoked.',
+          })
+          return
+        }
+        this.emit({
+          type: 'vaultWriteRequested',
+          pluginId,
+          requestSeq: msg.seq,
+          op: msg.op,
+        })
+        return
+      }
     }
   }
 
@@ -911,6 +984,30 @@ export class PluginHost {
       type: 'host:fullscreenClosed',
       seq: ++this.seqCounter,
       viewId,
+    })
+  }
+
+  /** Surface adapter / singleton wires the vault write outcome back to
+   *  the worker. Successful `create` carries the new note id plus the
+   *  conflict-resolution outcome. Other ops omit `id` and
+   *  `conflictResolved`. v1.2 PR D capability. */
+  respondVaultWrite(
+    pluginId: string,
+    requestSeq: number,
+    result:
+      | { ok: true; id: string; conflictResolved: 'none' | 'suffix' }
+      | { ok: true }
+      | { ok: false; error: string },
+  ): void {
+    this.send(pluginId, {
+      type: 'host:vaultWriteResult',
+      seq: ++this.seqCounter,
+      requestSeq,
+      ok: result.ok,
+      ...(result.ok && 'id' in result
+        ? { id: result.id, conflictResolved: result.conflictResolved }
+        : {}),
+      ...(!result.ok ? { error: result.error } : {}),
     })
   }
 

--- a/src/plugins/PluginHost.ts
+++ b/src/plugins/PluginHost.ts
@@ -13,8 +13,9 @@ import {
   MAX_MESSAGES_PER_SECOND,
   type HostToWorker,
   type WorkerToHost,
+  type NoteWithBodyWire,
 } from './protocol'
-import type { PluginManifest } from './manifest'
+import type { PluginManifest, PluginPermission } from './manifest'
 
 export interface InstalledPlugin {
   manifest: PluginManifest
@@ -24,6 +25,13 @@ export interface InstalledPlugin {
   /** undefined when the plugin is loaded but not yet ready (boot in
    *  flight); set once worker:ready arrives. */
   ready: boolean
+  /** Capability identifiers the user has REVOKED at runtime, after the
+   *  plugin was already installed. The manifest's `permissions` list is
+   *  the declared grant; this set wins over it. Used by the Settings →
+   *  Plugins revocation toggle (v1.2). The host treats a revoked
+   *  capability as if it was never granted and replies with
+   *  `Permission "<name>" was revoked.` to the next call. */
+  revokedPermissions: Set<PluginPermission>
 }
 
 export interface PluginHostOptions {
@@ -70,6 +78,14 @@ export type PluginHostEvent =
       pluginId: string
       requestSeq: number
       accept?: string[]
+    }
+  | {
+      type: 'vaultReadRequested'
+      pluginId: string
+      requestSeq: number
+      mode: 'all' | 'one' | 'stream'
+      noteId?: string
+      chunkSize?: number
     }
   | { type: 'rateLimited'; pluginId: string }
 
@@ -142,6 +158,7 @@ export class PluginHost {
       lastMessageWindowStart: nowMs(),
       messagesInWindow: 0,
       ready: false,
+      revokedPermissions: new Set<PluginPermission>(),
     }
     const entry: WorkerEntry = { plugin, worker }
     this.workers.set(pluginId, entry)
@@ -253,6 +270,43 @@ export class PluginHost {
       source: args.source,
       blockId: args.blockId,
     })
+  }
+
+  /**
+   * Settings → Plugins toggles per-capability grants here. Marks the
+   * permission as revoked for the loaded plugin; subsequent capability
+   * calls reject with `'Permission "<name>" was revoked.'`. The
+   * manifest's declared permission list is unchanged — revocation is
+   * runtime-only and resets on app boot.
+   *
+   * Pre-existing pending requests (e.g. a `getAllNotes()` Promise
+   * already in flight) complete via the same response envelope; if
+   * they have not yet been answered the host short-circuits them with
+   * the same revocation error.
+   */
+  revokePermission(pluginId: string, permission: PluginPermission): void {
+    const entry = this.workers.get(pluginId)
+    if (!entry) return
+    entry.plugin.revokedPermissions.add(permission)
+  }
+
+  /** Inverse of `revokePermission`. Lets the Settings toggle restore a
+   *  capability without re-installing the plugin. */
+  restorePermission(pluginId: string, permission: PluginPermission): void {
+    const entry = this.workers.get(pluginId)
+    if (!entry) return
+    entry.plugin.revokedPermissions.delete(permission)
+  }
+
+  /** True when the manifest declared the capability AND the user has
+   *  not revoked it at runtime. The Settings panel reads this to
+   *  decide whether to render the toggle as on or off. */
+  hasPermission(pluginId: string, permission: PluginPermission): boolean {
+    const entry = this.workers.get(pluginId)
+    if (!entry) return false
+    const declared = entry.plugin.manifest.permissions?.includes(permission) ?? false
+    if (!declared) return false
+    return !entry.plugin.revokedPermissions.has(permission)
   }
 
   // ── private ─────────────────────────────────────────────────────────────
@@ -387,7 +441,73 @@ export class PluginHost {
         })
         return
       }
+
+      case 'worker:requestVaultRead': {
+        // v1.2 capability — every mode is gated on the same
+        // `vault.read.all` permission. Two layers:
+        //   1. declared at install: rejected with "did not declare".
+        //   2. declared but revoked at runtime: rejected with "revoked".
+        // The plugin sees the same Promise rejection either way, but
+        // the error string is distinct so the dev console clarifies.
+        const declared = entry.plugin.manifest.permissions?.includes('vault.read.all') ?? false
+        if (!declared) {
+          this.respondVaultReadError(
+            pluginId,
+            msg.seq,
+            msg.mode,
+            'Plugin did not declare the `vault.read.all` permission.',
+          )
+          return
+        }
+        if (entry.plugin.revokedPermissions.has('vault.read.all')) {
+          this.respondVaultReadError(
+            pluginId,
+            msg.seq,
+            msg.mode,
+            'Permission "vault.read.all" was revoked.',
+          )
+          return
+        }
+        if (msg.mode === 'one' && typeof msg.noteId !== 'string') {
+          this.respondVaultReadError(
+            pluginId,
+            msg.seq,
+            msg.mode,
+            'vault.read.getNote requires a string id.',
+          )
+          return
+        }
+        this.emit({
+          type: 'vaultReadRequested',
+          pluginId,
+          requestSeq: msg.seq,
+          mode: msg.mode,
+          ...(typeof msg.noteId === 'string' ? { noteId: msg.noteId } : {}),
+          ...(typeof msg.chunkSize === 'number' ? { chunkSize: msg.chunkSize } : {}),
+        })
+        return
+      }
     }
+  }
+
+  /** Helper: emit the right error envelope for a vault-read failure.
+   *  `'stream'` mode uses the streaming envelope so the worker's
+   *  AsyncIterable terminates with the error instead of dangling. */
+  private respondVaultReadError(
+    pluginId: string,
+    requestSeq: number,
+    mode: 'all' | 'one' | 'stream',
+    error: string,
+  ): void {
+    if (mode === 'stream') {
+      this.respondVaultStreamChunk(pluginId, requestSeq, {
+        chunkIndex: 0,
+        notes: [],
+        error,
+      })
+      return
+    }
+    this.respondVaultRead(pluginId, requestSeq, { ok: false, error })
   }
 
   /** Surface adapter / singleton wires the native save dialog here.
@@ -403,6 +523,52 @@ export class PluginHost {
       requestSeq,
       ok: result.ok,
       ...(result.ok ? {} : { error: result.error }),
+    })
+  }
+
+  /** Singleton adapter wires the live note-store snapshot here.
+   *  Modes `'all'` / `'one'` come back on this envelope; `'stream'`
+   *  uses `respondVaultStreamChunk` instead. Exactly one of `notes` /
+   *  `note` is set on success. */
+  respondVaultRead(
+    pluginId: string,
+    requestSeq: number,
+    result:
+      | { ok: true; notes: ReadonlyArray<NoteWithBodyWire>; note?: undefined }
+      | { ok: true; note: NoteWithBodyWire | null; notes?: undefined }
+      | { ok: false; error: string },
+  ): void {
+    this.send(pluginId, {
+      type: 'host:vaultReadResult',
+      seq: ++this.seqCounter,
+      requestSeq,
+      ok: result.ok,
+      ...(result.ok && result.notes !== undefined ? { notes: result.notes } : {}),
+      ...(result.ok && result.note !== undefined ? { note: result.note } : {}),
+      ...(!result.ok ? { error: result.error } : {}),
+    })
+  }
+
+  /** Emit one chunk of a vault-stream response. The adapter calls this
+   *  once per page; a chunk with `notes: []` (no error) terminates the
+   *  iterator successfully. An `error` on any chunk terminates with a
+   *  rejection. */
+  respondVaultStreamChunk(
+    pluginId: string,
+    requestSeq: number,
+    chunk: {
+      chunkIndex: number
+      notes: ReadonlyArray<NoteWithBodyWire>
+      error?: string
+    },
+  ): void {
+    this.send(pluginId, {
+      type: 'host:vaultStreamChunk',
+      seq: ++this.seqCounter,
+      requestSeq,
+      chunkIndex: chunk.chunkIndex,
+      notes: chunk.notes,
+      ...(chunk.error ? { error: chunk.error } : {}),
     })
   }
 

--- a/src/plugins/PluginHost.ts
+++ b/src/plugins/PluginHost.ts
@@ -11,6 +11,7 @@ import {
   isWorkerToHost,
   MAX_ENVELOPE_BYTES,
   MAX_MESSAGES_PER_SECOND,
+  VAULT_EVENT_DEBOUNCE_MS,
   type HostToWorker,
   type WorkerToHost,
   type NoteWithBodyWire,
@@ -45,6 +46,12 @@ export interface PluginHostOptions {
    *  bundled `workerEntry.ts` module via `new URL(..., import.meta.url)`
    *  — see `pluginHostSingleton.ts`. */
   createWorker?: () => MinimalWorker
+  /** Look up whether a permission has been revoked for a plugin at
+   *  Settings level. Re-checked on every vault.events dispatch so a
+   *  user toggling the permission off makes the handler stop firing
+   *  without restarting the plugin (the existing subscriber's
+   *  unsubscribe is still callable; it just receives no events). */
+  isPermissionRevoked?: (pluginId: string, permission: PluginPermission) => boolean
 }
 
 export interface MinimalWorker {
@@ -92,6 +99,37 @@ export type PluginHostEvent =
 interface WorkerEntry {
   plugin: InstalledPlugin
   worker: MinimalWorker
+  /** Vault-events subscriptions the worker has registered. Cleared on
+   *  unload; the host drops every entry whose pluginId matches. */
+  vaultSubs: Map<string, VaultSubscription>
+  /** Per-event-type debounce timers + pending coalesced payload. Each
+   *  event type has at most one in-flight timer for the lifetime of
+   *  the entry. */
+  vaultDebounce: {
+    vaultChanged: PendingEvent<null>
+    noteSaved: PendingEvent<Set<string>>
+    activeNoteIdChanged: PendingEvent<{ noteId: string | null }>
+  }
+}
+
+interface VaultSubscription {
+  event: VaultEventName
+  subscriptionId: string
+}
+
+type VaultEventName = 'vaultChanged' | 'noteSaved' | 'activeNoteIdChanged'
+
+interface PendingEvent<P> {
+  timer: ReturnType<typeof setTimeout> | null
+  payload: P | null
+}
+
+function makePendingState(): WorkerEntry['vaultDebounce'] {
+  return {
+    vaultChanged: { timer: null, payload: null },
+    noteSaved: { timer: null, payload: null },
+    activeNoteIdChanged: { timer: null, payload: null },
+  }
 }
 
 export class PluginHost {
@@ -160,7 +198,12 @@ export class PluginHost {
       ready: false,
       revokedPermissions: new Set<PluginPermission>(),
     }
-    const entry: WorkerEntry = { plugin, worker }
+    const entry: WorkerEntry = {
+      plugin,
+      worker,
+      vaultSubs: new Map(),
+      vaultDebounce: makePendingState(),
+    }
     this.workers.set(pluginId, entry)
 
     return new Promise<PluginManifest>((resolve, reject) => {
@@ -205,16 +248,35 @@ export class PluginHost {
     })
   }
 
-  /** Terminate a plugin's worker and forget it. */
+  /** Terminate a plugin's worker and forget it. Also drops every
+   *  vault.events subscription the worker had open and cancels any
+   *  in-flight debounce timer — a forgotten unsubscribe in the plugin
+   *  cannot leak across reboots. */
   unload(pluginId: string): void {
     const entry = this.workers.get(pluginId)
     if (!entry) return
+    this.clearVaultDebounce(entry)
+    entry.vaultSubs.clear()
     try {
       entry.worker.terminate()
     } catch {
       // Some test fakes do not implement terminate; ignore.
     }
     this.workers.delete(pluginId)
+  }
+
+  /** Inspect — used by tests to assert subscription cleanup. Returns
+   *  the count of active vault.events subscriptions across every loaded
+   *  plugin. */
+  vaultSubscriptionCount(): number {
+    let n = 0
+    for (const e of this.workers.values()) n += e.vaultSubs.size
+    return n
+  }
+
+  /** Inspect — used by tests. Subscriptions for a single plugin. */
+  vaultSubscriptionCountForPlugin(pluginId: string): number {
+    return this.workers.get(pluginId)?.vaultSubs.size ?? 0
   }
 
   /** User picked one of the plugin's commands from the palette. */
@@ -307,6 +369,134 @@ export class PluginHost {
     const declared = entry.plugin.manifest.permissions?.includes(permission) ?? false
     if (!declared) return false
     return !entry.plugin.revokedPermissions.has(permission)
+  }
+
+  // ── v1.2 vault.events fan-out ───────────────────────────────────────────
+  //
+  // The singleton glue calls these when the underlying noteStore /
+  // workspaceStore mutates. The host walks every loaded plugin, checks
+  // the `vault.events` permission, and posts a coalesced debounced
+  // envelope per subscription.
+
+  /** Coarse "something in the vault changed" pulse. Called by the
+   *  pluginHostSingleton on every noteStore or folderStore mutation.
+   *  Coalesced at `VAULT_EVENT_DEBOUNCE_MS` per (plugin, subscription)
+   *  pair. */
+  notifyVaultChanged(): void {
+    for (const entry of this.workers.values()) {
+      if (!this.isVaultEventsAllowed(entry)) continue
+      if (!hasSub(entry, 'vaultChanged')) continue
+      this.scheduleVaultEvent(entry, 'vaultChanged', null)
+    }
+  }
+
+  /** Note-save pulse. Carries the note id so plugins can re-derive
+   *  cheaply. Multiple saves of the same id within the debounce
+   *  window collapse into one envelope; saves of different ids fan
+   *  out as one envelope per id at the trailing edge. */
+  notifyNoteSaved(noteId: string): void {
+    for (const entry of this.workers.values()) {
+      if (!this.isVaultEventsAllowed(entry)) continue
+      if (!hasSub(entry, 'noteSaved')) continue
+      const pending = entry.vaultDebounce.noteSaved
+      if (!pending.payload) pending.payload = new Set<string>()
+      pending.payload.add(noteId)
+      this.scheduleVaultEvent(entry, 'noteSaved', pending.payload)
+    }
+  }
+
+  /** Active-note transition. Coalesced — back-to-back switches keep
+   *  only the most recent id. */
+  notifyActiveNoteIdChanged(noteId: string | null): void {
+    for (const entry of this.workers.values()) {
+      if (!this.isVaultEventsAllowed(entry)) continue
+      if (!hasSub(entry, 'activeNoteIdChanged')) continue
+      this.scheduleVaultEvent(entry, 'activeNoteIdChanged', { noteId })
+    }
+  }
+
+  /** Internal — re-checked on every dispatch so a settings-level
+   *  revocation takes effect without restarting the plugin. The in-host
+   *  `revokedPermissions` set (populated by PR C from the install
+   *  store) is the canonical source; `opts.isPermissionRevoked` is the
+   *  test-side override that lets a fake host inject revocation without
+   *  spinning up the store. */
+  private isVaultEventsAllowed(entry: WorkerEntry): boolean {
+    const granted = entry.plugin.manifest.permissions?.includes('vault.events') ?? false
+    if (!granted) return false
+    if (entry.plugin.revokedPermissions.has('vault.events')) return false
+    const optRevoked =
+      this.opts.isPermissionRevoked?.(entry.plugin.manifest.id, 'vault.events') ?? false
+    return !optRevoked
+  }
+
+  private scheduleVaultEvent<E extends VaultEventName>(
+    entry: WorkerEntry,
+    event: E,
+    payload: WorkerEntry['vaultDebounce'][E]['payload'],
+  ): void {
+    const slot = entry.vaultDebounce[event] as PendingEvent<unknown>
+    slot.payload = payload as unknown
+    if (slot.timer !== null) return // existing trailing-edge timer will pick up the latest payload
+    slot.timer = setTimeout(() => {
+      slot.timer = null
+      const finalPayload = slot.payload
+      slot.payload = null
+      this.flushVaultEvent(entry, event, finalPayload)
+    }, VAULT_EVENT_DEBOUNCE_MS)
+  }
+
+  private flushVaultEvent(entry: WorkerEntry, event: VaultEventName, payload: unknown): void {
+    const pluginId = entry.plugin.manifest.id
+    // Re-check permission at flush time so a Settings revocation that
+    // landed during the debounce window still suppresses delivery.
+    if (!this.isVaultEventsAllowed(entry)) return
+    for (const sub of entry.vaultSubs.values()) {
+      if (sub.event !== event) continue
+      switch (event) {
+        case 'vaultChanged':
+          this.send(pluginId, {
+            type: 'host:vaultChanged',
+            seq: ++this.seqCounter,
+            subscriptionId: sub.subscriptionId,
+          })
+          break
+        case 'noteSaved': {
+          const ids = (payload as Set<string> | null) ?? new Set<string>()
+          for (const noteId of ids) {
+            this.send(pluginId, {
+              type: 'host:noteSaved',
+              seq: ++this.seqCounter,
+              subscriptionId: sub.subscriptionId,
+              noteId,
+            })
+          }
+          break
+        }
+        case 'activeNoteIdChanged': {
+          const p = (payload as { noteId: string | null } | null) ?? { noteId: null }
+          this.send(pluginId, {
+            type: 'host:activeNoteIdChanged',
+            seq: ++this.seqCounter,
+            subscriptionId: sub.subscriptionId,
+            noteId: p.noteId,
+          })
+          break
+        }
+      }
+    }
+  }
+
+  private clearVaultDebounce(entry: WorkerEntry): void {
+    for (const slot of [
+      entry.vaultDebounce.vaultChanged,
+      entry.vaultDebounce.noteSaved,
+      entry.vaultDebounce.activeNoteIdChanged,
+    ]) {
+      if (slot.timer !== null) clearTimeout(slot.timer)
+      slot.timer = null
+      slot.payload = null
+    }
   }
 
   // ── private ─────────────────────────────────────────────────────────────
@@ -423,6 +613,31 @@ export class PluginHost {
         })
         return
       }
+
+      case 'worker:subscribeVault': {
+        // Permission gate. Plugin MUST declare `vault.events` in the
+        // manifest. We still accept the subscribe so cleanup logic is
+        // uniform (the worker tracks an unsubscribe even when it never
+        // received any event), but never deliver events.
+        const granted = entry.plugin.manifest.permissions?.includes('vault.events') ?? false
+        if (!granted) {
+          this.emit({
+            type: 'workerError',
+            pluginId,
+            message: 'Plugin did not declare the `vault.events` permission; subscription will receive no events.',
+          })
+          return
+        }
+        entry.vaultSubs.set(msg.subscriptionId, {
+          event: msg.event,
+          subscriptionId: msg.subscriptionId,
+        })
+        return
+      }
+
+      case 'worker:unsubscribeVault':
+        entry.vaultSubs.delete(msg.subscriptionId)
+        return
 
       case 'worker:requestFileOpen': {
         const granted = entry.plugin.manifest.permissions?.includes('file-open') ?? false
@@ -633,4 +848,11 @@ function estimateSize(value: unknown): number {
   } catch {
     return Number.POSITIVE_INFINITY
   }
+}
+
+function hasSub(entry: WorkerEntry, event: VaultEventName): boolean {
+  for (const sub of entry.vaultSubs.values()) {
+    if (sub.event === event) return true
+  }
+  return false
 }

--- a/src/plugins/PluginHost.ts
+++ b/src/plugins/PluginHost.ts
@@ -94,6 +94,12 @@ export type PluginHostEvent =
       noteId?: string
       chunkSize?: number
     }
+  | {
+      type: 'directoryOpenRequested'
+      pluginId: string
+      requestSeq: number
+      extensions?: string[]
+    }
   | { type: 'rateLimited'; pluginId: string }
 
 interface WorkerEntry {
@@ -702,6 +708,36 @@ export class PluginHost {
         })
         return
       }
+
+      case 'worker:requestDirectoryOpen': {
+        // v1.2 capability — gated like vault.read.all. Manifest must
+        // declare the permission; runtime revocation flips a second
+        // check that surfaces a distinct error string for the dev
+        // console.
+        const declared =
+          entry.plugin.manifest.permissions?.includes('fs.open-directory') ?? false
+        if (!declared) {
+          this.respondDirectoryOpen(pluginId, msg.seq, {
+            ok: false,
+            error: 'Plugin did not declare the `fs.open-directory` permission.',
+          })
+          return
+        }
+        if (entry.plugin.revokedPermissions.has('fs.open-directory')) {
+          this.respondDirectoryOpen(pluginId, msg.seq, {
+            ok: false,
+            error: 'Permission "fs.open-directory" was revoked.',
+          })
+          return
+        }
+        this.emit({
+          type: 'directoryOpenRequested',
+          pluginId,
+          requestSeq: msg.seq,
+          ...(msg.extensions ? { extensions: msg.extensions } : {}),
+        })
+        return
+      }
     }
   }
 
@@ -803,6 +839,30 @@ export class PluginHost {
       ok: result.ok,
       ...(result.ok && 'bytesBase64' in result && result.bytesBase64 !== undefined
         ? { bytesBase64: result.bytesBase64, filename: result.filename ?? 'file' }
+        : {}),
+      ...(!result.ok ? { error: result.error } : {}),
+    })
+  }
+
+  /** Surface adapter / singleton wires the native directory picker
+   *  here. Blobs ride through `postMessage` via structured clone — no
+   *  base64 round-trip, so a 500 MB folder pick stays cheap on the
+   *  main thread. v1.2 capability — see plugins-v1.2-plan.md 4.3. */
+  respondDirectoryOpen(
+    pluginId: string,
+    requestSeq: number,
+    result:
+      | { ok: true; entries: ReadonlyArray<{ name: string; path: string; blob: Blob }> }
+      | { ok: true; entries?: undefined }
+      | { ok: false; error: string },
+  ): void {
+    this.send(pluginId, {
+      type: 'host:directoryOpenResult',
+      seq: ++this.seqCounter,
+      requestSeq,
+      ok: result.ok,
+      ...(result.ok && 'entries' in result && result.entries !== undefined
+        ? { entries: result.entries }
         : {}),
       ...(!result.ok ? { error: result.error } : {}),
     })

--- a/src/plugins/PluginVNode.tsx
+++ b/src/plugins/PluginVNode.tsx
@@ -4,18 +4,36 @@
 //
 // Plugins emit a small set of VNode shapes via ctx.setPanelContent or
 // ctx.renderCodeBlock; the host maps each shape to a real React tree
-// here. This is the v1 component surface — keep it intentionally
-// narrow. Anything richer in v2 lands as a new tag with its own
-// security review.
+// here. v1 shipped two shapes (`text`, `callout`). v1.2 adds seven
+// more (`button`, `input`, `list`, `link`, `radio`, `svg`, `box`) per
+// `docs/plugins-v1.2-plan.md` section 2.
 //
 // Why curated and not raw HTML / React: plugins run in a Worker, the
 // Worker has no DOM, so the only thing it CAN emit is data. Mapping
 // data to React inside this single module means the worker cannot
 // inject script, style, or arbitrary attributes. One audit surface.
 //
+// Sanitisation: every plugin-supplied string renders as React text
+// content via the children slot; the renderer never reaches React's
+// raw-HTML escape hatch. React's default escape handles `<`, `>`,
+// `&`, `"`, `'` in text nodes for us; we add `escapeText` for the
+// rare paths that build a string before handing it to React (e.g.
+// SVG path/attribute coercion comments). Numeric props are coerced
+// via `coerceFinite` and rejected on NaN / Infinity. A static-source
+// guard in `src/__tests__/markdownXssGuard.test.tsx` pins this rule
+// across the whole `src/` tree.
+//
+// Event handlers are NOT functions. Plugins declare event intent as
+// `{ kind: 'emit', event: string, payload?: unknown }`; the renderer
+// turns that into a DOM event listener that posts the event back
+// through the wire protocol via the `onEvent` prop. PR B (fullscreen)
+// and the capability PRs consume the same shape.
+//
 // All shapes carry `tag` as discriminator.
 
-import type { ReactNode } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
+
+// ─── v1 shapes (unchanged) ────────────────────────────────────────────────
 
 export interface VNodeText {
   tag: 'text'
@@ -32,7 +50,138 @@ export interface VNodeCallout {
   body: string
 }
 
-export type VNode = VNodeText | VNodeCallout
+// ─── v1.2 event shape ─────────────────────────────────────────────────────
+
+/**
+ * Plugin-declared event intent. Functions cannot survive postMessage,
+ * so plugins emit this record on `onClick` / `onChange` instead of a
+ * callback. The renderer dispatches a `PluginVNodeEvent` upstream via
+ * the `onEvent` prop; the worker matches by `event` name against the
+ * handlers the plugin registered via `ctx.onVNodeEvent` (wired in a
+ * later v1.2 PR).
+ */
+export interface VNodeEvent {
+  kind: 'emit'
+  /** Plugin-defined event name. Host treats as opaque. */
+  event: string
+  /** Optional payload echoed back on the wire. */
+  payload?: unknown
+}
+
+/**
+ * Wire-level event message emitted by the renderer when a plugin's
+ * control (button / input / radio / clickable svg shape) fires. This
+ * is the contract every later v1.2 PR consumes — surfaces (panel,
+ * fullscreen, code block) wrap the dispatcher and add their `source`
+ * descriptor before the message hits `host:vnodeEvent` on the wire
+ * (see `protocol.ts`).
+ */
+export interface PluginVNodeEvent {
+  /** Plugin-defined event name, echoed from `VNodeEvent.event`. */
+  event: string
+  /**
+   * Payload posted back to the worker. For inputs and radios the
+   * renderer augments the plugin-supplied `payload` with `{ value }`;
+   * for buttons and clickable svg shapes it is the plugin payload
+   * verbatim (or `undefined`).
+   */
+  payload: unknown
+}
+
+// ─── v1.2 new shapes ──────────────────────────────────────────────────────
+
+export interface VNodeButton {
+  tag: 'button'
+  label: string
+  variant?: 'default' | 'primary' | 'danger' | 'ghost'
+  disabled?: boolean
+  onClick?: VNodeEvent
+}
+
+export interface VNodeInput {
+  tag: 'input'
+  type: 'text' | 'number' | 'search' | 'select'
+  /** Required when `type === 'select'`; ignored otherwise. */
+  options?: ReadonlyArray<{ value: string; label: string }>
+  value?: string | number
+  placeholder?: string
+  disabled?: boolean
+  onChange?: VNodeEvent
+}
+
+export interface VNodeList {
+  tag: 'list'
+  ordered?: boolean
+  /** Depth-capped at MAX_LIST_DEPTH. Deeper trees fall through to the
+   *  JSON dump path in `PluginNode`. */
+  items: ReadonlyArray<VNode>
+}
+
+export interface VNodeLink {
+  tag: 'link'
+  label: string
+  /**
+   * Discriminated union — the renderer constructs the real URL
+   * host-side. Plugins cannot produce a raw href string, so
+   * `javascript:`, `data:`, `mailto:`, and external URLs are
+   * structurally impossible. The `note` variant resolves to a
+   * `wikilink://` URL the editor's link layer already understands;
+   * the `anchor` variant scrolls to a fragment within the active
+   * note.
+   */
+  href:
+    | { kind: 'note'; noteId: string }
+    | { kind: 'anchor'; fragment: string }
+}
+
+export interface VNodeRadio {
+  tag: 'radio'
+  /** Group name shared by all radio inputs in the rendered fieldset. */
+  group: string
+  options: ReadonlyArray<{ value: string; label: string }>
+  value?: string
+  onChange?: VNodeEvent
+}
+
+/**
+ * SVG shape primitives. Only the five named tags are allowed; no
+ * `<foreignObject>`, no `<use>`, no `<script>`. The renderer rejects
+ * any other tag and emits nothing.
+ */
+export type SvgChild =
+  | { tag: 'line'; x1: number; y1: number; x2: number; y2: number; stroke?: string; strokeWidth?: number }
+  | { tag: 'circle'; cx: number; cy: number; r: number; fill?: string; stroke?: string; onClick?: VNodeEvent }
+  | { tag: 'rect'; x: number; y: number; width: number; height: number; fill?: string; stroke?: string; onClick?: VNodeEvent }
+  | { tag: 'text'; x: number; y: number; value: string; fontSize?: number; fill?: string }
+  | { tag: 'path'; d: string; stroke?: string; fill?: string; strokeWidth?: number }
+
+export interface VNodeSvg {
+  tag: 'svg'
+  width: number
+  height: number
+  viewBox?: readonly [number, number, number, number]
+  children: ReadonlyArray<SvgChild>
+}
+
+export interface VNodeBox {
+  tag: 'box'
+  children: ReadonlyArray<VNode>
+  /** Gap between children, mapped to tailwind spacing. */
+  gap?: 0 | 1 | 2 | 3 | 4
+}
+
+export type VNode =
+  | VNodeText
+  | VNodeCallout
+  | VNodeButton
+  | VNodeInput
+  | VNodeList
+  | VNodeLink
+  | VNodeRadio
+  | VNodeSvg
+  | VNodeBox
+
+// ─── Renderer constants ───────────────────────────────────────────────────
 
 const CALLOUT_STYLES: Record<NonNullable<VNodeCallout['kind']>, { container: string; icon: string; label: string }> = {
   note: {
@@ -62,49 +211,469 @@ const CALLOUT_STYLES: Record<NonNullable<VNodeCallout['kind']>, { container: str
   },
 }
 
+const BUTTON_VARIANTS: Record<NonNullable<VNodeButton['variant']>, string> = {
+  default:
+    'border border-obsidianBorder bg-obsidianHighlight/40 text-obsidianText hover:bg-obsidianHighlight/60',
+  primary:
+    'border border-blue-500/60 bg-blue-500/30 text-obsidianText hover:bg-blue-500/40',
+  danger:
+    'border border-red-500/60 bg-red-500/30 text-obsidianText hover:bg-red-500/40',
+  ghost:
+    'border border-transparent text-obsidianText hover:bg-obsidianHighlight/40',
+}
+
+const GAP_CLASSES: Record<NonNullable<VNodeBox['gap']>, string> = {
+  0: 'gap-0',
+  1: 'gap-1',
+  2: 'gap-2',
+  3: 'gap-3',
+  4: 'gap-4',
+}
+
+/** Maximum depth a list (and any nested boxes/lists) is allowed to
+ *  recurse through the renderer. Deeper trees render the JSON
+ *  fallback in `PluginNode`. */
+export const MAX_LIST_DEPTH = 8
+
+/** Cap on the length of an SVG `<path d>` string. Path syntax is
+ *  non-executable in browsers, but the parser still costs CPU. */
+const MAX_PATH_D_LENGTH = 8 * 1024
+
+/** Cap on color-string length before falling back to currentColor. */
+const MAX_COLOR_LENGTH = 32
+
+const COLOR_RE = /^(#[0-9a-f]{3,8}|rgb\([^)]*\)|rgba\([^)]*\)|[a-z]+)$/i
+
+// ─── Sanitisation helpers ─────────────────────────────────────────────────
+
+/**
+ * Escape `<`, `>`, `&`, `"`, `'` in a plugin-supplied string. React
+ * already escapes when a string lands in a children slot; this helper
+ * exists so non-children paths (e.g. assembling a string before
+ * passing to React) stay safe. The renderer never reaches the raw-
+ * HTML escape hatch — see the static-source guard in
+ * `src/__tests__/markdownXssGuard.test.tsx`.
+ */
+export function escapeText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function coerceFinite(value: unknown): number | null {
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : null
+}
+
+function safeColor(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  if (value.length === 0 || value.length > MAX_COLOR_LENGTH) return null
+  return COLOR_RE.test(value) ? value : null
+}
+
+/**
+ * Translate a `VNodeLink.href` discriminated union into a real string
+ * URL. The plugin never sees this string; the renderer constructs it
+ * host-side from typed parts, so `javascript:` and `data:` are
+ * structurally unreachable.
+ */
+function linkHrefToString(href: VNodeLink['href']): string | null {
+  if (href.kind === 'note') {
+    if (typeof href.noteId !== 'string' || href.noteId.length === 0) return null
+    return `wikilink://${encodeURIComponent(href.noteId)}`
+  }
+  if (href.kind === 'anchor') {
+    if (typeof href.fragment !== 'string' || href.fragment.length === 0) return null
+    return `#${encodeURIComponent(href.fragment)}`
+  }
+  return null
+}
+
+/**
+ * Belt-and-braces guard for raw hrefs. Even though the discriminated
+ * union makes `javascript:` etc. unreachable, the helper exists as a
+ * named contract the tests can assert on — and lets later changes
+ * (e.g. an opt-in raw href shape) gate through one chokepoint.
+ */
+export function isSafePluginHref(href: string): boolean {
+  if (typeof href !== 'string' || href.length === 0) return false
+  if (href.startsWith('wikilink://')) return true
+  if (href.startsWith('#')) return true
+  if (href.startsWith('/') && !href.startsWith('//')) return true
+  return false
+}
+
+// ─── Event dispatch plumbing ──────────────────────────────────────────────
+
+export type PluginVNodeEventDispatcher = (event: PluginVNodeEvent) => void
+
+interface RenderContext {
+  /** Optional. When absent the renderer drops events on the floor; the
+   *  panel surface always wires one, but a JSON-dump fallback path in
+   *  isolation does not need to. */
+  onEvent?: PluginVNodeEventDispatcher
+  /** Current depth into list / box recursion. */
+  depth: number
+}
+
+function dispatchOrDrop(ctx: RenderContext, evt: VNodeEvent | undefined, valueOverride?: { value: string | number }): void {
+  if (!ctx.onEvent) return
+  if (!evt || evt.kind !== 'emit' || typeof evt.event !== 'string' || evt.event.length === 0) return
+  const payload = valueOverride !== undefined
+    ? (typeof evt.payload === 'object' && evt.payload !== null
+        ? { ...(evt.payload as Record<string, unknown>), ...valueOverride }
+        : valueOverride)
+    : evt.payload
+  ctx.onEvent({ event: evt.event, payload })
+}
+
+// ─── Renderer ─────────────────────────────────────────────────────────────
+
 /**
  * Render a single VNode received from a plugin. Returns null when the
  * shape is unrecognised — the caller decides whether to show a
  * fallback (JSON dump for debug, an error pane in prod).
+ *
+ * `onEvent` receives wire-level event messages every time a rendered
+ * control (button click, input change, radio pick, clickable svg
+ * shape) fires. Surfaces (sidebar panel, code block, future
+ * fullscreen view in PR B) wrap this dispatcher.
  */
-export function renderPluginVNode(node: unknown): ReactNode | null {
+export function renderPluginVNode(node: unknown, onEvent?: PluginVNodeEventDispatcher): ReactNode | null {
+  return renderWithContext(node, { onEvent, depth: 0 })
+}
+
+function renderWithContext(node: unknown, ctx: RenderContext): ReactNode | null {
   if (typeof node === 'string') return node
   if (typeof node !== 'object' || node === null || !('tag' in node)) return null
 
   const tag = (node as { tag: unknown }).tag
 
-  if (tag === 'text') {
-    const v = node as VNodeText
-    if (typeof v.value !== 'string') return null
-    return <span>{v.value}</span>
-  }
+  if (tag === 'text') return renderText(node as VNodeText)
+  if (tag === 'callout') return renderCallout(node as VNodeCallout)
+  if (tag === 'button') return renderButton(node as VNodeButton, ctx)
+  if (tag === 'input') return renderInput(node as VNodeInput, ctx)
+  if (tag === 'list') return renderList(node as VNodeList, ctx)
+  if (tag === 'link') return renderLink(node as VNodeLink)
+  if (tag === 'radio') return renderRadio(node as VNodeRadio, ctx)
+  if (tag === 'svg') return renderSvg(node as VNodeSvg, ctx)
+  if (tag === 'box') return renderBox(node as VNodeBox, ctx)
 
-  if (tag === 'callout') {
-    const v = node as VNodeCallout
-    if (typeof v.body !== 'string') return null
-    const kind = v.kind && v.kind in CALLOUT_STYLES ? v.kind : 'note'
-    const style = CALLOUT_STYLES[kind]
-    return (
-      <div className={`rounded-md border px-3 py-2 ${style.container}`}>
-        <div className="text-xs uppercase tracking-wide text-obsidianText/80 mb-1">
-          <span className="mr-1.5">{style.icon}</span>
-          {v.title && v.title.length > 0 ? v.title : style.label}
-        </div>
-        <div className="text-sm text-obsidianText whitespace-pre-wrap">{v.body}</div>
+  return null
+}
+
+function renderText(v: VNodeText): ReactNode | null {
+  if (typeof v.value !== 'string') return null
+  // React escapes the children slot; the string lands as text content.
+  return <span>{v.value}</span>
+}
+
+function renderCallout(v: VNodeCallout): ReactNode | null {
+  if (typeof v.body !== 'string') return null
+  const kind = v.kind && v.kind in CALLOUT_STYLES ? v.kind : 'note'
+  const style = CALLOUT_STYLES[kind]
+  return (
+    <div className={`rounded-md border px-3 py-2 ${style.container}`}>
+      <div className="text-xs uppercase tracking-wide text-obsidianText/80 mb-1">
+        <span className="mr-1.5">{style.icon}</span>
+        {v.title && v.title.length > 0 ? v.title : style.label}
       </div>
+      <div className="text-sm text-obsidianText whitespace-pre-wrap">{v.body}</div>
+    </div>
+  )
+}
+
+function renderButton(v: VNodeButton, ctx: RenderContext): ReactNode | null {
+  if (typeof v.label !== 'string') return null
+  const variant = v.variant && v.variant in BUTTON_VARIANTS ? v.variant : 'default'
+  const disabled = v.disabled === true
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      className={`inline-flex items-center justify-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${BUTTON_VARIANTS[variant]} disabled:cursor-not-allowed disabled:opacity-50`}
+      onClick={
+        disabled
+          ? undefined
+          : () => dispatchOrDrop(ctx, v.onClick)
+      }
+    >
+      {v.label}
+    </button>
+  )
+}
+
+function renderInput(v: VNodeInput, ctx: RenderContext): ReactNode | null {
+  if (v.type !== 'text' && v.type !== 'number' && v.type !== 'search' && v.type !== 'select') {
+    return null
+  }
+  const disabled = v.disabled === true
+  const baseClass =
+    'rounded-md border border-obsidianBorder bg-obsidianHighlight/30 px-2 py-1 text-sm text-obsidianText placeholder:text-obsidianSecondaryText focus:outline-none focus:ring-2 focus:ring-blue-500/40 disabled:cursor-not-allowed disabled:opacity-50'
+
+  if (v.type === 'select') {
+    const options = Array.isArray(v.options) ? v.options : []
+    return (
+      <select
+        className={baseClass}
+        disabled={disabled}
+        value={typeof v.value === 'string' || typeof v.value === 'number' ? String(v.value) : ''}
+        onChange={
+          disabled
+            ? undefined
+            : (e) => dispatchOrDrop(ctx, v.onChange, { value: e.target.value })
+        }
+      >
+        {options.map((opt, idx) => {
+          if (typeof opt?.value !== 'string' || typeof opt?.label !== 'string') return null
+          return (
+            <option key={`${opt.value}:${idx}`} value={opt.value}>
+              {opt.label}
+            </option>
+          )
+        })}
+      </select>
     )
   }
 
+  const value =
+    typeof v.value === 'string' || typeof v.value === 'number' ? String(v.value) : ''
+  return (
+    <input
+      type={v.type}
+      className={baseClass}
+      disabled={disabled}
+      placeholder={typeof v.placeholder === 'string' ? v.placeholder : undefined}
+      value={value}
+      onChange={
+        disabled
+          ? undefined
+          : (e) => {
+              const next = v.type === 'number' ? Number(e.target.value) : e.target.value
+              dispatchOrDrop(ctx, v.onChange, { value: next })
+            }
+      }
+    />
+  )
+}
+
+function renderList(v: VNodeList, ctx: RenderContext): ReactNode | null {
+  if (!Array.isArray(v.items)) return null
+  if (ctx.depth + 1 > MAX_LIST_DEPTH) return null
+  const childCtx: RenderContext = { onEvent: ctx.onEvent, depth: ctx.depth + 1 }
+  const ordered = v.ordered === true
+  const Tag = ordered ? 'ol' : 'ul'
+  return (
+    <Tag className={`${ordered ? 'list-decimal' : 'list-disc'} pl-5 text-sm text-obsidianText space-y-1`}>
+      {v.items.map((item, idx) => {
+        const rendered = renderWithContext(item, childCtx)
+        if (rendered === null) return null
+        return <li key={idx}>{rendered}</li>
+      })}
+    </Tag>
+  )
+}
+
+function renderLink(v: VNodeLink): ReactNode | null {
+  if (typeof v.label !== 'string' || v.label.length === 0) return null
+  if (typeof v.href !== 'object' || v.href === null || !('kind' in v.href)) return null
+  const href = linkHrefToString(v.href as VNodeLink['href'])
+  if (href === null) return null
+  // Belt-and-braces — the helper above already restricts to wikilink://
+  // and #fragment, but the named guard keeps the security contract
+  // explicit at the render site.
+  if (!isSafePluginHref(href)) return null
+  return (
+    <a
+      href={href}
+      className="text-blue-500 underline hover:text-blue-400"
+      rel="noopener noreferrer"
+    >
+      {v.label}
+    </a>
+  )
+}
+
+function renderRadio(v: VNodeRadio, ctx: RenderContext): ReactNode | null {
+  if (typeof v.group !== 'string' || v.group.length === 0) return null
+  if (!Array.isArray(v.options)) return null
+  const current = typeof v.value === 'string' ? v.value : undefined
+  return (
+    <fieldset className="flex flex-col gap-1">
+      {v.options.map((opt, idx) => {
+        if (typeof opt?.value !== 'string' || typeof opt?.label !== 'string') return null
+        const checked = current === opt.value
+        const id = `plugin-radio-${v.group}-${idx}`
+        return (
+          <label key={`${opt.value}:${idx}`} htmlFor={id} className="flex items-center gap-2 text-sm text-obsidianText">
+            <input
+              id={id}
+              type="radio"
+              name={`plugin-radio-${v.group}`}
+              value={opt.value}
+              checked={checked}
+              onChange={() => dispatchOrDrop(ctx, v.onChange, { value: opt.value })}
+              className="accent-blue-500"
+            />
+            <span>{opt.label}</span>
+          </label>
+        )
+      })}
+    </fieldset>
+  )
+}
+
+function renderSvg(v: VNodeSvg, ctx: RenderContext): ReactNode | null {
+  const width = coerceFinite(v.width)
+  const height = coerceFinite(v.height)
+  if (width === null || height === null) return null
+  if (!Array.isArray(v.children)) return null
+  let viewBox: string | undefined
+  if (Array.isArray(v.viewBox) && v.viewBox.length === 4) {
+    const parts = v.viewBox.map((n) => coerceFinite(n))
+    if (parts.every((n): n is number => n !== null)) {
+      viewBox = parts.join(' ')
+    }
+  }
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={viewBox}
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {v.children.map((child, idx) => renderSvgChild(child, idx, ctx))}
+    </svg>
+  )
+}
+
+function renderSvgChild(child: SvgChild | unknown, key: number, ctx: RenderContext): ReactNode | null {
+  if (typeof child !== 'object' || child === null || !('tag' in child)) return null
+  const tag = (child as { tag: unknown }).tag
+
+  if (tag === 'line') {
+    const c = child as Extract<SvgChild, { tag: 'line' }>
+    const x1 = coerceFinite(c.x1)
+    const y1 = coerceFinite(c.y1)
+    const x2 = coerceFinite(c.x2)
+    const y2 = coerceFinite(c.y2)
+    if (x1 === null || y1 === null || x2 === null || y2 === null) return null
+    const stroke = safeColor(c.stroke) ?? 'currentColor'
+    const strokeWidth = coerceFinite(c.strokeWidth) ?? 1
+    return <line key={key} x1={x1} y1={y1} x2={x2} y2={y2} stroke={stroke} strokeWidth={strokeWidth} />
+  }
+
+  if (tag === 'circle') {
+    const c = child as Extract<SvgChild, { tag: 'circle' }>
+    const cx = coerceFinite(c.cx)
+    const cy = coerceFinite(c.cy)
+    const r = coerceFinite(c.r)
+    if (cx === null || cy === null || r === null) return null
+    const fill = safeColor(c.fill) ?? 'currentColor'
+    const stroke = safeColor(c.stroke) ?? 'none'
+    return (
+      <circle
+        key={key}
+        cx={cx}
+        cy={cy}
+        r={r}
+        fill={fill}
+        stroke={stroke}
+        onClick={c.onClick ? () => dispatchOrDrop(ctx, c.onClick) : undefined}
+        style={c.onClick ? ({ cursor: 'pointer' } satisfies CSSProperties) : undefined}
+      />
+    )
+  }
+
+  if (tag === 'rect') {
+    const c = child as Extract<SvgChild, { tag: 'rect' }>
+    const x = coerceFinite(c.x)
+    const y = coerceFinite(c.y)
+    const width = coerceFinite(c.width)
+    const height = coerceFinite(c.height)
+    if (x === null || y === null || width === null || height === null) return null
+    const fill = safeColor(c.fill) ?? 'currentColor'
+    const stroke = safeColor(c.stroke) ?? 'none'
+    return (
+      <rect
+        key={key}
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill={fill}
+        stroke={stroke}
+        onClick={c.onClick ? () => dispatchOrDrop(ctx, c.onClick) : undefined}
+        style={c.onClick ? ({ cursor: 'pointer' } satisfies CSSProperties) : undefined}
+      />
+    )
+  }
+
+  if (tag === 'text') {
+    const c = child as Extract<SvgChild, { tag: 'text' }>
+    const x = coerceFinite(c.x)
+    const y = coerceFinite(c.y)
+    if (x === null || y === null) return null
+    if (typeof c.value !== 'string') return null
+    const fontSize = coerceFinite(c.fontSize) ?? 12
+    const fill = safeColor(c.fill) ?? 'currentColor'
+    return (
+      <text key={key} x={x} y={y} fontSize={fontSize} fill={fill}>
+        {c.value}
+      </text>
+    )
+  }
+
+  if (tag === 'path') {
+    const c = child as Extract<SvgChild, { tag: 'path' }>
+    if (typeof c.d !== 'string' || c.d.length === 0) return null
+    if (c.d.length > MAX_PATH_D_LENGTH) return null
+    const stroke = safeColor(c.stroke) ?? 'currentColor'
+    const fill = safeColor(c.fill) ?? 'none'
+    const strokeWidth = coerceFinite(c.strokeWidth) ?? 1
+    return <path key={key} d={c.d} stroke={stroke} fill={fill} strokeWidth={strokeWidth} />
+  }
+
   return null
+}
+
+function renderBox(v: VNodeBox, ctx: RenderContext): ReactNode | null {
+  if (!Array.isArray(v.children)) return null
+  if (ctx.depth + 1 > MAX_LIST_DEPTH) return null
+  const childCtx: RenderContext = { onEvent: ctx.onEvent, depth: ctx.depth + 1 }
+  const gap = v.gap !== undefined && v.gap in GAP_CLASSES ? GAP_CLASSES[v.gap] : 'gap-2'
+  return (
+    <div className={`flex flex-col ${gap}`}>
+      {v.children.map((child, idx) => {
+        const rendered = renderWithContext(child, childCtx)
+        if (rendered === null) return null
+        return <div key={idx}>{rendered}</div>
+      })}
+    </div>
+  )
 }
 
 /**
  * Render-or-fallback. Unrecognised shapes show a JSON dump in dev so
  * plugin authors can spot a typo, and the same dump in prod (we do
  * not strip it — the surface area is too small to bother gating).
+ *
+ * Pass `onEvent` to wire VNode events back into the host. Surfaces
+ * that need event delivery (the sidebar plugin panel, the code-block
+ * renderer, the future fullscreen view in PR B) all wrap this prop.
  */
-export function PluginNode({ node }: { node: unknown }) {
-  const rendered = renderPluginVNode(node)
+export function PluginNode({
+  node,
+  onEvent,
+}: {
+  node: unknown
+  onEvent?: PluginVNodeEventDispatcher
+}) {
+  const rendered = renderPluginVNode(node, onEvent)
   if (rendered !== null) return <>{rendered}</>
   return (
     <pre className="text-xs font-mono text-obsidianSecondaryText whitespace-pre-wrap">

--- a/src/plugins/__tests__/PluginFullscreenView.test.tsx
+++ b/src/plugins/__tests__/PluginFullscreenView.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * PluginFullscreenView.test.tsx
+ *
+ * Plugin API v1.2 PR B — host modal for the fullscreen surface.
+ *
+ * Covers per the plan section 3.1 and the deliverable list:
+ *   - mount / unmount driven by pluginStore.activeFullscreen
+ *   - Esc closes (capture phase so a plugin handler cannot trap it)
+ *   - X-close button closes + has the right aria-label
+ *   - focus trap wraps with Tab / Shift+Tab inside the modal
+ *   - body scroll lock while open
+ *   - only one fullscreen view at a time (single-view invariant)
+ *   - setFullscreenContent updates the rendered tree
+ *   - the host-side singleton handlers reject a second open with the
+ *     plan-mandated error message
+ */
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+
+import { PluginFullscreenView } from '../../components/plugins/PluginFullscreenView'
+import { usePluginStore, type ActiveFullscreenView } from '../../stores/pluginStore'
+
+// The component pulls in pluginHostSingleton to grab `dismissActiveFullscreen`
+// and `getPluginHost`. Stub the singleton so jsdom does not try to spawn a
+// real Web Worker. The dismiss helper is what we wire to X / Esc; the
+// stub forwards into the store so the modal closes the same way it would
+// in prod, without booting a worker.
+jest.mock('../../plugins/pluginHostSingleton', () => {
+  // The mock factory cannot reference outer-scope identifiers (Jest
+  // hoists it above the imports), so we re-require the store inside.
+  return {
+    getPluginHost: () => null,
+    dismissActiveFullscreen: () => {
+      const mod = jest.requireActual('../../stores/pluginStore') as typeof import('../../stores/pluginStore')
+      mod.usePluginStore.getState().setActiveFullscreen(null)
+    },
+  }
+})
+
+const sampleView = (
+  overrides: Partial<ActiveFullscreenView> = {},
+): ActiveFullscreenView => ({
+  pluginId: 'demo',
+  pluginName: 'Demo plugin',
+  viewId: 'main',
+  title: 'Sample view',
+  node: { tag: 'text', value: 'hello fullscreen' },
+  ...overrides,
+})
+
+beforeEach(() => {
+  act(() => {
+    usePluginStore.getState().clear()
+  })
+})
+
+describe('PluginFullscreenView — render', () => {
+  test('renders nothing when no fullscreen view is active', () => {
+    const { container } = render(<PluginFullscreenView />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  test('mounts the modal with the plugin title and name when active', () => {
+    act(() => {
+      usePluginStore.getState().setActiveFullscreen(sampleView())
+    })
+    render(<PluginFullscreenView />)
+    expect(screen.getByTestId('plugin-fullscreen-view')).toBeInTheDocument()
+    expect(screen.getByText('Sample view')).toBeInTheDocument()
+    expect(screen.getByText('Demo plugin')).toBeInTheDocument()
+    expect(screen.getByText('hello fullscreen')).toBeInTheDocument()
+  })
+
+  test('uses z-index 9999 so the overlay sits above panels and toasts', () => {
+    act(() => {
+      usePluginStore.getState().setActiveFullscreen(sampleView())
+    })
+    render(<PluginFullscreenView />)
+    const overlay = screen.getByTestId('plugin-fullscreen-view')
+    expect(overlay).toHaveStyle({ zIndex: '9999' })
+  })
+
+  test('locks body scroll while the modal is open and restores on close', () => {
+    document.body.style.overflow = ''
+    act(() => {
+      usePluginStore.getState().setActiveFullscreen(sampleView())
+    })
+    render(<PluginFullscreenView />)
+    expect(document.body.style.overflow).toBe('hidden')
+
+    act(() => {
+      usePluginStore.getState().setActiveFullscreen(null)
+    })
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  test('updates the body when activeFullscreen.node changes', () => {
+    act(() => {
+      usePluginStore.getState().setActiveFullscreen(sampleView())
+    })
+    render(<PluginFullscreenView />)
+    expect(screen.getByText('hello fullscreen')).toBeInTheDocument()
+
+    act(() => {
+      usePluginStore
+        .getState()
+        .updateActiveFullscreenContent('demo', 'main', {
+          tag: 'text',
+          value: 'updated content',
+        })
+    })
+    expect(screen.queryByText('hello fullscreen')).not.toBeInTheDocument()
+    expect(screen.getByText('updated content')).toBeInTheDocument()
+  })
+})
+
+describe('PluginFullscreenView — close affordances', () => {
+  test('X button closes the modal and exposes a clear aria-label', () => {
+    act(() => {
+      usePluginStore.getState().setActiveFullscreen(sampleView())
+    })
+    render(<PluginFullscreenView />)
+    const closeBtn = screen.getByLabelText('Close fullscreen view')
+    expect(closeBtn).toBeInTheDocument()
+    fireEvent.click(closeBtn)
+    expect(usePluginStore.getState().activeFullscreen).toBeNull()
+  })
+
+  test('Escape on document closes the modal', () => {
+    act(() => {
+      usePluginStore.getState().setActiveFullscreen(sampleView())
+    })
+    render(<PluginFullscreenView />)
+    expect(usePluginStore.getState().activeFullscreen).not.toBeNull()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(usePluginStore.getState().activeFullscreen).toBeNull()
+  })
+})
+
+describe('PluginFullscreenView — focus trap', () => {
+  test('Tab from the last focusable wraps to the first', () => {
+    act(() => {
+      usePluginStore.getState().setActiveFullscreen(
+        sampleView({
+          node: {
+            tag: 'box',
+            gap: 2,
+            children: [
+              { tag: 'button', label: 'First' },
+              { tag: 'button', label: 'Second' },
+            ],
+          },
+        }),
+      )
+    })
+    render(<PluginFullscreenView />)
+
+    const buttons = screen.getAllByRole('button')
+    // First is the X-close in the chrome; then First, Second.
+    const xClose = screen.getByLabelText('Close fullscreen view')
+    expect(buttons[0]).toBe(xClose)
+
+    const lastFocusable = buttons[buttons.length - 1]
+    act(() => lastFocusable.focus())
+    expect(document.activeElement).toBe(lastFocusable)
+
+    fireEvent.keyDown(document, { key: 'Tab' })
+    expect(document.activeElement).toBe(buttons[0])
+  })
+
+  test('Shift+Tab from the first focusable wraps to the last', () => {
+    act(() => {
+      usePluginStore.getState().setActiveFullscreen(
+        sampleView({
+          node: {
+            tag: 'box',
+            gap: 2,
+            children: [
+              { tag: 'button', label: 'First' },
+              { tag: 'button', label: 'Second' },
+            ],
+          },
+        }),
+      )
+    })
+    render(<PluginFullscreenView />)
+    const buttons = screen.getAllByRole('button')
+    const first = buttons[0]
+    const last = buttons[buttons.length - 1]
+    act(() => first.focus())
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true })
+    expect(document.activeElement).toBe(last)
+  })
+})
+
+describe('pluginStore — single-view invariant', () => {
+  test('setActiveFullscreen overwrites; updateActiveFullscreenContent only matches by ids', () => {
+    act(() => {
+      usePluginStore.getState().setActiveFullscreen(sampleView())
+    })
+    // Update against the wrong viewId — must NOT mutate.
+    act(() => {
+      usePluginStore
+        .getState()
+        .updateActiveFullscreenContent('demo', 'wrong-view-id', {
+          tag: 'text',
+          value: 'should be ignored',
+        })
+    })
+    expect(
+      (usePluginStore.getState().activeFullscreen?.node as { value: string })?.value,
+    ).toBe('hello fullscreen')
+  })
+})
+
+describe('pluginHostSingleton — fullscreen wire (real module, not mocked)', () => {
+  // This block exercises the actual singleton handlers — we unmock
+  // pluginHostSingleton specifically here. Because jest.resetModules
+  // gives back fresh module instances, we re-import the store from
+  // the SAME isolated graph so the two halves are wired to the same
+  // Zustand instance. Mixing the outer-scope store with the freshly
+  // required module would race against two unrelated singletons.
+  let realModule: typeof import('../../plugins/pluginHostSingleton')
+  let isolatedStore: typeof import('../../stores/pluginStore').usePluginStore
+  beforeAll(async () => {
+    jest.unmock('../../plugins/pluginHostSingleton')
+    jest.resetModules()
+    realModule = await import('../../plugins/pluginHostSingleton')
+    isolatedStore = (await import('../../stores/pluginStore')).usePluginStore
+  })
+
+  test('dismissActiveFullscreen is a no-op when nothing is open', () => {
+    isolatedStore.getState().setActiveFullscreen(null)
+    expect(() => realModule.dismissActiveFullscreen()).not.toThrow()
+    expect(isolatedStore.getState().activeFullscreen).toBeNull()
+  })
+
+  test('dismissActiveFullscreen clears the active view', () => {
+    isolatedStore.getState().setActiveFullscreen(sampleView())
+    realModule.dismissActiveFullscreen()
+    expect(isolatedStore.getState().activeFullscreen).toBeNull()
+  })
+})

--- a/src/plugins/__tests__/PluginVNode.test.tsx
+++ b/src/plugins/__tests__/PluginVNode.test.tsx
@@ -1,0 +1,537 @@
+/**
+ * PluginVNode.test.tsx
+ *
+ * Plugin API v1.2 PR A — exercise the extended VNode set:
+ *   button / input / list / link / radio / svg / box
+ *
+ * Each test asserts the rendered DOM is structurally what the plan in
+ * `docs/plugins-v1.2-plan.md` (section 2) describes, plus the host
+ * never reaches dangerouslySetInnerHTML, the sanitiser escapes script
+ * tags in plugin text, unsafe link hrefs are rejected, and the event
+ * shape round-trips through the dispatcher.
+ */
+
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import {
+  PluginNode,
+  renderPluginVNode,
+  escapeText,
+  isSafePluginHref,
+  MAX_LIST_DEPTH,
+  type PluginVNodeEvent,
+  type VNode,
+} from '../PluginVNode'
+
+describe('PluginVNode — v1 shapes still work', () => {
+  test('text renders its value as a span', () => {
+    render(<PluginNode node={{ tag: 'text', value: 'hello world' }} />)
+    expect(screen.getByText('hello world').tagName).toBe('SPAN')
+  })
+
+  test('callout renders the body and falls back to "note" kind', () => {
+    render(<PluginNode node={{ tag: 'callout', body: 'body text' }} />)
+    expect(screen.getByText('body text')).toBeInTheDocument()
+    expect(screen.getByText('Note')).toBeInTheDocument()
+  })
+})
+
+describe('PluginVNode — button', () => {
+  test('renders the label and fires onClick with payload', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'button',
+          label: 'Save',
+          variant: 'primary',
+          onClick: { kind: 'emit', event: 'save', payload: { id: 1 } },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: 'Save' })
+    expect(btn).not.toBeDisabled()
+    fireEvent.click(btn)
+    expect(events).toEqual([{ event: 'save', payload: { id: 1 } }])
+  })
+
+  test('disabled buttons render disabled and never fire events', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'button',
+          label: 'Save',
+          disabled: true,
+          onClick: { kind: 'emit', event: 'save' },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const btn = screen.getByRole('button', { name: 'Save' })
+    expect(btn).toBeDisabled()
+    fireEvent.click(btn)
+    expect(events).toEqual([])
+  })
+
+  test('non-string label rejects the node', () => {
+    const out = renderPluginVNode({ tag: 'button', label: 42 } as unknown)
+    expect(out).toBeNull()
+  })
+})
+
+describe('PluginVNode — input', () => {
+  test('text input forwards typed value through the dispatcher', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'input',
+          type: 'text',
+          value: '',
+          placeholder: 'Search…',
+          onChange: { kind: 'emit', event: 'q' },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const input = screen.getByPlaceholderText('Search…') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'abc' } })
+    expect(events).toEqual([{ event: 'q', payload: { value: 'abc' } }])
+  })
+
+  test('number input coerces value to a number in the payload', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'input',
+          type: 'number',
+          value: 0,
+          onChange: { kind: 'emit', event: 'n' },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const input = screen.getByRole('spinbutton') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '7' } })
+    expect(events).toEqual([{ event: 'n', payload: { value: 7 } }])
+  })
+
+  test('select input renders options and emits the picked value', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'input',
+          type: 'select',
+          value: 'a',
+          options: [
+            { value: 'a', label: 'Alpha' },
+            { value: 'b', label: 'Bravo' },
+          ],
+          onChange: { kind: 'emit', event: 'pick' },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const select = screen.getByRole('combobox') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'b' } })
+    expect(events).toEqual([{ event: 'pick', payload: { value: 'b' } }])
+  })
+
+  test('unknown input type rejects the node', () => {
+    const out = renderPluginVNode({ tag: 'input', type: 'password' } as unknown)
+    expect(out).toBeNull()
+  })
+})
+
+describe('PluginVNode — list', () => {
+  test('unordered list renders <ul> with child VNodes', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'list',
+          ordered: false,
+          items: [
+            { tag: 'text', value: 'one' },
+            { tag: 'text', value: 'two' },
+          ],
+        }}
+      />,
+    )
+    const ul = screen.getByText('one').closest('ul')
+    expect(ul).not.toBeNull()
+    expect(screen.getByText('two')).toBeInTheDocument()
+  })
+
+  test('ordered list renders <ol>', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'list',
+          ordered: true,
+          items: [{ tag: 'text', value: 'first' }],
+        }}
+      />,
+    )
+    expect(screen.getByText('first').closest('ol')).not.toBeNull()
+  })
+
+  test('list nested beyond MAX_LIST_DEPTH drops the leaf, does not blow the stack', () => {
+    // Build a list nested deeper than MAX_LIST_DEPTH levels with a
+    // text leaf at the bottom. The outer lists render fine, but the
+    // recursion stops once depth exceeds the cap — so the leaf text
+    // never reaches the DOM. The bound exists to keep a malicious
+    // plugin from blowing the React stack, not to error noisily.
+    let node: VNode = { tag: 'text', value: 'leaf-too-deep' }
+    for (let i = 0; i < MAX_LIST_DEPTH + 2; i++) {
+      node = { tag: 'list', items: [node] }
+    }
+    const { container } = render(<PluginNode node={node} />)
+    expect(container.textContent).not.toContain('leaf-too-deep')
+  })
+})
+
+describe('PluginVNode — link', () => {
+  test('note href renders an anchor with a wikilink:// URL', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'link',
+          label: 'Open',
+          href: { kind: 'note', noteId: 'abc' },
+        }}
+      />,
+    )
+    const a = screen.getByRole('link', { name: 'Open' }) as HTMLAnchorElement
+    expect(a.getAttribute('href')).toBe('wikilink://abc')
+  })
+
+  test('anchor href renders a fragment link', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'link',
+          label: 'Jump',
+          href: { kind: 'anchor', fragment: 'section-1' },
+        }}
+      />,
+    )
+    const a = screen.getByRole('link', { name: 'Jump' }) as HTMLAnchorElement
+    expect(a.getAttribute('href')).toBe('#section-1')
+  })
+
+  test('javascript: cannot be expressed — discriminated union rejects raw hrefs', () => {
+    // Try to slip a raw href through. The renderer reads `href.kind` —
+    // a plain string fails the type guard, the node renders to null,
+    // and `PluginNode` shows the JSON fallback.
+    const out = renderPluginVNode({
+      tag: 'link',
+      label: 'click',
+      href: 'javascript:alert(1)' as unknown,
+    } as unknown)
+    expect(out).toBeNull()
+  })
+
+  test('isSafePluginHref rejects javascript: and data:', () => {
+    expect(isSafePluginHref('javascript:alert(1)')).toBe(false)
+    expect(isSafePluginHref('data:text/html,<script>')).toBe(false)
+    expect(isSafePluginHref('http://evil.example')).toBe(false)
+    expect(isSafePluginHref('mailto:a@b.c')).toBe(false)
+    expect(isSafePluginHref('//evil.example/path')).toBe(false)
+    expect(isSafePluginHref('wikilink://abc')).toBe(true)
+    expect(isSafePluginHref('#fragment')).toBe(true)
+    expect(isSafePluginHref('/local/path')).toBe(true)
+  })
+})
+
+describe('PluginVNode — radio', () => {
+  test('renders one radio per option and emits the picked value', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'radio',
+          group: 'format',
+          value: 'obsidian',
+          options: [
+            { value: 'obsidian', label: 'Obsidian' },
+            { value: 'notion', label: 'Notion' },
+          ],
+          onChange: { kind: 'emit', event: 'pickFormat' },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const notion = screen.getByLabelText('Notion') as HTMLInputElement
+    expect(notion.checked).toBe(false)
+    fireEvent.click(notion)
+    expect(events).toEqual([{ event: 'pickFormat', payload: { value: 'notion' } }])
+  })
+})
+
+describe('PluginVNode — svg', () => {
+  test('renders the five permitted shape primitives', () => {
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 100,
+          height: 100,
+          viewBox: [0, 0, 100, 100],
+          children: [
+            { tag: 'line', x1: 0, y1: 0, x2: 10, y2: 10 },
+            { tag: 'circle', cx: 50, cy: 50, r: 5, fill: '#f00' },
+            { tag: 'rect', x: 1, y: 2, width: 3, height: 4 },
+            { tag: 'text', x: 10, y: 10, value: 'hi' },
+            { tag: 'path', d: 'M0 0 L10 10' },
+          ],
+        }}
+      />,
+    )
+    const svg = container.querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg?.getAttribute('viewBox')).toBe('0 0 100 100')
+    expect(container.querySelector('line')).not.toBeNull()
+    expect(container.querySelector('circle')).not.toBeNull()
+    expect(container.querySelector('rect')).not.toBeNull()
+    expect(container.querySelector('text')?.textContent).toBe('hi')
+    expect(container.querySelector('path')).not.toBeNull()
+  })
+
+  test('non-finite numeric props reject the affected child', () => {
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 100,
+          height: 100,
+          children: [
+            { tag: 'circle', cx: Number.NaN, cy: 0, r: 5 },
+            { tag: 'circle', cx: 1, cy: 2, r: 3 },
+          ],
+        }}
+      />,
+    )
+    // Only the second circle survives the coerceFinite guard.
+    const circles = container.querySelectorAll('circle')
+    expect(circles.length).toBe(1)
+    expect(circles[0].getAttribute('cx')).toBe('1')
+  })
+
+  test('clickable circle dispatches onClick event', () => {
+    const events: PluginVNodeEvent[] = []
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 100,
+          height: 100,
+          children: [
+            {
+              tag: 'circle',
+              cx: 50,
+              cy: 50,
+              r: 5,
+              onClick: { kind: 'emit', event: 'pickNode', payload: { id: 'n1' } },
+            },
+          ],
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const circle = container.querySelector('circle')
+    expect(circle).not.toBeNull()
+    fireEvent.click(circle!)
+    expect(events).toEqual([{ event: 'pickNode', payload: { id: 'n1' } }])
+  })
+
+  test('unknown svg child tags are dropped', () => {
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 10,
+          height: 10,
+          children: [{ tag: 'script', value: 'alert(1)' }],
+        } as unknown}
+      />,
+    )
+    expect(container.querySelector('script')).toBeNull()
+  })
+
+  test('unsafe color string falls back to currentColor', () => {
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 10,
+          height: 10,
+          children: [
+            { tag: 'line', x1: 0, y1: 0, x2: 1, y2: 1, stroke: 'url(javascript:alert(1))' },
+          ],
+        }}
+      />,
+    )
+    const line = container.querySelector('line')
+    expect(line?.getAttribute('stroke')).toBe('currentColor')
+  })
+})
+
+describe('PluginVNode — box', () => {
+  test('renders each child of a box', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'box',
+          gap: 2,
+          children: [
+            { tag: 'text', value: 'header' },
+            { tag: 'text', value: 'body' },
+          ],
+        }}
+      />,
+    )
+    expect(screen.getByText('header')).toBeInTheDocument()
+    expect(screen.getByText('body')).toBeInTheDocument()
+  })
+})
+
+describe('PluginVNode — sanitisation', () => {
+  test('script-tag strings render as text content, never as DOM nodes', () => {
+    const evil = '<script>alert("x")</script>'
+    const { container } = render(<PluginNode node={{ tag: 'text', value: evil }} />)
+    // React renders the string as text content — no <script> element.
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.textContent).toContain(evil)
+  })
+
+  test('escapeText escapes &, <, >, ", and \'', () => {
+    expect(escapeText('<script>alert("x")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;',
+    )
+    expect(escapeText("A & B's <tag>")).toBe('A &amp; B&#39;s &lt;tag&gt;')
+  })
+
+  test('svg text value renders as text content, not markup', () => {
+    const evil = '<script>alert(1)</script>'
+    const { container } = render(
+      <PluginNode
+        node={{
+          tag: 'svg',
+          width: 10,
+          height: 10,
+          children: [{ tag: 'text', x: 0, y: 0, value: evil }],
+        }}
+      />,
+    )
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.querySelector('text')?.textContent).toBe(evil)
+  })
+
+  test('renderer never reaches dangerouslySetInnerHTML for any v1.2 shape', () => {
+    // Spy on React's warning channel — dangerouslySetInnerHTML on a
+    // mismatched element would log. We just confirm no element in any
+    // rendered v1.2 shape carries the attribute.
+    const shapes: VNode[] = [
+      { tag: 'button', label: 'b' },
+      { tag: 'input', type: 'text' },
+      { tag: 'list', items: [{ tag: 'text', value: 'x' }] },
+      { tag: 'link', label: 'l', href: { kind: 'note', noteId: 'a' } },
+      { tag: 'radio', group: 'g', options: [{ value: 'a', label: 'A' }] },
+      {
+        tag: 'svg',
+        width: 10,
+        height: 10,
+        children: [{ tag: 'text', x: 0, y: 0, value: 'x' }],
+      },
+      { tag: 'box', children: [{ tag: 'text', value: 'x' }] },
+    ]
+    for (const shape of shapes) {
+      const { container, unmount } = render(<PluginNode node={shape} />)
+      const html = container.innerHTML
+      expect(html).not.toContain('dangerouslySetInnerHTML')
+      unmount()
+    }
+  })
+})
+
+describe('PluginVNode — event shape round-trip', () => {
+  test('VNodeEvent + dispatcher preserve event name and payload verbatim', () => {
+    const events: PluginVNodeEvent[] = []
+    const payload = { complex: { nested: [1, 2, 3] }, str: 'hello' }
+    render(
+      <PluginNode
+        node={{
+          tag: 'button',
+          label: 'fire',
+          onClick: { kind: 'emit', event: 'fire', payload },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'fire' }))
+    expect(events).toHaveLength(1)
+    expect(events[0].event).toBe('fire')
+    expect(events[0].payload).toEqual(payload)
+  })
+
+  test('input change merges value into the plugin-supplied payload', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{
+          tag: 'input',
+          type: 'text',
+          value: '',
+          onChange: { kind: 'emit', event: 'edit', payload: { fieldId: 'name' } },
+        }}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Jon' } })
+    expect(events).toEqual([
+      { event: 'edit', payload: { fieldId: 'name', value: 'Jon' } },
+    ])
+  })
+
+  test('missing onEvent dispatcher silently drops the event', () => {
+    // Component must not throw when a surface forgets to wire onEvent.
+    render(
+      <PluginNode
+        node={{
+          tag: 'button',
+          label: 'orphan',
+          onClick: { kind: 'emit', event: 'fire' },
+        }}
+      />,
+    )
+    expect(() => fireEvent.click(screen.getByRole('button'))).not.toThrow()
+  })
+
+  test('missing or malformed VNodeEvent does not call the dispatcher', () => {
+    const events: PluginVNodeEvent[] = []
+    render(
+      <PluginNode
+        node={{ tag: 'button', label: 'noop' } as VNode}
+        onEvent={(e) => events.push(e)}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(events).toEqual([])
+  })
+})
+
+describe('PluginVNode — unrecognised node fallback', () => {
+  test('PluginNode dumps JSON for an unknown tag', () => {
+    const { container } = render(
+      <PluginNode node={{ tag: 'totally-made-up', x: 1 }} />,
+    )
+    const pre = container.querySelector('pre')
+    expect(pre).not.toBeNull()
+    expect(pre?.textContent).toContain('totally-made-up')
+  })
+})

--- a/src/plugins/__tests__/vaultRead.test.ts
+++ b/src/plugins/__tests__/vaultRead.test.ts
@@ -1,0 +1,489 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Plugin API v1.2 PR C — `vault.read.all` capability.
+ *
+ * Coverage:
+ *   - Manifest validator accepts the new permission and rejects unknown
+ *     variants.
+ *   - Host snapshot returns the live note-store contents, parsed
+ *     frontmatter included.
+ *   - The chunked stream emits the right slice counts at chunkSize=1,
+ *     100, and clamps to the 500-note ceiling on oversized requests.
+ *   - PluginHost rejects `worker:requestVaultRead` when the permission
+ *     was not declared or was revoked at runtime.
+ *
+ * The PluginHost tests inject a FakeWorker (real Web Workers are not
+ * available in Jest) to assert the message routing without spinning
+ * up the real worker entry. The snapshot tests drive the real
+ * Zustand stores via their setState API.
+ */
+
+import { validateManifest, PERMISSIONS, PERMISSION_DESCRIPTIONS } from '@/plugins/manifest'
+import { PluginHost, type MinimalWorker } from '@/plugins/PluginHost'
+import type { HostToWorker, WorkerToHost } from '@/plugins/protocol'
+import {
+  snapshotAllNotes,
+  snapshotNoteById,
+  streamVaultSnapshot,
+  resetVaultSnapshotCacheForTests,
+  computeVaultSha,
+  MAX_STREAM_CHUNK_SIZE,
+} from '@/plugins/vaultSnapshot'
+import { useNoteStore } from '@/stores/noteStore'
+import { useFolderStore } from '@/stores/folderStore'
+import type { Note } from '@/types'
+
+function makeNote(over: Partial<Note> & { id: string; title: string }): Note {
+  return {
+    folderId: null,
+    content: '',
+    createdAt: 1,
+    updatedAt: 1,
+    isDeleted: false,
+    deletedAt: null,
+    isPinned: false,
+    templateId: null,
+    ...over,
+  } as Note
+}
+
+function seedStore(notes: Note[]): void {
+  resetVaultSnapshotCacheForTests()
+  useNoteStore.setState({ notes, selectedNoteId: null })
+  useFolderStore.setState({ folders: [] })
+}
+
+afterEach(() => {
+  resetVaultSnapshotCacheForTests()
+  useNoteStore.setState({ notes: [], selectedNoteId: null })
+  useFolderStore.setState({ folders: [] })
+})
+
+describe('manifest accepts vault.read.all', () => {
+  const base = {
+    id: 'echo',
+    name: 'Echo',
+    version: '1.0.0',
+    surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+  }
+
+  test('vault.read.all is in the PERMISSIONS list and has a description', () => {
+    expect((PERMISSIONS as readonly string[]).includes('vault.read.all')).toBe(true)
+    expect(typeof PERMISSION_DESCRIPTIONS['vault.read.all']).toBe('string')
+    expect(PERMISSION_DESCRIPTIONS['vault.read.all'].length).toBeGreaterThan(0)
+  })
+
+  test('validator accepts vault.read.all alongside v1.1 permissions', () => {
+    const r = validateManifest({ ...base, permissions: ['file-open', 'vault.read.all'] })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.permissions).toEqual(['file-open', 'vault.read.all'])
+  })
+
+  test('validator still rejects unknown permissions', () => {
+    const r = validateManifest({ ...base, permissions: ['vault.read.all', 'vault.write'] })
+    expect(r.ok).toBe(false)
+    // Error must mention the unknown one specifically.
+    expect(r.errors.some((e) => e.includes('vault.write'))).toBe(true)
+  })
+
+  test('validator deduplicates a repeated vault.read.all', () => {
+    const r = validateManifest({ ...base, permissions: ['vault.read.all', 'vault.read.all'] })
+    expect(r.ok).toBe(true)
+    expect(r.manifest?.permissions).toEqual(['vault.read.all'])
+  })
+})
+
+describe('host snapshot', () => {
+  test('snapshotAllNotes returns every non-deleted note with body + frontmatter', () => {
+    seedStore([
+      makeNote({
+        id: 'a',
+        title: 'A',
+        content: '---\nstatus: draft\ntags: [x, y]\n---\nBody A',
+        updatedAt: 100,
+      }),
+      makeNote({ id: 'b', title: 'B', content: 'Plain body', updatedAt: 200 }),
+      makeNote({
+        id: 'gone',
+        title: 'Gone',
+        content: 'deleted',
+        isDeleted: true,
+        deletedAt: 300,
+      }),
+    ])
+
+    const snap = snapshotAllNotes()
+    expect(snap).toHaveLength(2)
+    const a = snap.find((n) => n.id === 'a')!
+    expect(a.body).toBe('Body A')
+    expect(a.frontmatter).toEqual({ status: 'draft', tags: ['x', 'y'] })
+    const b = snap.find((n) => n.id === 'b')!
+    expect(b.body).toBe('Plain body')
+    expect(b.frontmatter).toBeNull()
+  })
+
+  test('snapshotAllNotes caches by SHA — second call is the same array', () => {
+    seedStore([makeNote({ id: 'a', title: 'A', content: 'x', updatedAt: 1 })])
+    const first = snapshotAllNotes()
+    const second = snapshotAllNotes()
+    expect(second).toBe(first)
+  })
+
+  test('snapshotAllNotes invalidates when a note updates', () => {
+    seedStore([makeNote({ id: 'a', title: 'A', content: 'x', updatedAt: 1 })])
+    const first = snapshotAllNotes()
+    useNoteStore.setState({
+      notes: [makeNote({ id: 'a', title: 'A', content: 'y', updatedAt: 2 })],
+    })
+    const second = snapshotAllNotes()
+    expect(second).not.toBe(first)
+    expect(second[0].body).toBe('y')
+  })
+
+  test('snapshotNoteById returns null for deleted / unknown notes', () => {
+    seedStore([
+      makeNote({ id: 'a', title: 'A', content: 'x', updatedAt: 1 }),
+      makeNote({ id: 'b', title: 'B', content: 'y', isDeleted: true, deletedAt: 1 }),
+    ])
+    expect(snapshotNoteById('a')?.body).toBe('x')
+    expect(snapshotNoteById('b')).toBeNull()
+    expect(snapshotNoteById('missing')).toBeNull()
+  })
+
+  test('computeVaultSha changes when content updates', () => {
+    seedStore([makeNote({ id: 'a', title: 'A', content: 'x', updatedAt: 1 })])
+    const a = computeVaultSha()
+    useNoteStore.setState({
+      notes: [makeNote({ id: 'a', title: 'A', content: 'y', updatedAt: 2 })],
+    })
+    expect(computeVaultSha()).not.toBe(a)
+  })
+})
+
+describe('chunked stream', () => {
+  function seedN(n: number): void {
+    const notes: Note[] = []
+    for (let i = 0; i < n; i++) {
+      notes.push(
+        makeNote({ id: `n${i}`, title: `N${i}`, content: `body ${i}`, updatedAt: i + 1 }),
+      )
+    }
+    seedStore(notes)
+  }
+
+  test('chunkSize=1 yields one chunk per note', async () => {
+    seedN(5)
+    const sizes: number[] = []
+    await streamVaultSnapshot({
+      chunkSize: 1,
+      onChunk: (slice) => {
+        sizes.push(slice.length)
+      },
+    })
+    expect(sizes).toEqual([1, 1, 1, 1, 1])
+  })
+
+  test('chunkSize=100 yields one chunk for 50 notes', async () => {
+    seedN(50)
+    const sizes: number[] = []
+    await streamVaultSnapshot({
+      chunkSize: 100,
+      onChunk: (slice) => {
+        sizes.push(slice.length)
+      },
+    })
+    expect(sizes).toEqual([50])
+  })
+
+  test('chunkSize=100 yields three chunks for 250 notes', async () => {
+    seedN(250)
+    const sizes: number[] = []
+    await streamVaultSnapshot({
+      chunkSize: 100,
+      onChunk: (slice) => {
+        sizes.push(slice.length)
+      },
+    })
+    expect(sizes).toEqual([100, 100, 50])
+  })
+
+  test('chunkSize is clamped to MAX_STREAM_CHUNK_SIZE', async () => {
+    seedN(MAX_STREAM_CHUNK_SIZE + 10)
+    const sizes: number[] = []
+    await streamVaultSnapshot({
+      chunkSize: MAX_STREAM_CHUNK_SIZE * 4,
+      onChunk: (slice) => {
+        sizes.push(slice.length)
+      },
+    })
+    // Two chunks — clamped to 500 each, last is the remainder.
+    expect(sizes[0]).toBe(MAX_STREAM_CHUNK_SIZE)
+    expect(sizes[1]).toBe(10)
+  })
+
+  test('isAborted terminates the stream with onAbort + no further chunks', async () => {
+    seedN(20)
+    const sizes: number[] = []
+    let aborted: string | null = null
+    let chunks = 0
+    await streamVaultSnapshot({
+      chunkSize: 5,
+      isAborted: () => (chunks >= 2 ? 'Permission "vault.read.all" was revoked.' : null),
+      onChunk: (slice) => {
+        chunks++
+        sizes.push(slice.length)
+      },
+      onAbort: (reason) => {
+        aborted = reason
+      },
+    })
+    expect(sizes).toEqual([5, 5])
+    expect(aborted).toBe('Permission "vault.read.all" was revoked.')
+  })
+
+  test('end-of-stream onEnd fires after the last chunk', async () => {
+    seedN(3)
+    const order: string[] = []
+    await streamVaultSnapshot({
+      chunkSize: 2,
+      onChunk: (slice) => {
+        order.push(`chunk:${slice.length}`)
+      },
+      onEnd: () => {
+        order.push('end')
+      },
+    })
+    expect(order).toEqual(['chunk:2', 'chunk:1', 'end'])
+  })
+})
+
+// ─── PluginHost wire-protocol gate ──────────────────────────────────────
+
+interface FakeWorkerHandle {
+  worker: MinimalWorker
+  sent: HostToWorker[]
+  inject: (data: unknown) => void
+}
+
+function makeFakeWorker(manifest: {
+  id: string
+  name: string
+  version: string
+  surfaces: object
+  permissions?: string[]
+}): FakeWorkerHandle {
+  const sent: HostToWorker[] = []
+  let handler: ((event: MessageEvent) => void) | null = null
+  const worker: MinimalWorker = {
+    onmessage: null,
+    postMessage(message: unknown) {
+      sent.push(message as HostToWorker)
+      const msg = message as HostToWorker
+      if (msg.type === 'host:boot') {
+        queueMicrotask(() => {
+          handler?.({
+            data: { type: 'worker:ready', seq: msg.seq, manifest } as WorkerToHost,
+          } as MessageEvent)
+        })
+      }
+    },
+    terminate() {
+      handler = null
+    },
+  } as MinimalWorker
+  Object.defineProperty(worker, 'onmessage', {
+    configurable: true,
+    get() {
+      return handler
+    },
+    set(v) {
+      handler = v
+    },
+  })
+  return {
+    worker,
+    sent,
+    inject(data: unknown) {
+      handler?.({ data } as MessageEvent)
+    },
+  }
+}
+
+async function flush(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('PluginHost vault.read.all gate', () => {
+  test('refuses worker:requestVaultRead when permission not declared', async () => {
+    const fake = makeFakeWorker({
+      id: 'no-perm',
+      name: 'No perm',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'no-perm', pluginSource: '' })
+
+    fake.inject({ type: 'worker:requestVaultRead', seq: 5, mode: 'all' })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultReadResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultReadResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.requestSeq).toBe(5)
+      expect(reply.error).toMatch(/vault\.read\.all/)
+    }
+  })
+
+  test('refuses stream-mode request with a terminal chunk on no-permission', async () => {
+    const fake = makeFakeWorker({
+      id: 'no-perm2',
+      name: 'No perm 2',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'no-perm2', pluginSource: '' })
+
+    fake.inject({ type: 'worker:requestVaultRead', seq: 7, mode: 'stream' })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultStreamChunk')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultStreamChunk') {
+      expect(reply.requestSeq).toBe(7)
+      expect(reply.notes).toEqual([])
+      expect(reply.error).toMatch(/vault\.read\.all/)
+    }
+  })
+
+  test('emits vaultReadRequested when permission IS declared', async () => {
+    const fake = makeFakeWorker({
+      id: 'ok',
+      name: 'OK',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.read.all'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const events: string[] = []
+    host.on((e) => events.push(e.type))
+    await host.load({ pluginId: 'ok', pluginSource: '' })
+
+    fake.inject({ type: 'worker:requestVaultRead', seq: 11, mode: 'all' })
+    await flush()
+
+    expect(events).toContain('vaultReadRequested')
+    // No early rejection.
+    const earlyError = fake.sent.find(
+      (m) => m.type === 'host:vaultReadResult' && m.ok === false,
+    )
+    expect(earlyError).toBeUndefined()
+  })
+
+  test('revocation rejects the next call', async () => {
+    const fake = makeFakeWorker({
+      id: 'revokee',
+      name: 'Revokee',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.read.all'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'revokee', pluginSource: '' })
+
+    host.revokePermission('revokee', 'vault.read.all')
+    fake.inject({ type: 'worker:requestVaultRead', seq: 13, mode: 'all' })
+    await flush()
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultReadResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultReadResult') {
+      expect(reply.ok).toBe(false)
+      expect(reply.requestSeq).toBe(13)
+      expect(reply.error).toMatch(/revoked/)
+    }
+  })
+
+  test('restorePermission re-enables after a revoke', async () => {
+    const fake = makeFakeWorker({
+      id: 'flap',
+      name: 'Flap',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.read.all'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const events: string[] = []
+    host.on((e) => events.push(e.type))
+    await host.load({ pluginId: 'flap', pluginSource: '' })
+
+    host.revokePermission('flap', 'vault.read.all')
+    expect(host.hasPermission('flap', 'vault.read.all')).toBe(false)
+    host.restorePermission('flap', 'vault.read.all')
+    expect(host.hasPermission('flap', 'vault.read.all')).toBe(true)
+
+    fake.inject({ type: 'worker:requestVaultRead', seq: 17, mode: 'all' })
+    await flush()
+    expect(events).toContain('vaultReadRequested')
+  })
+
+  test('respondVaultRead routes the snapshot back to the worker', async () => {
+    const fake = makeFakeWorker({
+      id: 'h',
+      name: 'H',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.read.all'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'h', pluginSource: '' })
+
+    host.respondVaultRead('h', 99, {
+      ok: true,
+      notes: [
+        { id: 'a', title: 'A', folderPath: '', body: 'x', frontmatter: null, updatedAt: 1 },
+      ],
+    })
+
+    const reply = fake.sent.find((m) => m.type === 'host:vaultReadResult')
+    expect(reply).toBeDefined()
+    if (reply && reply.type === 'host:vaultReadResult') {
+      expect(reply.ok).toBe(true)
+      expect(reply.requestSeq).toBe(99)
+      expect(reply.notes?.[0].id).toBe('a')
+    }
+  })
+
+  test('respondVaultStreamChunk passes chunkIndex + notes through', async () => {
+    const fake = makeFakeWorker({
+      id: 's',
+      name: 'S',
+      version: '1.0.0',
+      surfaces: { commands: [{ id: 'go', title: 'Go' }] },
+      permissions: ['vault.read.all'],
+    })
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 's', pluginSource: '' })
+
+    host.respondVaultStreamChunk('s', 21, {
+      chunkIndex: 1,
+      notes: [
+        { id: 'a', title: 'A', folderPath: '', body: 'x', frontmatter: null, updatedAt: 1 },
+      ],
+    })
+    host.respondVaultStreamChunk('s', 21, { chunkIndex: 2, notes: [] })
+
+    const chunks = fake.sent.filter((m) => m.type === 'host:vaultStreamChunk') as Array<
+      Extract<HostToWorker, { type: 'host:vaultStreamChunk' }>
+    >
+    expect(chunks).toHaveLength(2)
+    expect(chunks[0].chunkIndex).toBe(1)
+    expect(chunks[0].notes).toHaveLength(1)
+    expect(chunks[1].chunkIndex).toBe(2)
+    expect(chunks[1].notes).toHaveLength(0)
+  })
+})

--- a/src/plugins/__tests__/vaultRead.test.ts
+++ b/src/plugins/__tests__/vaultRead.test.ts
@@ -81,10 +81,11 @@ describe('manifest accepts vault.read.all', () => {
   })
 
   test('validator still rejects unknown permissions', () => {
-    const r = validateManifest({ ...base, permissions: ['vault.read.all', 'vault.write'] })
+    // PRs C/D/E/F each added a v1.2 permission; pick a name that has
+    // never shipped to verify the rejection arm still works.
+    const r = validateManifest({ ...base, permissions: ['vault.read.all', 'network.fetch'] })
     expect(r.ok).toBe(false)
-    // Error must mention the unknown one specifically.
-    expect(r.errors.some((e) => e.includes('vault.write'))).toBe(true)
+    expect(r.errors.some((e) => e.includes('network.fetch'))).toBe(true)
   })
 
   test('validator deduplicates a repeated vault.read.all', () => {

--- a/src/plugins/directoryPickerHelpers.ts
+++ b/src/plugins/directoryPickerHelpers.ts
@@ -1,0 +1,87 @@
+// Pure helpers extracted from pluginHostSingleton.ts so they can be
+// unit-tested in isolation. The singleton wires these into the live
+// host; this file owns the walking + filtering logic that survives
+// without a window / Zustand stores / toast adapter.
+//
+// See docs/plugins-v1.2-plan.md section 4.3 and
+// docs/plugins-v1.2-impl-notes.md PR E.
+
+import { MAX_DIRECTORY_ENTRIES } from './protocol'
+
+/** Minimal typing of the File System Access API directory handle shape
+ *  we touch. The full DOM lib's `FileSystemDirectoryHandle` is not in
+ *  every TS lib build (it landed in 2023), so we keep a local interface
+ *  the walker accepts. The shape matches the spec subset we read. */
+export interface FileSystemDirectoryHandleLike {
+  kind: 'directory'
+  name: string
+  values(): AsyncIterable<FileSystemHandleLike>
+}
+export type FileSystemHandleLike =
+  | FileSystemDirectoryHandleLike
+  | { kind: 'file'; name: string; getFile(): Promise<File> }
+
+/** Build a case-insensitive suffix matcher from the optional
+ *  `extensions` arg the plugin passed. Leading dots are normalised.
+ *  An empty / missing list matches every file. */
+export function buildExtensionMatcher(
+  extensions: string[] | undefined,
+): (name: string) => boolean {
+  if (!extensions || extensions.length === 0) return () => true
+  const norm = extensions.map((e) => (e.startsWith('.') ? e : `.${e}`).toLowerCase())
+  return (name: string) => {
+    const lower = name.toLowerCase()
+    for (const e of norm) {
+      if (lower.endsWith(e)) return true
+    }
+    return false
+  }
+}
+
+/** Recursively walk a `FileSystemDirectoryHandle`, returning every
+ *  file under it. Iterative DFS to avoid blowing the call stack on a
+ *  deep vault. Stops walking once the cap is crossed so a 1M-file
+ *  pick does not block the main thread for minutes — the caller turns
+ *  the over-cap return into a "Directory too large" error.
+ *
+ *  Symlink loops cannot recurse: the File System Access API does not
+ *  follow symlinks by spec. We also de-dupe on handle identity as a
+ *  defensive belt-and-braces (a future spec change cannot quietly
+ *  re-enable infinite recursion). */
+export async function walkDirectoryHandle(
+  root: FileSystemDirectoryHandleLike,
+  matcher: (name: string) => boolean,
+): Promise<Array<{ name: string; path: string; blob: Blob }>> {
+  const out: Array<{ name: string; path: string; blob: Blob }> = []
+  const visited = new Set<FileSystemDirectoryHandleLike>()
+  const stack: Array<{ handle: FileSystemDirectoryHandleLike; prefix: string }> = [
+    { handle: root, prefix: '' },
+  ]
+  while (stack.length > 0) {
+    if (out.length > MAX_DIRECTORY_ENTRIES) return out
+    const { handle, prefix } = stack.pop() as {
+      handle: FileSystemDirectoryHandleLike
+      prefix: string
+    }
+    if (visited.has(handle)) continue
+    visited.add(handle)
+    for await (const child of handle.values()) {
+      if (child.kind === 'directory') {
+        stack.push({
+          handle: child,
+          prefix: prefix ? `${prefix}/${child.name}` : child.name,
+        })
+        continue
+      }
+      if (!matcher(child.name)) continue
+      const file = await child.getFile()
+      out.push({
+        name: child.name,
+        path: prefix ? `${prefix}/${child.name}` : child.name,
+        blob: file as Blob,
+      })
+      if (out.length > MAX_DIRECTORY_ENTRIES) return out
+    }
+  }
+  return out
+}

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -62,18 +62,25 @@ export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
 /** Surface kinds the manifest can declare. Used by the install-preview
  *  modal to render a one-line explanation per kind alongside the count.
  *  Keep the prose short — these appear as bullets next to a count. */
-export type PluginSurfaceKind = 'commands' | 'sidebarPanels' | 'codeBlockRenderers'
+export type PluginSurfaceKind =
+  | 'commands'
+  | 'sidebarPanels'
+  | 'codeBlockRenderers'
+  | 'fullscreenViews'
 
 export const SURFACE_DESCRIPTIONS: Record<PluginSurfaceKind, string> = {
   commands: 'Adds entries to the command palette you can run with the keyboard.',
   sidebarPanels: 'Adds a panel to the sidebar showing plugin-rendered content.',
   codeBlockRenderers: 'Renders fenced code blocks of a given language inside notes.',
+  fullscreenViews:
+    'Opens a full-window view when the plugin asks. You can close it any time with Esc or the X button.',
 }
 
 export interface PluginSurfaces {
   commands?: PluginCommand[]
   sidebarPanels?: PluginSidebarPanel[]
   codeBlockRenderers?: PluginCodeBlockRenderer[]
+  fullscreenViews?: PluginFullscreenView[]
 }
 
 export interface PluginCommand {
@@ -99,6 +106,21 @@ export interface PluginCodeBlockRenderer {
    *  insensitive; the host lowercases on register. First plugin to
    *  claim a language wins; later registrations log a warning. */
   language: string
+}
+
+/** v1.2 PR B — a full-window view the plugin can request the host to
+ *  mount. Only one fullscreen view (across all installed plugins) is
+ *  open at a time; the host rejects a second `openFullscreen` call
+ *  while another view is showing. */
+export interface PluginFullscreenView {
+  /** Stable id within the plugin, kebab-case. Plugin references the
+   *  same id in `ctx.openFullscreen` / `setFullscreenContent`. */
+  id: string
+  /** Human title shown in the modal chrome. */
+  title: string
+  /** Heroicon name from the curated set, same contract as
+   *  `PluginSidebarPanel.icon`. */
+  icon?: string
 }
 
 /** Stable identifier shape: lowercase letters, digits, dashes; 2-60
@@ -171,6 +193,7 @@ export function validateManifest(input: unknown): ManifestValidationResult {
   const commands = validateCommands(surfaces.commands, errors)
   const sidebarPanels = validateSidebarPanels(surfaces.sidebarPanels, errors)
   const codeBlockRenderers = validateCodeBlockRenderers(surfaces.codeBlockRenderers, errors)
+  const fullscreenViews = validateFullscreenViews(surfaces.fullscreenViews, errors)
   const permissions = validatePermissions(m.permissions, errors)
 
   if (errors.length > 0) return { ok: false, errors }
@@ -180,11 +203,12 @@ export function validateManifest(input: unknown): ManifestValidationResult {
   const total =
     (commands?.length ?? 0) +
     (sidebarPanels?.length ?? 0) +
-    (codeBlockRenderers?.length ?? 0)
+    (codeBlockRenderers?.length ?? 0) +
+    (fullscreenViews?.length ?? 0)
   if (total === 0) {
     return {
       ok: false,
-      errors: ['Manifest must declare at least one surface (command, panel, or renderer).'],
+      errors: ['Manifest must declare at least one surface (command, panel, renderer, or fullscreen view).'],
     }
   }
 
@@ -200,6 +224,9 @@ export function validateManifest(input: unknown): ManifestValidationResult {
       ...(sidebarPanels && sidebarPanels.length > 0 ? { sidebarPanels } : {}),
       ...(codeBlockRenderers && codeBlockRenderers.length > 0
         ? { codeBlockRenderers }
+        : {}),
+      ...(fullscreenViews && fullscreenViews.length > 0
+        ? { fullscreenViews }
         : {}),
     },
     ...(permissions && permissions.length > 0 ? { permissions } : {}),
@@ -288,6 +315,49 @@ function validateCodeBlockRenderers(
     }
     return { language: r.language.toLowerCase() }
   }).filter((x): x is PluginCodeBlockRenderer => x !== null)
+}
+
+function validateFullscreenViews(
+  input: unknown,
+  errors: string[],
+): PluginFullscreenView[] | undefined {
+  if (input === undefined) return undefined
+  if (!Array.isArray(input)) {
+    errors.push('"surfaces.fullscreenViews" must be an array when present.')
+    return undefined
+  }
+  const seen = new Set<string>()
+  return input.map((entry, idx) => {
+    if (!isPlainObject(entry)) {
+      errors.push(`surfaces.fullscreenViews[${idx}] must be an object.`)
+      return null
+    }
+    const v = entry as Record<string, unknown>
+    if (typeof v.id !== 'string' || !ID_RE.test(v.id)) {
+      errors.push(`surfaces.fullscreenViews[${idx}].id must be lowercase kebab-case.`)
+      return null
+    }
+    if (typeof v.title !== 'string' || v.title.length === 0 || v.title.length > 80) {
+      errors.push(
+        `surfaces.fullscreenViews[${idx}].title must be a non-empty string up to 80 chars.`,
+      )
+      return null
+    }
+    if (v.icon !== undefined && typeof v.icon !== 'string') {
+      errors.push(`surfaces.fullscreenViews[${idx}].icon must be a string when present.`)
+      return null
+    }
+    if (seen.has(v.id)) {
+      errors.push(`surfaces.fullscreenViews[${idx}].id "${v.id}" is duplicated.`)
+      return null
+    }
+    seen.add(v.id)
+    return {
+      id: v.id,
+      title: v.title,
+      ...(typeof v.icon === 'string' ? { icon: v.icon } : {}),
+    }
+  }).filter((x): x is PluginFullscreenView => x !== null)
 }
 
 function validatePermissions(

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -32,17 +32,19 @@ export interface PluginManifest {
  *  by the validator. The host gates each runtime capability call against
  *  the granted set stored alongside the install record.
  *
- *  v1.1 added the two `file-*` capabilities; v1.2 starts layering the
- *  vault / fs capabilities. `vault.read.all` reads every note's body +
- *  frontmatter (PR C). `vault.events` subscribes to vault-change
- *  pulses (PR F). `fs.open-directory` pops the native directory picker
- *  for importer workflows (PR E). */
+ *  v1.1 added the two `file-*` capabilities; v1.2 layers in vault /
+ *  fs capabilities. PR C lands `vault.read.all` (read every note's
+ *  body + frontmatter); PR D lands `vault.write` (the first
+ *  DESTRUCTIVE permission — see below); PR E lands `fs.open-directory`
+ *  (native directory picker for importer workflows); PR F lands
+ *  `vault.events` (subscribe to vault-change pulses). */
 export const PERMISSIONS = [
   'file-save',         // v1.1
   'file-open',         // v1.1
-  'vault.read.all',    // v1.2 — see docs/plugins-v1.2-plan.md §4.1
-  'vault.events',      // v1.2 — see docs/plugins-v1.2-plan.md §4.4
-  'fs.open-directory', // v1.2 — see docs/plugins-v1.2-plan.md §4.3
+  'vault.read.all',    // v1.2 PR C — see docs/plugins-v1.2-plan.md §4.1
+  'vault.write',       // v1.2 PR D — see docs/plugins-v1.2-plan.md §4.2
+  'fs.open-directory', // v1.2 PR E — see docs/plugins-v1.2-plan.md §4.3
+  'vault.events',      // v1.2 PR F — see docs/plugins-v1.2-plan.md §4.4
 ] as const
 export type PluginPermission = (typeof PERMISSIONS)[number]
 
@@ -53,10 +55,26 @@ export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
   'file-open': 'Read a file you pick (opens the native file picker; the plugin sees the bytes of the file you choose, nothing else).',
   'vault.read.all':
     'Read the full content of every note in your vault. Required for features like backlinks, graph views, and AI search.',
+  'vault.write': 'This plugin can create, edit, and delete notes.',
   'vault.events':
     'Listen for changes to the vault. The plugin learns that a note was saved or that you switched notes (by id), but reading the body still requires a separate read permission.',
   'fs.open-directory':
     'Open folders to read files into the plugin. You pick the folder; the plugin sees the file names and contents under that folder, nothing else.',
+}
+
+/** Permissions flagged as DESTRUCTIVE in the install-confirm modal —
+ *  the user sees a red bullet + must opt-in. Required for any
+ *  capability that mutates vault contents.
+ *
+ *  v1.2 introduces `vault.write` as the first destructive permission.
+ *  Future destructive caps (e.g. `network.fetch`, `vault.hard-delete`)
+ *  add themselves here so the UI gating stays single-sourced. */
+export const DESTRUCTIVE_PERMISSIONS: ReadonlyArray<PluginPermission> = [
+  'vault.write',
+]
+
+export function isDestructivePermission(p: PluginPermission): boolean {
+  return DESTRUCTIVE_PERMISSIONS.includes(p)
 }
 
 /** Surface kinds the manifest can declare. Used by the install-preview

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -28,10 +28,19 @@ export interface PluginManifest {
   permissions?: PluginPermission[]
 }
 
-/** v1.1 capability identifiers. Unknown values are rejected by the
- *  validator. The host gates each runtime capability call against the
- *  granted set stored alongside the install record. */
-export const PERMISSIONS = ['file-save', 'file-open'] as const
+/** Capability identifiers known to the host. Unknown values are rejected
+ *  by the validator. The host gates each runtime capability call against
+ *  the granted set stored alongside the install record.
+ *
+ *  v1.1 added the two `file-*` capabilities; v1.2 starts layering the
+ *  vault / fs capabilities. `vault.read.all` is the first of the v1.2
+ *  set — it lets a plugin read every note's body + frontmatter, which
+ *  backlinks, AI-RAG, and graph-derivation plugins all need. */
+export const PERMISSIONS = [
+  'file-save',       // v1.1
+  'file-open',       // v1.1
+  'vault.read.all',  // v1.2 — see docs/plugins-v1.2-plan.md §4.1
+] as const
 export type PluginPermission = (typeof PERMISSIONS)[number]
 
 /** Human-readable text shown to the user in the install confirmation
@@ -39,6 +48,8 @@ export type PluginPermission = (typeof PERMISSIONS)[number]
 export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
   'file-save': 'Save a file to your computer (opens the native save dialog when the plugin needs to write a file).',
   'file-open': 'Read a file you pick (opens the native file picker; the plugin sees the bytes of the file you choose, nothing else).',
+  'vault.read.all':
+    'Read the full content of every note in your vault. Required for features like backlinks, graph views, and AI search.',
 }
 
 /** Surface kinds the manifest can declare. Used by the install-preview

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -33,14 +33,16 @@ export interface PluginManifest {
  *  the granted set stored alongside the install record.
  *
  *  v1.1 added the two `file-*` capabilities; v1.2 starts layering the
- *  vault / fs capabilities. `vault.read.all` lets a plugin read every
- *  note's body + frontmatter (PR C). `vault.events` lets a plugin
- *  subscribe to vault-change pulses (PR F). */
+ *  vault / fs capabilities. `vault.read.all` reads every note's body +
+ *  frontmatter (PR C). `vault.events` subscribes to vault-change
+ *  pulses (PR F). `fs.open-directory` pops the native directory picker
+ *  for importer workflows (PR E). */
 export const PERMISSIONS = [
-  'file-save',       // v1.1
-  'file-open',       // v1.1
-  'vault.read.all',  // v1.2 — see docs/plugins-v1.2-plan.md §4.1
-  'vault.events',    // v1.2 — see docs/plugins-v1.2-plan.md §4.4
+  'file-save',         // v1.1
+  'file-open',         // v1.1
+  'vault.read.all',    // v1.2 — see docs/plugins-v1.2-plan.md §4.1
+  'vault.events',      // v1.2 — see docs/plugins-v1.2-plan.md §4.4
+  'fs.open-directory', // v1.2 — see docs/plugins-v1.2-plan.md §4.3
 ] as const
 export type PluginPermission = (typeof PERMISSIONS)[number]
 
@@ -51,7 +53,10 @@ export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
   'file-open': 'Read a file you pick (opens the native file picker; the plugin sees the bytes of the file you choose, nothing else).',
   'vault.read.all':
     'Read the full content of every note in your vault. Required for features like backlinks, graph views, and AI search.',
-  'vault.events': 'Listen for changes to the vault. The plugin learns that a note was saved or that you switched notes (by id), but reading the body still requires a separate read permission.',
+  'vault.events':
+    'Listen for changes to the vault. The plugin learns that a note was saved or that you switched notes (by id), but reading the body still requires a separate read permission.',
+  'fs.open-directory':
+    'Open folders to read files into the plugin. You pick the folder; the plugin sees the file names and contents under that folder, nothing else.',
 }
 
 /** Surface kinds the manifest can declare. Used by the install-preview

--- a/src/plugins/manifest.ts
+++ b/src/plugins/manifest.ts
@@ -33,13 +33,14 @@ export interface PluginManifest {
  *  the granted set stored alongside the install record.
  *
  *  v1.1 added the two `file-*` capabilities; v1.2 starts layering the
- *  vault / fs capabilities. `vault.read.all` is the first of the v1.2
- *  set — it lets a plugin read every note's body + frontmatter, which
- *  backlinks, AI-RAG, and graph-derivation plugins all need. */
+ *  vault / fs capabilities. `vault.read.all` lets a plugin read every
+ *  note's body + frontmatter (PR C). `vault.events` lets a plugin
+ *  subscribe to vault-change pulses (PR F). */
 export const PERMISSIONS = [
   'file-save',       // v1.1
   'file-open',       // v1.1
   'vault.read.all',  // v1.2 — see docs/plugins-v1.2-plan.md §4.1
+  'vault.events',    // v1.2 — see docs/plugins-v1.2-plan.md §4.4
 ] as const
 export type PluginPermission = (typeof PERMISSIONS)[number]
 
@@ -50,6 +51,7 @@ export const PERMISSION_DESCRIPTIONS: Record<PluginPermission, string> = {
   'file-open': 'Read a file you pick (opens the native file picker; the plugin sees the bytes of the file you choose, nothing else).',
   'vault.read.all':
     'Read the full content of every note in your vault. Required for features like backlinks, graph views, and AI search.',
+  'vault.events': 'Listen for changes to the vault. The plugin learns that a note was saved or that you switched notes (by id), but reading the body still requires a separate read permission.',
 }
 
 /** Surface kinds the manifest can declare. Used by the install-preview

--- a/src/plugins/pluginHostSingleton.ts
+++ b/src/plugins/pluginHostSingleton.ts
@@ -26,6 +26,13 @@ import { useWorkspaceStore } from '@/stores/workspaceStore'
 import { fetchPluginFromUrl, fetchPluginFromManifest, sha256Hex } from './installer'
 import type { VaultManifestCandidate } from './vaultScan'
 import { bootMark, bootMeasure, yieldToMain } from '@/utils/bootTrace'
+import {
+  snapshotAllNotes,
+  snapshotNoteById,
+  streamVaultSnapshot,
+  projectPayloadSize,
+  MAX_GET_ALL_BYTES,
+} from './vaultSnapshot'
 
 let instance: PluginHost | null = null
 
@@ -124,6 +131,13 @@ export async function confirmAndInstallPlugin(record: InstalledPluginRecord): Pr
     pluginId: record.manifest.id,
     pluginSource: record.mainSource,
   })
+  // Apply any persisted revocations from previous sessions. Without
+  // this a user who revokes a capability, restarts the app, and lets
+  // the bootstrap reload the plugin would silently regain the
+  // capability on next call.
+  for (const perm of record.revokedPermissions ?? []) {
+    host.revokePermission(record.manifest.id, perm)
+  }
 }
 
 /**
@@ -182,6 +196,14 @@ export async function bootstrapInstalledPlugins(): Promise<void> {
         pluginId: record.manifest.id,
         pluginSource: record.mainSource,
       })
+      // Re-apply persisted capability revocations from previous
+      // sessions before the worker gets a chance to make any
+      // capability call from onActivate (the load() above already
+      // ran onActivate, but the worker can also fire requests on
+      // the next event loop tick — better to apply right away).
+      for (const perm of record.revokedPermissions ?? []) {
+        host.revokePermission(record.manifest.id, perm)
+      }
     } catch (err) {
       // The host emits bootError separately, which lands in the toast
       // via the listener. Swallow here so one bad plugin does not
@@ -193,6 +215,27 @@ export async function bootstrapInstalledPlugins(): Promise<void> {
 
   bootMark('plugin-bootstrap:end')
   bootMeasure('plugin-bootstrap', 'plugin-bootstrap:start', 'plugin-bootstrap:end')
+}
+
+/**
+ * Toggle a capability grant for an already-installed plugin. Writes
+ * through to BOTH the persisted install record (so the change survives
+ * a reload) and the in-memory PluginHost (so the next capability call
+ * from the running worker rejects immediately).
+ *
+ * No-op when the plugin is unknown. Idempotent for the same value.
+ */
+export function setPluginPermissionRevoked(
+  pluginId: string,
+  permission: import('./manifest').PluginPermission,
+  revoked: boolean,
+): void {
+  usePluginInstallStore.getState().setPermissionRevoked(pluginId, permission, revoked)
+  const host = getPluginHost()
+  if (host) {
+    if (revoked) host.revokePermission(pluginId, permission)
+    else host.restorePermission(pluginId, permission)
+  }
 }
 
 /**
@@ -360,8 +403,118 @@ function wireListener(host: PluginHost): void {
       case 'fileOpenRequested':
         void handleFileOpenRequest(host, event)
         return
+
+      case 'vaultReadRequested':
+        void handleVaultReadRequest(host, event)
+        return
     }
   })
+}
+
+/**
+ * Snapshot the active note store, serialise to plain objects, and post
+ * back to the plugin worker. The `vault.read.all` permission gate has
+ * already been checked in PluginHost; this handler only owns the
+ * snapshot + chunking work.
+ *
+ * Per the perf budget (docs/plugins-v1.2-plan.md §9 + issue #79) the
+ * snapshot may not block the main thread for more than 50 ms on a
+ * 5000-note vault. The streaming path yields between chunks via the
+ * shared `streamVaultSnapshot` helper; the one-shot `getAllNotes` path
+ * relies on the post-snapshot SHA cache (a second call within the same
+ * SHA is a single hash compare).
+ */
+async function handleVaultReadRequest(
+  host: PluginHost,
+  event: Extract<import('./PluginHost').PluginHostEvent, { type: 'vaultReadRequested' }>,
+): Promise<void> {
+  const { pluginId, requestSeq, mode, noteId, chunkSize } = event
+
+  // Guard: the note store hydrates from IndexedDB at boot. A plugin
+  // that fires `getAllNotes()` from `onActivate` may race the hydrate;
+  // surface a clear retry message instead of returning an empty array
+  // that the plugin would silently cache.
+  const notes = useNoteStore.getState().notes
+  const hasHydratedState = (useNoteStore as unknown as {
+    persist?: { hasHydrated: () => boolean }
+  }).persist
+  if (hasHydratedState && typeof hasHydratedState.hasHydrated === 'function' && !hasHydratedState.hasHydrated() && notes.length === 0) {
+    if (mode === 'stream') {
+      host.respondVaultStreamChunk(pluginId, requestSeq, {
+        chunkIndex: 0,
+        notes: [],
+        error: 'Vault not yet loaded.',
+      })
+    } else {
+      host.respondVaultRead(pluginId, requestSeq, { ok: false, error: 'Vault not yet loaded.' })
+    }
+    return
+  }
+
+  try {
+    if (mode === 'one') {
+      const note = snapshotNoteById(noteId ?? '')
+      host.respondVaultRead(pluginId, requestSeq, { ok: true, note })
+      return
+    }
+
+    if (mode === 'all') {
+      const snapshot = snapshotAllNotes()
+      const bytes = projectPayloadSize(snapshot)
+      if (bytes > MAX_GET_ALL_BYTES) {
+        host.respondVaultRead(pluginId, requestSeq, {
+          ok: false,
+          error: 'Vault too large; use stream().',
+        })
+        return
+      }
+      host.respondVaultRead(pluginId, requestSeq, { ok: true, notes: snapshot })
+      return
+    }
+
+    // mode === 'stream' — paginate, yielding between chunks. We poll
+    // the host's revocation state before every chunk so a mid-flight
+    // toggle in Settings terminates the iterator with a clear error.
+    let chunkIndexEmitted = 0
+    await streamVaultSnapshot({
+      ...(typeof chunkSize === 'number' ? { chunkSize } : {}),
+      isAborted: () =>
+        host.hasPermission(pluginId, 'vault.read.all')
+          ? null
+          : 'Permission "vault.read.all" was revoked.',
+      onChunk: (slice, chunkIndex) => {
+        chunkIndexEmitted = chunkIndex
+        host.respondVaultStreamChunk(pluginId, requestSeq, {
+          chunkIndex,
+          notes: slice,
+        })
+      },
+      onAbort: (reason) => {
+        host.respondVaultStreamChunk(pluginId, requestSeq, {
+          chunkIndex: chunkIndexEmitted + 1,
+          notes: [],
+          error: reason,
+        })
+      },
+      onEnd: () => {
+        host.respondVaultStreamChunk(pluginId, requestSeq, {
+          chunkIndex: chunkIndexEmitted + 1,
+          notes: [],
+        })
+      },
+    })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (mode === 'stream') {
+      host.respondVaultStreamChunk(pluginId, requestSeq, {
+        chunkIndex: 0,
+        notes: [],
+        error: message,
+      })
+    } else {
+      host.respondVaultRead(pluginId, requestSeq, { ok: false, error: message })
+    }
+  }
 }
 
 /** Open the native save dialog, write the plugin's bytes to it.

--- a/src/plugins/pluginHostSingleton.ts
+++ b/src/plugins/pluginHostSingleton.ts
@@ -513,6 +513,24 @@ function wireListener(host: PluginHost): void {
       case 'directoryOpenRequested':
         void handleDirectoryOpenRequest(host, event)
         return
+
+      case 'fullscreenOpenRequested':
+        handleFullscreenOpenRequest(host, event)
+        return
+
+      case 'fullscreenCloseRequested':
+        handleFullscreenCloseRequest(host, event)
+        return
+
+      case 'fullscreenContent':
+        // Plugin pushed new content for its open fullscreen view. The
+        // store ignores updates for views that are not active, so a
+        // plugin that races a setFullscreenContent with a close does
+        // not zombie state in.
+        usePluginStore
+          .getState()
+          .updateActiveFullscreenContent(event.pluginId, event.viewId, event.node)
+        return
     }
   })
 }
@@ -621,6 +639,104 @@ async function handleVaultReadRequest(
       host.respondVaultRead(pluginId, requestSeq, { ok: false, error: message })
     }
   }
+}
+
+/**
+ * v1.2 PR B — host-side fullscreen lifecycle.
+ *
+ * Single-view invariant: only one fullscreen view is mounted at a
+ * time, across all installed plugins. When a second plugin (or the
+ * same plugin twice) calls `openFullscreen` we REJECT rather than
+ * replace — replacing would silently kill the original view's state
+ * and surprise the user mid-flow. The error message names the
+ * conflict so the plugin can fall back gracefully.
+ *
+ * Note focus loss: opening a fullscreen view does NOT suspend the
+ * editor, and does NOT auto-close when the active note changes. The
+ * plugin is in control. The store-backed view persists until the
+ * user dismisses (X, Esc) or the plugin calls `closeFullscreen`.
+ * That matches the plan section 3.1 decision and the issue #71 graph
+ * + issue #70 chat use cases, both of which need to stay open across
+ * note switches.
+ */
+function handleFullscreenOpenRequest(
+  host: PluginHost,
+  event: Extract<import('./PluginHost').PluginHostEvent, { type: 'fullscreenOpenRequested' }>,
+): void {
+  const { pluginId, requestSeq, viewId } = event
+  const store = usePluginStore.getState()
+
+  // Single-view invariant. PluginHost already validated the view id
+  // against the manifest; this is the cross-plugin coordination
+  // check.
+  if (store.activeFullscreen !== null) {
+    host.respondFullscreenOpen(pluginId, requestSeq, {
+      ok: false,
+      error: 'Another fullscreen view is already open.',
+    })
+    return
+  }
+
+  const plugin = store.loaded[pluginId]
+  if (!plugin) {
+    host.respondFullscreenOpen(pluginId, requestSeq, {
+      ok: false,
+      error: 'Plugin is not loaded.',
+    })
+    return
+  }
+
+  const view = plugin.manifest.surfaces.fullscreenViews?.find((v) => v.id === viewId)
+  if (!view) {
+    // Defence in depth — PluginHost checks the same condition, but
+    // the manifest snapshot here might be newer.
+    host.respondFullscreenOpen(pluginId, requestSeq, {
+      ok: false,
+      error: `Fullscreen view "${viewId}" is not declared in the manifest.`,
+    })
+    return
+  }
+
+  store.setActiveFullscreen({
+    pluginId,
+    pluginName: plugin.manifest.name,
+    viewId,
+    title: view.title,
+    node: null,
+  })
+
+  host.respondFullscreenOpen(pluginId, requestSeq, { ok: true })
+  // Notify the worker AFTER resolving the open promise so the
+  // plugin's openFullscreen() awaits cleanly; the mount handler then
+  // emits the initial setFullscreenContent.
+  host.notifyFullscreenOpened(pluginId, viewId)
+}
+
+function handleFullscreenCloseRequest(
+  host: PluginHost,
+  event: Extract<import('./PluginHost').PluginHostEvent, { type: 'fullscreenCloseRequested' }>,
+): void {
+  const { pluginId, viewId } = event
+  const cur = usePluginStore.getState().activeFullscreen
+  // Silently no-op when the request does not match the currently
+  // open view. Lets a plugin call closeFullscreen defensively
+  // without spamming errors.
+  if (!cur || cur.pluginId !== pluginId || cur.viewId !== viewId) return
+  usePluginStore.getState().setActiveFullscreen(null)
+  host.notifyFullscreenClosed(pluginId, viewId)
+}
+
+/**
+ * Surfaced to the host modal component — when the user hits X or
+ * Esc, the modal calls this to tear the view down and notify the
+ * plugin. Imported by `PluginFullscreenView.tsx`.
+ */
+export function dismissActiveFullscreen(): void {
+  const host = getPluginHost()
+  const cur = usePluginStore.getState().activeFullscreen
+  if (!cur) return
+  usePluginStore.getState().setActiveFullscreen(null)
+  if (host) host.notifyFullscreenClosed(cur.pluginId, cur.viewId)
 }
 
 /** Open the native save dialog, write the plugin's bytes to it.

--- a/src/plugins/pluginHostSingleton.ts
+++ b/src/plugins/pluginHostSingleton.ts
@@ -16,7 +16,7 @@
 // safety: the function returns null on the server, since Workers do
 // not exist there.
 
-import { PluginHost, type MinimalWorker } from './PluginHost'
+import { PluginHost, type MinimalWorker, type VaultWriteOp } from './PluginHost'
 import { MAX_DIRECTORY_ENTRIES } from './protocol'
 import {
   buildExtensionMatcher,
@@ -39,6 +39,7 @@ import {
   projectPayloadSize,
   MAX_GET_ALL_BYTES,
 } from './vaultSnapshot'
+import { recordPluginWrite } from '@/utils/pluginAudit'
 
 let instance: PluginHost | null = null
 
@@ -531,6 +532,10 @@ function wireListener(host: PluginHost): void {
           .getState()
           .updateActiveFullscreenContent(event.pluginId, event.viewId, event.node)
         return
+
+      case 'vaultWriteRequested':
+        handleVaultWriteRequest(host, event)
+        return
     }
   })
 }
@@ -828,6 +833,311 @@ async function handleFileOpenRequest(
       host.respondFileOpen(pluginId, requestSeq, { ok: false, error: message })
     }
   }
+}
+
+// ─── vault.write capability (PR D) ─────────────────────────────────────────
+//
+// The host writes through the same `useNoteStore.addNote` / `updateNote` /
+// `deleteNote` and `useFolderStore.addFolder` / `ensureFolderPath` paths a
+// user action would use, so sync, indexing, undo, and the Trash UI all
+// behave identically whether the user or a plugin made the change.
+//
+// Conflict resolution: when a `create` lands a title that already
+// exists in the target folder, the host appends " (imported)" to the
+// title and reports `conflictResolved: 'suffix'`. The policy lives
+// here — the importer plugin gets the conflict outcome for free in
+// its progress log and never has to retry.
+//
+// Audit: every accepted op (and every rejection that survives the
+// permission gate) calls recordPluginWrite. Destructive permission
+// demands traceability.
+
+const MAX_TITLE_LEN = 200
+const MAX_BODY_BYTES = 1 * 1024 * 1024 // 1 MiB cap; matches plan §4.2.
+const FOLDER_PATH_RE = /^[^\s/][^/]*(\/[^\s/][^/]*)*$/
+
+function handleVaultWriteRequest(
+  host: PluginHost,
+  event: Extract<import('./PluginHost').PluginHostEvent, { type: 'vaultWriteRequested' }>,
+): void {
+  const { pluginId, requestSeq, op } = event
+  try {
+    switch (op.kind) {
+      case 'create': {
+        const result = applyCreate(pluginId, op)
+        host.respondVaultWrite(pluginId, requestSeq, {
+          ok: true,
+          id: result.id,
+          conflictResolved: result.conflictResolved,
+        })
+        recordPluginWrite({
+          pluginId,
+          op: 'create',
+          target: result.id,
+          ok: true,
+          conflictResolved: result.conflictResolved,
+        })
+        return
+      }
+      case 'update': {
+        applyUpdate(pluginId, op)
+        host.respondVaultWrite(pluginId, requestSeq, { ok: true })
+        recordPluginWrite({ pluginId, op: 'update', target: op.id, ok: true })
+        return
+      }
+      case 'delete': {
+        applyDelete(pluginId, op)
+        host.respondVaultWrite(pluginId, requestSeq, { ok: true })
+        recordPluginWrite({ pluginId, op: 'delete', target: op.id, ok: true })
+        return
+      }
+      case 'createFolder': {
+        applyCreateFolder(pluginId, op)
+        host.respondVaultWrite(pluginId, requestSeq, { ok: true })
+        recordPluginWrite({
+          pluginId,
+          op: 'createFolder',
+          target: op.path,
+          ok: true,
+        })
+        return
+      }
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    host.respondVaultWrite(pluginId, requestSeq, { ok: false, error: message })
+    recordPluginWrite({
+      pluginId,
+      op: op.kind,
+      target: extractTarget(op),
+      ok: false,
+      error: message,
+    })
+  }
+}
+
+function extractTarget(op: VaultWriteOp): string {
+  switch (op.kind) {
+    case 'create':
+      return op.title
+    case 'update':
+    case 'delete':
+      return op.id
+    case 'createFolder':
+      return op.path
+  }
+}
+
+/** Resolve a forward-slash folder path to an existing folder id (or
+ *  null for the root). Creates missing segments via
+ *  `useFolderStore.ensureFolderPath` — the same code path the importer
+ *  and pull layer use for "given a path, give me an id". */
+function resolveFolderPath(folderPath: string | undefined): string | null {
+  if (!folderPath || folderPath.length === 0) return null
+  const segments = folderPath.split('/').filter((s) => s.length > 0)
+  if (segments.length === 0) return null
+  return useFolderStore.getState().ensureFolderPath(segments)
+}
+
+function applyCreate(
+  _pluginId: string,
+  op: Extract<VaultWriteOp, { kind: 'create' }>,
+): { id: string; conflictResolved: 'none' | 'suffix' } {
+  const title = (op.title ?? '').trim()
+  if (title.length === 0) throw new Error('createNote: title is required.')
+  if (title.length > MAX_TITLE_LEN) {
+    throw new Error(`createNote: title exceeds ${MAX_TITLE_LEN} chars.`)
+  }
+  const body = op.body ?? ''
+  if (byteLength(body) > MAX_BODY_BYTES) {
+    throw new Error(`createNote: body exceeds ${MAX_BODY_BYTES} bytes.`)
+  }
+  if (op.folderPath !== undefined && op.folderPath.length > 0) {
+    if (!FOLDER_PATH_RE.test(op.folderPath)) {
+      throw new Error(`createNote: invalid folderPath "${op.folderPath}".`)
+    }
+  }
+
+  const folderId = resolveFolderPath(op.folderPath)
+  const noteStore = useNoteStore.getState()
+
+  // Conflict resolution: look for an active (non-trashed) note with the
+  // same title in the same folder. If found, append " (imported)". If
+  // that ALSO collides, append a numeric suffix. The latter case is rare
+  // (two imports of the same source) but we never want to bail entirely.
+  const { resolvedTitle, conflictResolved } = resolveTitleConflict(
+    title,
+    folderId,
+    noteStore.notes,
+  )
+
+  const finalContent = composeContent(resolvedTitle, body, op.frontmatter)
+  const created = noteStore.addNote({
+    title: resolvedTitle,
+    content: finalContent,
+    folderId,
+  })
+  return { id: created.id, conflictResolved }
+}
+
+function applyUpdate(
+  _pluginId: string,
+  op: Extract<VaultWriteOp, { kind: 'update' }>,
+): void {
+  const noteStore = useNoteStore.getState()
+  const note = noteStore.notes.find((n) => n.id === op.id)
+  if (!note || note.isDeleted) {
+    throw new Error(`updateNote: note "${op.id}" does not exist.`)
+  }
+  if (op.body !== undefined && byteLength(op.body) > MAX_BODY_BYTES) {
+    throw new Error(`updateNote: body exceeds ${MAX_BODY_BYTES} bytes.`)
+  }
+  if (op.title !== undefined) {
+    const t = op.title.trim()
+    if (t.length === 0 || t.length > MAX_TITLE_LEN) {
+      throw new Error(`updateNote: title must be 1-${MAX_TITLE_LEN} chars.`)
+    }
+  }
+
+  const patch: { title?: string; content?: string } = {}
+  if (op.title !== undefined) patch.title = op.title.trim()
+  if (op.body !== undefined || op.frontmatter !== undefined) {
+    // Re-compose. If only one of the two was supplied, preserve the
+    // other from the existing note content.
+    const nextTitle = op.title?.trim() ?? note.title ?? 'Untitled'
+    const nextBody = op.body !== undefined ? op.body : stripFrontmatter(note.content ?? '').body
+    const nextFrontmatter =
+      op.frontmatter !== undefined
+        ? op.frontmatter
+        : stripFrontmatter(note.content ?? '').frontmatter
+    patch.content = composeContent(nextTitle, nextBody, nextFrontmatter)
+  }
+  noteStore.updateNote(op.id, patch)
+}
+
+function applyDelete(
+  _pluginId: string,
+  op: Extract<VaultWriteOp, { kind: 'delete' }>,
+): void {
+  const noteStore = useNoteStore.getState()
+  const note = noteStore.notes.find((n) => n.id === op.id)
+  if (!note || note.isDeleted) {
+    throw new Error(`deleteNote: note "${op.id}" does not exist.`)
+  }
+  // SOFT-delete only — the plan §4.2 forbids hard-delete from a
+  // plugin. The note remains recoverable from the Trash UI.
+  noteStore.deleteNote(op.id)
+}
+
+function applyCreateFolder(
+  _pluginId: string,
+  op: Extract<VaultWriteOp, { kind: 'createFolder' }>,
+): void {
+  if (!FOLDER_PATH_RE.test(op.path)) {
+    throw new Error(`createFolder: invalid path "${op.path}".`)
+  }
+  const segments = op.path.split('/').filter((s) => s.length > 0)
+  if (segments.length === 0) throw new Error('createFolder: path is empty.')
+  useFolderStore.getState().ensureFolderPath(segments)
+}
+
+function resolveTitleConflict(
+  desired: string,
+  folderId: string | null,
+  notes: ReadonlyArray<{ id: string; title?: string; folderId: string | null; isDeleted: boolean }>,
+): { resolvedTitle: string; conflictResolved: 'none' | 'suffix' } {
+  const samFolderActive = notes.filter(
+    (n) => !n.isDeleted && (n.folderId ?? null) === folderId,
+  )
+  const titles = new Set(samFolderActive.map((n) => (n.title ?? '').toLowerCase()))
+  if (!titles.has(desired.toLowerCase())) {
+    return { resolvedTitle: desired, conflictResolved: 'none' }
+  }
+  let candidate = `${desired} (imported)`
+  let n = 2
+  while (titles.has(candidate.toLowerCase())) {
+    candidate = `${desired} (imported ${n})`
+    n++
+  }
+  return { resolvedTitle: candidate, conflictResolved: 'suffix' }
+}
+
+function byteLength(s: string): number {
+  if (typeof TextEncoder !== 'undefined') {
+    return new TextEncoder().encode(s).length
+  }
+  // Rough fallback for environments without TextEncoder (none we ship
+  // to; included so unit tests in node-without-DOM don't trip).
+  return s.length
+}
+
+/** Compose the on-disk note content: optional frontmatter block first,
+ *  then the body. Matches the canonical layout the importer / GitHub
+ *  push layer produce so a plugin-created note round-trips identically. */
+function composeContent(
+  _title: string,
+  body: string,
+  frontmatter: Record<string, unknown> | undefined,
+): string {
+  if (!frontmatter || Object.keys(frontmatter).length === 0) return body
+  const lines = ['---']
+  for (const [k, v] of Object.entries(frontmatter)) {
+    lines.push(`${k}: ${serialiseFrontmatterValue(v)}`)
+  }
+  lines.push('---')
+  lines.push('')
+  lines.push(body)
+  return lines.join('\n')
+}
+
+function serialiseFrontmatterValue(v: unknown): string {
+  if (v === null || v === undefined) return ''
+  if (typeof v === 'number' || typeof v === 'boolean') return String(v)
+  if (Array.isArray(v)) {
+    return `[${v.map((x) => serialiseFrontmatterValue(x)).join(', ')}]`
+  }
+  if (typeof v === 'object') return JSON.stringify(v)
+  const s = String(v)
+  return /[:#\[\]{}|>"'\n]/.test(s) ? JSON.stringify(s) : s
+}
+
+/** Split a note body into its frontmatter (parsed) + body. Used by the
+ *  update path so a partial patch ({ body } OR { frontmatter }) leaves
+ *  the other half alone. */
+function stripFrontmatter(content: string): {
+  frontmatter: Record<string, unknown> | undefined
+  body: string
+} {
+  if (!content.startsWith('---\n')) return { frontmatter: undefined, body: content }
+  const end = content.indexOf('\n---', 4)
+  if (end < 0) return { frontmatter: undefined, body: content }
+  const block = content.slice(4, end)
+  const after = content.slice(end + 4).replace(/^\n/, '')
+  const fm: Record<string, unknown> = {}
+  for (const line of block.split('\n')) {
+    const idx = line.indexOf(':')
+    if (idx < 0) continue
+    const k = line.slice(0, idx).trim()
+    const raw = line.slice(idx + 1).trim()
+    fm[k] = raw
+  }
+  return { frontmatter: fm, body: after }
+}
+
+/** Test-only: wire the vault.write handler onto a fresh PluginHost.
+ *
+ *  Production code uses `getPluginHost()` which lazily wires every
+ *  listener (including the file-I/O ones). Unit tests want to drive
+ *  the vault.write path in isolation against a FakeWorker, without
+ *  spinning up the toast / install store wiring. This export lets a
+ *  test subscribe just the vault.write event for the duration of the
+ *  test. Not for production use. */
+export function wireSingletonHandlersForTests(host: PluginHost): void {
+  host.on((event) => {
+    if (event.type === 'vaultWriteRequested') {
+      handleVaultWriteRequest(host, event)
+    }
+  })
 }
 
 function pickFileViaInput(accept: string[] | undefined): Promise<File> {

--- a/src/plugins/pluginHostSingleton.ts
+++ b/src/plugins/pluginHostSingleton.ts
@@ -17,6 +17,12 @@
 // not exist there.
 
 import { PluginHost, type MinimalWorker } from './PluginHost'
+import { MAX_DIRECTORY_ENTRIES } from './protocol'
+import {
+  buildExtensionMatcher,
+  walkDirectoryHandle,
+  type FileSystemDirectoryHandleLike,
+} from './directoryPickerHelpers'
 import { usePluginStore } from '@/stores/pluginStore'
 import { usePluginInstallStore, type InstalledPluginRecord } from '@/stores/pluginInstallStore'
 import { useToastStore } from '@/stores/toastStore'
@@ -503,6 +509,10 @@ function wireListener(host: PluginHost): void {
       case 'vaultReadRequested':
         void handleVaultReadRequest(host, event)
         return
+
+      case 'directoryOpenRequested':
+        void handleDirectoryOpenRequest(host, event)
+        return
     }
   })
 }
@@ -726,6 +736,137 @@ function pickFileViaInput(accept: string[] | undefined): Promise<File> {
     input.click()
   })
 }
+
+/**
+ * v1.2 `fs.open-directory` capability handler. Modern path uses
+ * `showDirectoryPicker` (Chrome / Edge / Opera) and walks the returned
+ * `FileSystemDirectoryHandle` recursively. Fallback path uses
+ * `<input type="file" webkitdirectory>` for Safari + Firefox — the
+ * existing single-file fallback at line ~458 above does NOT set
+ * `webkitdirectory`, so the directory equivalent lives here.
+ *
+ * Both paths return `Array<{ name, path, blob }>`. `path` is the
+ * forward-slash relative path inside the picked root; `blob` lets the
+ * plugin read each file's contents lazily.
+ *
+ * See plugins-v1.2-plan.md section 4.3 for the design.
+ */
+async function handleDirectoryOpenRequest(
+  host: PluginHost,
+  event: Extract<import('./PluginHost').PluginHostEvent, { type: 'directoryOpenRequested' }>,
+): Promise<void> {
+  const { pluginId, requestSeq, extensions } = event
+  // Manifest-level + runtime revocation gating already happened inside
+  // PluginHost.handleWorkerMessage (PR C unified that layer). By the
+  // time the singleton receives `directoryOpenRequested` the permission
+  // is known to be both declared AND not revoked.
+  const matcher = buildExtensionMatcher(extensions)
+  try {
+    const w = window as unknown as {
+      showDirectoryPicker?: () => Promise<FileSystemDirectoryHandleLike>
+    }
+    let entries: Array<{ name: string; path: string; blob: Blob }>
+    if (typeof w.showDirectoryPicker === 'function') {
+      const root = await w.showDirectoryPicker()
+      entries = await walkDirectoryHandle(root, matcher)
+    } else {
+      entries = await pickDirectoryViaInput(matcher)
+    }
+
+    if (entries.length > MAX_DIRECTORY_ENTRIES) {
+      host.respondDirectoryOpen(pluginId, requestSeq, {
+        ok: false,
+        error: `Directory too large: ${entries.length} entries exceeds the ${MAX_DIRECTORY_ENTRIES} cap.`,
+      })
+      return
+    }
+
+    host.respondDirectoryOpen(pluginId, requestSeq, { ok: true, entries })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    if (
+      message.includes('aborted') ||
+      message.includes('Abort') ||
+      message === 'cancelled'
+    ) {
+      // Cancellation is not an error from the plugin's view — return
+      // ok=true with no entries so ctx.fs.openDirectory resolves to
+      // `null`. Mirrors the file-open fallback shape above.
+      host.respondDirectoryOpen(pluginId, requestSeq, { ok: true })
+    } else {
+      host.respondDirectoryOpen(pluginId, requestSeq, { ok: false, error: message })
+    }
+  }
+}
+
+/** Safari + Firefox fallback. `<input type="file" webkitdirectory>`
+ *  surfaces every file under the picked folder, but unlike the single
+ *  `<input type=file>` fallback above this one has to handle:
+ *
+ *   - `webkitRelativePath` on each `File` (used as the `path`),
+ *   - the `cancel` event firing when the user dismisses the picker
+ *     (rejection path the unit tests cover).
+ *
+ *  The `accept` attribute is intentionally NOT set: webkitdirectory
+ *  ignores it on most browsers, and we filter host-side via `matcher`
+ *  anyway so the response stays consistent across paths. */
+function pickDirectoryViaInput(
+  matcher: (name: string) => boolean,
+): Promise<Array<{ name: string; path: string; blob: Blob }>> {
+  return new Promise((resolve, reject) => {
+    const input = document.createElement('input')
+    input.type = 'file'
+    // Non-standard but universally supported. The TS lib types it as a
+    // string attribute so we set it via `setAttribute` to avoid a cast.
+    input.setAttribute('webkitdirectory', '')
+    input.setAttribute('directory', '')
+    input.multiple = true
+    input.style.position = 'fixed'
+    input.style.left = '-9999px'
+
+    let settled = false
+    const cleanup = (): void => {
+      input.remove()
+    }
+
+    input.onchange = () => {
+      if (settled) return
+      settled = true
+      const files = input.files
+      cleanup()
+      if (!files || files.length === 0) {
+        reject(new Error('cancelled'))
+        return
+      }
+      const out: Array<{ name: string; path: string; blob: Blob }> = []
+      for (let i = 0; i < files.length; i++) {
+        const f = files[i]
+        if (!matcher(f.name)) continue
+        // webkitRelativePath includes the picked root's name as the
+        // first segment, e.g. "MyVault/notes/a.md". Strip it so the
+        // returned `path` is relative to the picked root, matching the
+        // showDirectoryPicker path.
+        const rel = (f as File & { webkitRelativePath?: string }).webkitRelativePath ?? f.name
+        const slashIdx = rel.indexOf('/')
+        const path = slashIdx >= 0 ? rel.slice(slashIdx + 1) : rel
+        out.push({ name: f.name, path, blob: f as Blob })
+      }
+      resolve(out)
+    }
+    // Cancellation: modern browsers fire `cancel` when the picker is
+    // dismissed without a selection. Unit-tested via the rejection
+    // path — see permissions.test.ts / dedicated suite.
+    input.addEventListener('cancel', () => {
+      if (settled) return
+      settled = true
+      cleanup()
+      reject(new Error('cancelled'))
+    })
+    document.body.appendChild(input)
+    input.click()
+  })
+}
+
 
 function acceptToTypes(accept: string[]): Record<string, string[]> {
   const out: Record<string, string[]> = {}

--- a/src/plugins/pluginHostSingleton.ts
+++ b/src/plugins/pluginHostSingleton.ts
@@ -41,9 +41,16 @@ let instance: PluginHost | null = null
 export function getPluginHost(): PluginHost | null {
   if (typeof window === 'undefined') return null
   if (instance === null) {
-    instance = new PluginHost({ createWorker: spawnPluginWorker })
+    instance = new PluginHost({
+      createWorker: spawnPluginWorker,
+      isPermissionRevoked: (pluginId, permission) => {
+        const rec = usePluginInstallStore.getState().records[pluginId]
+        return rec?.revokedPermissions?.includes(permission) ?? false
+      },
+    })
     wireListener(instance)
     wireActiveNoteTracker(instance)
+    wireVaultEvents(instance)
   }
   return instance
 }
@@ -321,6 +328,95 @@ function wireActiveNoteTracker(host: PluginHost): void {
       host.activeNoteChanged(event.pluginId, note)
     }
   })
+}
+
+/**
+ * Wire `vault.events` fan-out. Subscribes to the note + workspace +
+ * folder stores and translates each mutation into the right host call:
+ *
+ *   - Any noteStore / folderStore change → notifyVaultChanged()
+ *   - A `notes` array mutation that changes a note's content / title /
+ *     frontmatter (i.e. a save) → notifyNoteSaved(noteId)
+ *   - A workspace active-tab transition that resolves to a different
+ *     noteId → notifyActiveNoteIdChanged(noteId)
+ *
+ * The host debounces every signal at 250 ms (VAULT_EVENT_DEBOUNCE_MS),
+ * so this wrapper does NOT bother coalescing — it just dispatches as
+ * the store fires. Keystrokes in the editor are noisy; the debounce
+ * absorbs the burst.
+ */
+function wireVaultEvents(host: PluginHost): void {
+  type NoteSnap = { id: string; title: string; content: string; updatedAt: number; isDeleted: boolean }
+  let lastNotes: Map<string, NoteSnap> = snapshotNotes(useNoteStore.getState().notes)
+  let lastActiveNoteId: string | null = resolveActiveNoteId()
+
+  useNoteStore.subscribe((state) => {
+    const next = snapshotNotes(state.notes)
+    let vaultDirty = false
+
+    // Detect adds, deletions, and content / title changes.
+    for (const [id, cur] of next) {
+      const prev = lastNotes.get(id)
+      if (!prev) {
+        vaultDirty = true
+        host.notifyNoteSaved(id)
+        continue
+      }
+      if (
+        prev.content !== cur.content ||
+        prev.title !== cur.title ||
+        prev.isDeleted !== cur.isDeleted
+      ) {
+        vaultDirty = true
+        host.notifyNoteSaved(id)
+      }
+    }
+    for (const id of lastNotes.keys()) {
+      if (!next.has(id)) vaultDirty = true
+    }
+
+    if (vaultDirty) host.notifyVaultChanged()
+    lastNotes = next
+  })
+
+  useFolderStore.subscribe(() => {
+    host.notifyVaultChanged()
+  })
+
+  useWorkspaceStore.subscribe(() => {
+    const cur = resolveActiveNoteId()
+    if (cur !== lastActiveNoteId) {
+      lastActiveNoteId = cur
+      host.notifyActiveNoteIdChanged(cur)
+    }
+  })
+}
+
+function snapshotNotes(
+  notes: ReadonlyArray<{ id: string; title?: string; content?: string; updatedAt?: number; isDeleted?: boolean }>,
+): Map<string, { id: string; title: string; content: string; updatedAt: number; isDeleted: boolean }> {
+  const map = new Map<string, { id: string; title: string; content: string; updatedAt: number; isDeleted: boolean }>()
+  for (const n of notes) {
+    map.set(n.id, {
+      id: n.id,
+      title: n.title ?? '',
+      content: n.content ?? '',
+      updatedAt: n.updatedAt ?? 0,
+      isDeleted: n.isDeleted ?? false,
+    })
+  }
+  return map
+}
+
+function resolveActiveNoteId(): string | null {
+  const ws = useWorkspaceStore.getState()
+  const activePane = ws.panes.find((p) => p.id === ws.activePaneId) ?? ws.panes[0]
+  const activeTab = activePane?.tabs.find((t) => t.id === activePane?.activeTabId)
+  if (!activeTab) return null
+  if (activeTab.kind !== 'note') return null
+  const note = useNoteStore.getState().notes.find((n) => n.id === activeTab.noteId)
+  if (!note || note.isDeleted) return null
+  return note.id
 }
 
 function buildFolderPath(

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -57,6 +57,9 @@ export type HostToWorker =
   | HostNoteSavedEvent
   | HostActiveNoteIdChanged
   | HostDirectoryOpenResult
+  | HostFullscreenOpened
+  | HostFullscreenClosed
+  | HostFullscreenOpenResult
 
 /** First message the host sends. Worker initialises the plugin module
  *  and replies with WorkerReady on success or WorkerBootError on failure. */
@@ -248,6 +251,38 @@ export interface HostDirectoryOpenResult {
   error?: string
 }
 
+/** v1.2 PR B — fullscreen view surface. Sent after the host has
+ *  mounted the modal in response to a `worker:openFullscreen`. The
+ *  worker fires `onFullscreenMount` so the plugin can populate
+ *  content via `ctx.setFullscreenContent`. Fire-and-forget — the
+ *  response to the open request is `host:fullscreenOpenResult`. */
+export interface HostFullscreenOpened {
+  type: 'host:fullscreenOpened'
+  seq: number
+  viewId: string
+}
+
+/** v1.2 PR B — sent after the host has unmounted the modal (X click,
+ *  Esc, page unload, or `worker:closeFullscreen`). The worker fires
+ *  `onFullscreenUnmount`. */
+export interface HostFullscreenClosed {
+  type: 'host:fullscreenClosed'
+  seq: number
+  viewId: string
+}
+
+/** v1.2 PR B — host's reply to `worker:openFullscreen`. Carries
+ *  `ok: false` when the view id was not declared in the manifest
+ *  or when another fullscreen view is already open. Pairs by
+ *  `requestSeq` the same way `host:fileSaveResult` does. */
+export interface HostFullscreenOpenResult {
+  type: 'host:fullscreenOpenResult'
+  seq: number
+  requestSeq: number
+  ok: boolean
+  error?: string
+}
+
 // ─── Worker → Host ─────────────────────────────────────────────────────────
 
 export type WorkerToHost =
@@ -265,6 +300,9 @@ export type WorkerToHost =
   | WorkerError
   | WorkerSubscribeVault
   | WorkerUnsubscribeVault
+  | WorkerOpenFullscreen
+  | WorkerCloseFullscreen
+  | WorkerSetFullscreenContent
 
 /** Sent in reply to host:boot once the plugin module loaded and
  *  `definePlugin` ran. Includes the validated manifest, which the host
@@ -470,6 +508,38 @@ export interface WorkerRequestDirectoryOpen {
   extensions?: string[]
 }
 
+/** v1.2 PR B — plugin asking the host to mount the named fullscreen
+ *  view. Host validates the view id against the manifest's declared
+ *  `surfaces.fullscreenViews` and the single-open invariant before
+ *  mounting. Replies with `host:fullscreenOpenResult` keyed by
+ *  `requestSeq` so the plugin's Promise resolves to the right call. */
+export interface WorkerOpenFullscreen {
+  type: 'worker:openFullscreen'
+  seq: number
+  viewId: string
+}
+
+/** v1.2 PR B — plugin asking the host to unmount the current
+ *  fullscreen view. No reply; host emits `host:fullscreenClosed`
+ *  when the unmount lands so the plugin's `onFullscreenUnmount`
+ *  runs the same way an X / Esc dismiss does. */
+export interface WorkerCloseFullscreen {
+  type: 'worker:closeFullscreen'
+  seq: number
+  viewId: string
+}
+
+/** v1.2 PR B — plugin updating the fullscreen view's content tree.
+ *  Same VNode contract as `worker:setPanelContent`; the host runs
+ *  the value through the curated renderer. Silently dropped if the
+ *  named view is not currently open. */
+export interface WorkerSetFullscreenContent {
+  type: 'worker:setFullscreenContent'
+  seq: number
+  viewId: string
+  node: unknown
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 export function isHostToWorker(msg: unknown): msg is HostToWorker {
@@ -489,6 +559,9 @@ export function isHostToWorker(msg: unknown): msg is HostToWorker {
     'host:noteSaved',
     'host:activeNoteIdChanged',
     'host:directoryOpenResult',
+    'host:fullscreenOpened',
+    'host:fullscreenClosed',
+    'host:fullscreenOpenResult',
   ])
 }
 
@@ -508,6 +581,9 @@ export function isWorkerToHost(msg: unknown): msg is WorkerToHost {
     'worker:subscribeVault',
     'worker:unsubscribeVault',
     'worker:requestDirectoryOpen',
+    'worker:openFullscreen',
+    'worker:closeFullscreen',
+    'worker:setFullscreenContent',
   ])
 }
 

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -33,6 +33,12 @@ export const VAULT_EVENT_DEBOUNCE_MS = 250
  *  `onActiveNoteChange` calls synchronously beyond this. */
 export const MAX_VAULT_SUBSCRIPTIONS_PER_EVENT = 16
 
+/** Hard cap on entries returned from `fs.openDirectory`. Above this the
+ *  host rejects with "Directory too large". Prevents an accidental
+ *  whole-disk pick from emitting a multi-million-entry response. See
+ *  plugins-v1.2-plan.md section 4.3. */
+export const MAX_DIRECTORY_ENTRIES = 50_000
+
 // ─── Host → Worker ─────────────────────────────────────────────────────────
 
 export type HostToWorker =
@@ -50,6 +56,7 @@ export type HostToWorker =
   | HostVaultChangedEvent
   | HostNoteSavedEvent
   | HostActiveNoteIdChanged
+  | HostDirectoryOpenResult
 
 /** First message the host sends. Worker initialises the plugin module
  *  and replies with WorkerReady on success or WorkerBootError on failure. */
@@ -224,6 +231,23 @@ export interface HostVaultStreamChunk {
   error?: string
 }
 
+/** Host's reply to a worker:requestDirectoryOpen. Carries an array of
+ *  entries with their raw `Blob` so the plugin can read each file
+ *  lazily via `blob.text()` / `blob.arrayBuffer()`. v1.2 capability —
+ *  requires `fs.open-directory` permission. See plugins-v1.2-plan.md
+ *  section 4.3. */
+export interface HostDirectoryOpenResult {
+  type: 'host:directoryOpenResult'
+  seq: number
+  requestSeq: number
+  ok: boolean
+  /** Present on success; absent / empty when the user cancelled. Blobs
+   *  survive structured clone unchanged so the worker can hand them to
+   *  plugin code without re-encoding. */
+  entries?: ReadonlyArray<{ name: string; path: string; blob: Blob }>
+  error?: string
+}
+
 // ─── Worker → Host ─────────────────────────────────────────────────────────
 
 export type WorkerToHost =
@@ -237,6 +261,7 @@ export type WorkerToHost =
   | WorkerRequestFileSave
   | WorkerRequestFileOpen
   | WorkerRequestVaultRead
+  | WorkerRequestDirectoryOpen
   | WorkerError
   | WorkerSubscribeVault
   | WorkerUnsubscribeVault
@@ -430,6 +455,21 @@ export interface WorkerUnsubscribeVault {
   subscriptionId: string
 }
 
+/** Plugin asking the host to open the native directory picker and
+ *  return a flat list of every file inside the chosen folder. v1.2
+ *  capability — requires `fs.open-directory` permission. See
+ *  plugins-v1.2-plan.md section 4.3.
+ *
+ *  The optional `extensions` filter narrows the result host-side; the
+ *  picker still shows every file, but the response only carries entries
+ *  whose name ends with one of the supplied extensions (case-insensitive,
+ *  leading dot optional). */
+export interface WorkerRequestDirectoryOpen {
+  type: 'worker:requestDirectoryOpen'
+  seq: number
+  extensions?: string[]
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 export function isHostToWorker(msg: unknown): msg is HostToWorker {
@@ -448,6 +488,7 @@ export function isHostToWorker(msg: unknown): msg is HostToWorker {
     'host:vaultChanged',
     'host:noteSaved',
     'host:activeNoteIdChanged',
+    'host:directoryOpenResult',
   ])
 }
 
@@ -466,6 +507,7 @@ export function isWorkerToHost(msg: unknown): msg is WorkerToHost {
     'worker:requestVaultRead',
     'worker:subscribeVault',
     'worker:unsubscribeVault',
+    'worker:requestDirectoryOpen',
   ])
 }
 

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -33,6 +33,7 @@ export type HostToWorker =
   | HostActiveNoteChanged
   | HostFileSaveResult
   | HostFileOpenResult
+  | HostVNodeEvent
 
 /** First message the host sends. Worker initialises the plugin module
  *  and replies with WorkerReady on success or WorkerBootError on failure. */
@@ -117,6 +118,38 @@ export interface HostFileOpenResult {
   bytesBase64?: string
   filename?: string
   error?: string
+}
+
+/** v1.2 — VNode event delivery. The renderer dispatches one of these
+ *  every time a plugin-rendered control fires (button click, input
+ *  change, radio pick, clickable svg shape). The worker matches
+ *  `event` against handlers the plugin registered via
+ *  `ctx.onVNodeEvent` (registration API ships in a later v1.2 PR;
+ *  this envelope is the wire contract every later PR builds on).
+ *
+ *  `source` tells the worker which surface produced the event so the
+ *  plugin can disambiguate when the same `event` name is used in two
+ *  surfaces. PR B fills `kind: 'fullscreen'`; this PR (A) only emits
+ *  `kind: 'panel'` / `kind: 'codeBlock'`.
+ *
+ *  Per the v1.2 plan section 2.1, the host curates which event types
+ *  are wireable (`onClick`, `onChange`, `onSubmit`, `onKeyDown`). For
+ *  inputs and radios the host augments `payload` with `{ value }`
+ *  before posting, so the worker reads the user's selection without
+ *  guessing the DOM event shape. */
+export interface HostVNodeEvent {
+  type: 'host:vnodeEvent'
+  seq: number
+  /** Plugin-defined event name. Host treats as opaque. */
+  event: string
+  /** Plugin-supplied payload, possibly augmented with `{ value }` for
+   *  inputs and radios. */
+  payload: unknown
+  /** Which rendered surface produced the event. */
+  source:
+    | { kind: 'panel'; panelId: string }
+    | { kind: 'codeBlock'; blockId: string }
+    | { kind: 'fullscreen'; viewId: string }
 }
 
 // ─── Worker → Host ─────────────────────────────────────────────────────────
@@ -238,6 +271,7 @@ export function isHostToWorker(msg: unknown): msg is HostToWorker {
     'host:activeNoteChanged',
     'host:fileSaveResult',
     'host:fileOpenResult',
+    'host:vnodeEvent',
   ])
 }
 

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -53,6 +53,7 @@ export type HostToWorker =
   | HostVNodeEvent
   | HostVaultReadResult
   | HostVaultStreamChunk
+  | HostVaultWriteResult
   | HostVaultChangedEvent
   | HostNoteSavedEvent
   | HostActiveNoteIdChanged
@@ -283,6 +284,23 @@ export interface HostFullscreenOpenResult {
   error?: string
 }
 
+/** Host's reply to a worker:requestVaultWrite. Carries the new note id
+ *  on a successful `create`, plus the `conflictResolved` flag indicating
+ *  whether the host had to suffix the title (`'suffix'` → " (imported)"
+ *  was appended) or accepted the requested title verbatim (`'none'`).
+ *  v1.2 capability — requires `vault.write` permission. */
+export interface HostVaultWriteResult {
+  type: 'host:vaultWriteResult'
+  seq: number
+  requestSeq: number
+  ok: boolean
+  /** Set on successful `create`; identifies the new note. Absent on
+   *  update / delete / createFolder. */
+  id?: string
+  conflictResolved?: 'none' | 'suffix'
+  error?: string
+}
+
 // ─── Worker → Host ─────────────────────────────────────────────────────────
 
 export type WorkerToHost =
@@ -296,6 +314,7 @@ export type WorkerToHost =
   | WorkerRequestFileSave
   | WorkerRequestFileOpen
   | WorkerRequestVaultRead
+  | WorkerRequestVaultWrite
   | WorkerRequestDirectoryOpen
   | WorkerError
   | WorkerSubscribeVault
@@ -540,6 +559,36 @@ export interface WorkerSetFullscreenContent {
   node: unknown
 }
 
+/** Plugin asking the host to mutate the vault — create / update /
+ *  soft-delete a note, or create a folder. v1.2 capability — requires
+ *  `vault.write` permission in the manifest AND granted at install.
+ *
+ *  The host writes through the same `useNoteStore` / `useFolderStore`
+ *  paths a user action would take, so sync, indexing, and undo behave
+ *  identically. Title-collision on `create` resolves by appending
+ *  ` (imported)` and returning `conflictResolved: 'suffix'`. */
+export interface WorkerRequestVaultWrite {
+  type: 'worker:requestVaultWrite'
+  seq: number
+  op:
+    | {
+        kind: 'create'
+        title: string
+        body: string
+        folderPath?: string
+        frontmatter?: Record<string, unknown>
+      }
+    | {
+        kind: 'update'
+        id: string
+        title?: string
+        body?: string
+        frontmatter?: Record<string, unknown>
+      }
+    | { kind: 'delete'; id: string }
+    | { kind: 'createFolder'; path: string }
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 export function isHostToWorker(msg: unknown): msg is HostToWorker {
@@ -555,6 +604,7 @@ export function isHostToWorker(msg: unknown): msg is HostToWorker {
     'host:vnodeEvent',
     'host:vaultReadResult',
     'host:vaultStreamChunk',
+    'host:vaultWriteResult',
     'host:vaultChanged',
     'host:noteSaved',
     'host:activeNoteIdChanged',
@@ -578,6 +628,7 @@ export function isWorkerToHost(msg: unknown): msg is WorkerToHost {
     'worker:requestFileSave',
     'worker:requestFileOpen',
     'worker:requestVaultRead',
+    'worker:requestVaultWrite',
     'worker:subscribeVault',
     'worker:unsubscribeVault',
     'worker:requestDirectoryOpen',

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -34,6 +34,8 @@ export type HostToWorker =
   | HostFileSaveResult
   | HostFileOpenResult
   | HostVNodeEvent
+  | HostVaultReadResult
+  | HostVaultStreamChunk
 
 /** First message the host sends. Worker initialises the plugin module
  *  and replies with WorkerReady on success or WorkerBootError on failure. */
@@ -152,6 +154,62 @@ export interface HostVNodeEvent {
     | { kind: 'fullscreen'; viewId: string }
 }
 
+/** v1.2 capability: snapshot of one note's body / frontmatter, sent
+ *  across the worker bridge as a plain object. The host normalises
+ *  Uint8Arrays / Date / Map into plain types before serialising;
+ *  `frontmatter` is the host's parsed view (never raw YAML). */
+export interface NoteWithBodyWire {
+  id: string
+  title: string
+  folderPath: string
+  body: string
+  /** Plain JSON object or null. The host parses YAML; the worker never
+   *  sees raw YAML, so it cannot probe noteser-core parser bugs through
+   *  this surface. */
+  frontmatter: Record<string, unknown> | null
+  updatedAt: number
+}
+
+/** Host's reply to a `worker:requestVaultRead` in mode `'all'` or
+ *  `'one'`. v1.2 capability — requires `vault.read.all` permission.
+ *  `requestSeq` matches the seq the worker emitted so the plugin's
+ *  pending Promise resolves to the right call.
+ *
+ *  For `mode === 'all'` the host returns `notes`; for `'one'` it
+ *  returns a single `note` (or null when the id is unknown / deleted).
+ *  Errors land here when the permission was revoked, the vault has
+ *  not hydrated yet, or the projected payload exceeds
+ *  `MAX_ENVELOPE_BYTES` and the plugin should fall back to
+ *  `stream()`. */
+export interface HostVaultReadResult {
+  type: 'host:vaultReadResult'
+  seq: number
+  requestSeq: number
+  ok: boolean
+  notes?: ReadonlyArray<NoteWithBodyWire>
+  note?: NoteWithBodyWire | null
+  error?: string
+}
+
+/** One chunk of a vault-wide stream read. v1.2 capability — requires
+ *  `vault.read.all` permission. The host paginates over the in-memory
+ *  notes array on the main thread, chunks at `chunkSize` (capped at
+ *  500 to stay under `MAX_ENVELOPE_BYTES`), and emits one of these per
+ *  page.
+ *
+ *  Termination: a chunk with `notes: []` signals end-of-stream. A
+ *  non-empty `error` on any chunk terminates the iterator with that
+ *  error (used on mid-flight permission revocation). `chunkIndex` is
+ *  1-indexed and strictly increasing per `requestSeq`. */
+export interface HostVaultStreamChunk {
+  type: 'host:vaultStreamChunk'
+  seq: number
+  requestSeq: number
+  chunkIndex: number
+  notes: ReadonlyArray<NoteWithBodyWire>
+  error?: string
+}
+
 // ─── Worker → Host ─────────────────────────────────────────────────────────
 
 export type WorkerToHost =
@@ -164,6 +222,7 @@ export type WorkerToHost =
   | WorkerNotify
   | WorkerRequestFileSave
   | WorkerRequestFileOpen
+  | WorkerRequestVaultRead
   | WorkerError
 
 /** Sent in reply to host:boot once the plugin module loaded and
@@ -259,6 +318,34 @@ export interface WorkerRequestFileOpen {
   accept?: string[]
 }
 
+/** Plugin asking the host for vault-wide note reads. v1.2 capability —
+ *  requires `vault.read.all` permission.
+ *
+ *  Three modes:
+ *  - `'all'`     — return every non-deleted note in one response. Host
+ *                  rejects with `'Vault too large; use stream().'` when
+ *                  projected serialised size exceeds 4 MiB.
+ *  - `'one'`     — return a single note by id (or null when unknown /
+ *                  deleted). `noteId` is required.
+ *  - `'stream'`  — paginate over the vault in chunks. The host emits
+ *                  one `host:vaultStreamChunk` per page; the worker
+ *                  yields each chunk to the plugin's AsyncIterable.
+ *                  Default `chunkSize` is 100; max 500 (the spec
+ *                  ceiling, to stay under `MAX_ENVELOPE_BYTES`).
+ *
+ *  Host replies with `host:vaultReadResult` (modes `'all'` / `'one'`)
+ *  or a sequence of `host:vaultStreamChunk` carrying the same
+ *  `requestSeq`. */
+export interface WorkerRequestVaultRead {
+  type: 'worker:requestVaultRead'
+  seq: number
+  mode: 'all' | 'one' | 'stream'
+  /** Required when `mode === 'one'`. Ignored for the other modes. */
+  noteId?: string
+  /** Only meaningful for `mode === 'stream'`. Default 100, max 500. */
+  chunkSize?: number
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 export function isHostToWorker(msg: unknown): msg is HostToWorker {
@@ -272,6 +359,8 @@ export function isHostToWorker(msg: unknown): msg is HostToWorker {
     'host:fileSaveResult',
     'host:fileOpenResult',
     'host:vnodeEvent',
+    'host:vaultReadResult',
+    'host:vaultStreamChunk',
   ])
 }
 
@@ -287,6 +376,7 @@ export function isWorkerToHost(msg: unknown): msg is WorkerToHost {
     'worker:error',
     'worker:requestFileSave',
     'worker:requestFileOpen',
+    'worker:requestVaultRead',
   ])
 }
 

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -22,6 +22,17 @@ export const MAX_ENVELOPE_BYTES = 256 * 1024 // 256 KB
 /** Per-plugin rate limit. Host drops + warns above this. */
 export const MAX_MESSAGES_PER_SECOND = 60
 
+/** Debounce window (ms) the host applies to every `vault.events`
+ *  dispatch (vaultChanged / noteSaved / activeNoteIdChanged). Plugins
+ *  cannot lower this — the cap is host-side so a runaway plugin cannot
+ *  force a re-derive on every keystroke. Section 4.4 of the v1.2 plan. */
+export const VAULT_EVENT_DEBOUNCE_MS = 250
+
+/** Per-event-type cap on active subscriptions for a single plugin. The
+ *  worker rejects further `onVaultChange` / `onNoteSaved` /
+ *  `onActiveNoteChange` calls synchronously beyond this. */
+export const MAX_VAULT_SUBSCRIPTIONS_PER_EVENT = 16
+
 // ─── Host → Worker ─────────────────────────────────────────────────────────
 
 export type HostToWorker =
@@ -36,6 +47,9 @@ export type HostToWorker =
   | HostVNodeEvent
   | HostVaultReadResult
   | HostVaultStreamChunk
+  | HostVaultChangedEvent
+  | HostNoteSavedEvent
+  | HostActiveNoteIdChanged
 
 /** First message the host sends. Worker initialises the plugin module
  *  and replies with WorkerReady on success or WorkerBootError on failure. */
@@ -224,6 +238,8 @@ export type WorkerToHost =
   | WorkerRequestFileOpen
   | WorkerRequestVaultRead
   | WorkerError
+  | WorkerSubscribeVault
+  | WorkerUnsubscribeVault
 
 /** Sent in reply to host:boot once the plugin module loaded and
  *  `definePlugin` ran. Includes the validated manifest, which the host
@@ -346,6 +362,74 @@ export interface WorkerRequestVaultRead {
   chunkSize?: number
 }
 
+// ─── v1.2 vault.events subscription protocol ─────────────────────────────
+//
+// Subscription model: the worker tells the host which vault events it
+// wants by emitting `worker:subscribeVault` (carrying a worker-allocated
+// `subscriptionId`). The host stores the (pluginId, subscriptionId,
+// event) triple and starts dispatching `host:vaultChanged` /
+// `host:noteSaved` / `host:activeNoteIdChanged` envelopes whose
+// `subscriptionId` matches. To stop receiving events the worker emits
+// `worker:unsubscribeVault` with the same id.
+//
+// Cleanup on plugin unload is automatic — the host drops every
+// subscription whose pluginId matches when the worker is terminated, so
+// a plugin that forgets to unsubscribe does not leak.
+//
+// vaultChanged is a coarse "something in the vault changed" signal the
+// host emits at most every 250 ms (debounce). noteSaved carries the
+// noteId whose body / title was updated; activeNoteIdChanged fires on
+// editor-pane transitions and carries the new id (or null when no note
+// is open).
+
+/** Host telling the worker that the vault changed (any note added /
+ *  updated / deleted / folder mutated). Coalesced at 250 ms; the worker
+ *  must NOT count individual events for keystroke detection. */
+export interface HostVaultChangedEvent {
+  type: 'host:vaultChanged'
+  seq: number
+  subscriptionId: string
+}
+
+/** Host telling the worker that a specific note was saved (content /
+ *  title / frontmatter change). Coalesced at 250 ms — back-to-back
+ *  saves of the same id within the debounce window fire ONCE. */
+export interface HostNoteSavedEvent {
+  type: 'host:noteSaved'
+  seq: number
+  subscriptionId: string
+  noteId: string
+}
+
+/** Host telling the worker that the active editor switched to a new
+ *  note (or to no note). Coalesced at 250 ms. */
+export interface HostActiveNoteIdChanged {
+  type: 'host:activeNoteIdChanged'
+  seq: number
+  subscriptionId: string
+  noteId: string | null
+}
+
+/** Worker subscribing to a vault event. The worker chooses the
+ *  `subscriptionId` (uuid-ish) so it can pair host-delivered events
+ *  with the in-worker handler that registered the subscription. The
+ *  host treats the id as opaque. */
+export interface WorkerSubscribeVault {
+  type: 'worker:subscribeVault'
+  seq: number
+  event: 'vaultChanged' | 'noteSaved' | 'activeNoteIdChanged'
+  subscriptionId: string
+}
+
+/** Worker dropping a subscription it previously registered. The host
+ *  stops delivering events for that id. Idempotent — unknown ids are
+ *  no-ops. */
+export interface WorkerUnsubscribeVault {
+  type: 'worker:unsubscribeVault'
+  seq: number
+  subscriptionId: string
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 export function isHostToWorker(msg: unknown): msg is HostToWorker {
@@ -361,6 +445,9 @@ export function isHostToWorker(msg: unknown): msg is HostToWorker {
     'host:vnodeEvent',
     'host:vaultReadResult',
     'host:vaultStreamChunk',
+    'host:vaultChanged',
+    'host:noteSaved',
+    'host:activeNoteIdChanged',
   ])
 }
 
@@ -377,6 +464,8 @@ export function isWorkerToHost(msg: unknown): msg is WorkerToHost {
     'worker:requestFileSave',
     'worker:requestFileOpen',
     'worker:requestVaultRead',
+    'worker:subscribeVault',
+    'worker:unsubscribeVault',
   ])
 }
 

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -122,16 +122,18 @@ export interface PluginCtx {
   requestFileOpen(args?: { accept?: string[] }): Promise<{ bytes: Uint8Array; filename: string } | null>
 
   /**
-   * v1.2 vault namespace. Always populated; methods reject when the
-   * matching permission was not granted or has been revoked. Plugins
+   * v1.2 vault capability namespace. Always present on `ctx`. Methods
+   * REJECT with `'Permission "<name>" was not granted.'` (or
+   * `'... was revoked.'`) when the plugin did not declare the matching
+   * permission OR the user revoked it from Settings → Plugins. Plugins
    * can catch and degrade.
    *
    * - `read` ships in PR C (vault.read.all), spec §4.1.
+   * - `write` ships in PR D (vault.write), spec §4.2.
    * - `events` ships in PR F (vault.events), spec §4.4.
-   * - `write` lands in PR D (vault.write), spec §4.2.
    */
-  vault: {
-    read: {
+  readonly vault: {
+    readonly read: {
       /**
        * Snapshot every non-deleted note in the vault. Resolves with a
        * plain array of `NoteWithBody`. For very large vaults the host
@@ -157,7 +159,45 @@ export interface PluginCtx {
        */
       stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
     }
-    events: {
+    readonly write: {
+      /** Create a new note. Returns the new note's id plus a
+       *  `conflictResolved` flag: `'none'` when the title was used
+       *  verbatim, `'suffix'` when " (imported)" had to be appended
+       *  because another note already owned that title in the target
+       *  folder. Requires `vault.write` permission. */
+      createNote(args: {
+        title: string
+        body: string
+        folderPath?: string
+        frontmatter?: Record<string, unknown>
+      }): Promise<{ id: string; conflictResolved: 'none' | 'suffix' }>
+
+      /** Patch an existing note. Each field in `patch` is optional —
+       *  omitted fields are left untouched. Rejects when the note id
+       *  does not resolve to a non-deleted note. Requires
+       *  `vault.write` permission. */
+      updateNote(
+        id: string,
+        patch: {
+          title?: string
+          body?: string
+          frontmatter?: Record<string, unknown>
+        },
+      ): Promise<void>
+
+      /** Move a note to the trash (soft-delete only). Hard-delete is
+       *  intentionally absent — recovery from a plugin bug stays
+       *  possible through the existing trash UI. Requires
+       *  `vault.write` permission. */
+      deleteNote(id: string): Promise<void>
+
+      /** Create a folder at the given forward-slash-separated path
+       *  (e.g. "Imported/Obsidian"). Missing intermediate folders are
+       *  created. Idempotent — existing folders are reused. Requires
+       *  `vault.write` permission. */
+      createFolder(path: string): Promise<void>
+    }
+    readonly events: {
       /** Fires when any note in the vault changes (added / updated /
        *  trashed / restored). Coarse "something changed" pulse — use
        *  `onNoteSaved` if you need the id.

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -101,10 +101,11 @@ export interface PluginCtx {
   /**
    * v1.2 vault namespace. Always populated; methods reject when the
    * matching permission was not granted or has been revoked. Plugins
-   * can catch and degrade. PR C wires the `read` sub-namespace; PRs
-   * D / F introduce `write` and `events` later.
+   * can catch and degrade.
    *
-   * Spec reference: docs/plugins-v1.2-plan.md §4.1.
+   * - `read` ships in PR C (vault.read.all), spec §4.1.
+   * - `events` ships in PR F (vault.events), spec §4.4.
+   * - `write` lands in PR D (vault.write), spec §4.2.
    */
   vault: {
     read: {
@@ -133,8 +134,36 @@ export interface PluginCtx {
        */
       stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
     }
+    events: {
+      /** Fires when any note in the vault changes (added / updated /
+       *  trashed / restored). Coarse "something changed" pulse — use
+       *  `onNoteSaved` if you need the id.
+       *
+       *  Requires `vault.events` permission. Returns an `Unsubscribe`
+       *  thunk; the host also auto-unwinds every subscription on
+       *  plugin unload, so a forgotten call leaks at most until the
+       *  next reboot. Debounced host-side at 250 ms; plugins cannot
+       *  lower the window. Per-event-type cap of 16 subscriptions; a
+       *  17th call throws synchronously. */
+      onVaultChange(handler: () => void): Unsubscribe
+      /** Fires when a specific note's body / title / frontmatter is
+       *  saved. The handler receives the note id; reading the body
+       *  still requires the `vault.read.all` permission. Same
+       *  debounce / cap rules as `onVaultChange`. */
+      onNoteSaved(handler: (noteId: string) => void): Unsubscribe
+      /** Fires when the editor moves to a different note (or to no
+       *  note). `null` means the welcome / blank state. Same
+       *  debounce / cap rules as `onVaultChange`. */
+      onActiveNoteChange(handler: (noteId: string | null) => void): Unsubscribe
+    }
   }
 }
+
+/** Cleanup thunk returned by every `vault.events` subscription. The
+ *  plugin must call this when it no longer needs the events; the host
+ *  ALSO calls every outstanding unsubscribe when the plugin unloads,
+ *  so a missed call leaks at most until the next reboot. */
+export type Unsubscribe = () => void
 
 export interface PluginHandlers {
   /** Optional — fires after the worker boots and the manifest validates. */

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -32,6 +32,21 @@ export type {
   SvgChild,
 } from './PluginVNode'
 
+/** A note's body + frontmatter as the host renders them. Returned by
+ *  the v1.2 `ctx.vault.read.*` family. Strings only — the host never
+ *  hands the worker a `Uint8Array` (postMessage clones it) or a raw
+ *  YAML string (the worker would have to re-parse, opening a fresh
+ *  parser-bug surface). */
+export interface NoteWithBody {
+  id: string
+  title: string
+  folderPath: string
+  body: string
+  /** Parsed by the host. `null` when the note has no frontmatter. */
+  frontmatter: Readonly<Record<string, unknown>> | null
+  updatedAt: number
+}
+
 /** Narrow capability surface exposed to plugin handlers. The plugin
  *  never sees `localStorage`, the GitHub token, or the bodies of notes
  *  it is not currently viewing. v1 read scope is intentionally tight:
@@ -82,6 +97,43 @@ export interface PluginCtx {
    * `['.pdf', 'application/pdf']`.
    */
   requestFileOpen(args?: { accept?: string[] }): Promise<{ bytes: Uint8Array; filename: string } | null>
+
+  /**
+   * v1.2 vault namespace. Always populated; methods reject when the
+   * matching permission was not granted or has been revoked. Plugins
+   * can catch and degrade. PR C wires the `read` sub-namespace; PRs
+   * D / F introduce `write` and `events` later.
+   *
+   * Spec reference: docs/plugins-v1.2-plan.md §4.1.
+   */
+  vault: {
+    read: {
+      /**
+       * Snapshot every non-deleted note in the vault. Resolves with a
+       * plain array of `NoteWithBody`. For very large vaults the host
+       * rejects with `'Vault too large; use stream().'`; plugins MUST
+       * fall back to `stream()` in that case.
+       *
+       * Requires `vault.read.all` permission.
+       */
+      getAllNotes(): Promise<ReadonlyArray<NoteWithBody>>
+
+      /** Resolve a single note by id. Returns null when the id is
+       *  unknown or the note has been soft-deleted. Requires
+       *  `vault.read.all` permission. */
+      getNote(id: string): Promise<NoteWithBody | null>
+
+      /**
+       * Paginate over the vault. Each iteration yields up to
+       * `chunkSize` notes (default 100, max 500). The iterator
+       * completes naturally when the vault is exhausted; it throws
+       * when the permission is revoked mid-stream.
+       *
+       * Requires `vault.read.all` permission.
+       */
+      stream(opts?: { chunkSize?: number }): AsyncIterable<ReadonlyArray<NoteWithBody>>
+    }
+  }
 }
 
 export interface PluginHandlers {

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -47,6 +47,29 @@ export interface NoteWithBody {
   updatedAt: number
 }
 
+/**
+ * One entry returned by `ctx.fs.openDirectory`. v1.2 capability — see
+ * docs/plugins-v1.2-plan.md section 4.3.
+ *
+ *  - `name` is the filename (no path prefix), e.g. "note.md".
+ *  - `path` is the forward-slash relative path inside the picked root,
+ *    e.g. "subfolder/note.md".
+ *  - `blob` lets the plugin read the file lazily on demand via
+ *    `blob.text()` or `blob.arrayBuffer()`. The host does not pre-load
+ *    file bytes; this keeps a 500 MB directory pick from blowing the
+ *    Worker's heap before the plugin even iterates.
+ */
+export interface DirectoryEntry {
+  name: string
+  path: string
+  blob: Blob
+}
+
+/** Array form returned by `ctx.fs.openDirectory`. Read-only so plugins
+ *  cannot mutate the host's snapshot in place. */
+export type DirectoryEntries = ReadonlyArray<DirectoryEntry>
+
+
 /** Narrow capability surface exposed to plugin handlers. The plugin
  *  never sees `localStorage`, the GitHub token, or the bodies of notes
  *  it is not currently viewing. v1 read scope is intentionally tight:
@@ -156,6 +179,34 @@ export interface PluginCtx {
        *  debounce / cap rules as `onVaultChange`. */
       onActiveNoteChange(handler: (noteId: string | null) => void): Unsubscribe
     }
+  }
+
+  /**
+   * v1.2 file-system namespace. Always populated; methods reject when
+   * the matching permission was not granted (or was revoked from
+   * Settings → Plugins) with the message
+   * `Permission "fs.open-directory" was not granted.` Plugins can catch
+   * + degrade.
+   */
+  fs: {
+    /**
+     * v1.2 capability: open the native directory picker. Resolves with
+     * an array of `{ name, path, blob }` for every file under the
+     * picked root, or `null` when the user cancelled.
+     *
+     * Requires `permissions: ['fs.open-directory']`. Required for
+     * Obsidian / Logseq importers. See plugins-v1.2-plan.md section 4.3.
+     *
+     *  - `args.extensions` (case-insensitive, leading dot optional):
+     *    filters the response to entries whose name ends with one of
+     *    the listed suffixes, e.g. `['.md', '.markdown']`. Empty /
+     *    undefined returns every file.
+     *
+     * Rejects with `Directory too large` when the picked folder
+     * contains more than 50,000 entries (post-filter). Picks a smaller
+     * folder if you trip this.
+     */
+    openDirectory(args?: { extensions?: string[] }): Promise<DirectoryEntries | null>
   }
 }
 

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -13,6 +13,25 @@
 
 import type { PluginManifest } from './manifest'
 
+// Re-export the v1.2 VNode types so plugin authors importing from the
+// SDK can construct VNodes type-safely. PR A only adds the types —
+// new SDK methods (event registration, fullscreen, vault, fs) ship in
+// later v1.2 PRs.
+export type {
+  VNode,
+  VNodeText,
+  VNodeCallout,
+  VNodeButton,
+  VNodeInput,
+  VNodeList,
+  VNodeLink,
+  VNodeRadio,
+  VNodeSvg,
+  VNodeBox,
+  VNodeEvent,
+  SvgChild,
+} from './PluginVNode'
+
 /** Narrow capability surface exposed to plugin handlers. The plugin
  *  never sees `localStorage`, the GitHub token, or the bodies of notes
  *  it is not currently viewing. v1 read scope is intentionally tight:

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -208,6 +208,36 @@ export interface PluginCtx {
      */
     openDirectory(args?: { extensions?: string[] }): Promise<DirectoryEntries | null>
   }
+
+  /**
+   * v1.2 PR B — request that the host mount one of this plugin's
+   * declared fullscreen views. The view id must appear in
+   * `surfaces.fullscreenViews` of the manifest. Only one fullscreen
+   * view is open at a time across the whole app; if another one is
+   * already open the Promise rejects with a clear message.
+   *
+   * Once the modal mounts, the plugin's `onFullscreenMount` handler
+   * fires and the plugin should populate content with
+   * `setFullscreenContent`. The modal stays open across active-note
+   * changes — the plugin is in control and decides when to close.
+   */
+  openFullscreen(viewId: string): Promise<void>
+
+  /**
+   * v1.2 PR B — close the currently-mounted fullscreen view. No-op
+   * when no view is open or when the id does not match. The plugin's
+   * `onFullscreenUnmount` handler fires when the host unmounts the
+   * modal.
+   */
+  closeFullscreen(viewId: string): void
+
+  /**
+   * v1.2 PR B — replace the content tree of the named fullscreen
+   * view. Same VNode contract as `setPanelContent`; the host runs
+   * the value through the curated renderer. Silently dropped if the
+   * named view is not currently open.
+   */
+  setFullscreenContent(viewId: string, node: unknown): void
 }
 
 /** Cleanup thunk returned by every `vault.events` subscription. The
@@ -248,6 +278,15 @@ export interface PluginHandlers {
     args: { language: string; source: string; blockId: string },
     ctx: PluginCtx,
   ) => void | Promise<void>
+
+  /** v1.2 PR B — fires after the host mounts a fullscreen view in
+   *  response to `ctx.openFullscreen(viewId)`. Plugin populates
+   *  content here via `ctx.setFullscreenContent`. */
+  onFullscreenMount?: (viewId: string, ctx: PluginCtx) => void | Promise<void>
+
+  /** v1.2 PR B — fires after the host unmounts a fullscreen view
+   *  (X click, Esc, page unload, or `ctx.closeFullscreen`). */
+  onFullscreenUnmount?: (viewId: string, ctx: PluginCtx) => void | Promise<void>
 }
 
 export interface PluginDefinition extends PluginManifest, PluginHandlers {}

--- a/src/plugins/vaultSnapshot.ts
+++ b/src/plugins/vaultSnapshot.ts
@@ -1,0 +1,244 @@
+// Host-side snapshot of the vault, packaged for the `vault.read.all`
+// capability. The plugin Worker has no access to `useNoteStore` /
+// IndexedDB / the DOM; this module sits on the main thread and turns
+// the Zustand store into a plain-object array the host can post to the
+// worker bridge.
+//
+// Performance contract (docs/plugins-v1.2-plan.md §4.1 + perf #79):
+//   - The first call walks every non-deleted note and parses its
+//     frontmatter. On a 5000-note vault that is the dominant cost; the
+//     work is chunked over `requestIdleCallback` slices in the stream
+//     path so the main thread is never blocked for >50ms.
+//   - We cache the assembled array keyed by a vault snapshot SHA. A
+//     second `getAllNotes()` call within the same SHA returns the
+//     cached array instantly. The SHA is a cheap rolling hash of the
+//     `(id, updatedAt)` pairs of every note + every folder — not a
+//     cryptographic digest, just an identity key.
+//
+// What this module does NOT do:
+//   - It does not post any messages itself. PluginHost handles the
+//     protocol; this module hands it a plain array.
+//   - It does not honour the `vault.read.all` permission gate — that
+//     check lives in PluginHost, before this module is reached.
+
+import { useNoteStore } from '@/stores/noteStore'
+import { useFolderStore } from '@/stores/folderStore'
+import { parseFrontmatter } from '@/utils/frontmatter'
+import type { Note, Folder } from '@/types'
+import type { NoteWithBodyWire } from './protocol'
+
+/** Max projected serialised payload for `getAllNotes()` before the
+ *  host forces the plugin to use `stream()`. Two orders of magnitude
+ *  more than `MAX_ENVELOPE_BYTES` is intentional — `getAllNotes` is
+ *  meant for small vaults and dev plugins; the stream path is for the
+ *  general case. */
+export const MAX_GET_ALL_BYTES = 4 * 1024 * 1024 // 4 MiB
+
+/** Cached snapshot, keyed by the vault SHA. */
+let cached: { sha: string; notes: ReadonlyArray<NoteWithBodyWire> } | null = null
+
+/** Identity-cached folder-path map. Recomputed when the folders array
+ *  identity changes (Zustand replaces it on every mutation). */
+let folderPathCache: { folders: ReadonlyArray<Folder>; byId: Map<string, string> } | null = null
+
+/**
+ * Build a cheap identity hash from the live store's `(id, updatedAt)`
+ * pairs plus folder ids. NOT cryptographic — only used to detect
+ * whether the cached snapshot is still valid.
+ */
+export function computeVaultSha(): string {
+  const notes = useNoteStore.getState().notes
+  const folders = useFolderStore.getState().folders
+  // FNV-1a 32-bit. Fast, deterministic, plenty for cache-key duty.
+  let h = 0x811c9dc5
+  const mix = (s: string): void => {
+    for (let i = 0; i < s.length; i++) {
+      h ^= s.charCodeAt(i)
+      h = (h + ((h << 1) | 0) + ((h << 4) | 0) + ((h << 7) | 0) + ((h << 8) | 0) + ((h << 24) | 0)) | 0
+    }
+  }
+  mix(`n:${notes.length}`)
+  for (let i = 0; i < notes.length; i++) {
+    const n = notes[i]
+    if (n.isDeleted) continue
+    mix(`${n.id}|${n.updatedAt}|`)
+  }
+  mix(`f:${folders.length}`)
+  for (let i = 0; i < folders.length; i++) {
+    const f = folders[i]
+    mix(`${f.id}|${f.parentId ?? '_'}|${f.name}|`)
+  }
+  // Force unsigned, hex-encode.
+  return ((h >>> 0) >>> 0).toString(16)
+}
+
+/** Reset the cache. Tests + the host invalidate this on permission
+ *  revocation so a follow-up call rebuilds against the live store. */
+export function resetVaultSnapshotCacheForTests(): void {
+  cached = null
+  folderPathCache = null
+}
+
+/**
+ * Synchronously snapshot the entire (non-deleted) vault into wire
+ * objects. Cheap when the cache is warm (single SHA compare); ~tens of
+ * ms on a 5000-note cold call because frontmatter parsing dominates.
+ *
+ * For large vaults the caller should prefer the streaming path so the
+ * main thread is never blocked for >50ms — `streamVaultSnapshot`
+ * cooperatively yields between chunks.
+ */
+export function snapshotAllNotes(): ReadonlyArray<NoteWithBodyWire> {
+  const sha = computeVaultSha()
+  if (cached && cached.sha === sha) return cached.notes
+
+  const notes = useNoteStore.getState().notes
+  const folders = useFolderStore.getState().folders
+  const byId = getFolderPathMap(folders)
+  const out: NoteWithBodyWire[] = []
+  for (let i = 0; i < notes.length; i++) {
+    const n = notes[i]
+    if (n.isDeleted) continue
+    out.push(noteToWire(n, byId))
+  }
+  cached = { sha, notes: out }
+  return out
+}
+
+/**
+ * Stream the vault in chunks. Each chunk is `chunkSize` notes (the
+ * plan's section 4.1 caps this at 500; the SDK defaults to 100). The
+ * caller awaits `onChunk` between pages, so a slow consumer (the
+ * worker bridge under back-pressure) throttles the iterator naturally.
+ *
+ * The iterator yields to the main thread between every chunk via
+ * `queueMicrotask`. A 5000-note vault with chunkSize=100 yields 50
+ * times during the walk, each chunk costing well under 50ms. The cap
+ * lives in `MAX_STREAM_CHUNK_SIZE`; values above it are clamped.
+ */
+export const MIN_STREAM_CHUNK_SIZE = 1
+export const DEFAULT_STREAM_CHUNK_SIZE = 100
+export const MAX_STREAM_CHUNK_SIZE = 500
+
+export async function streamVaultSnapshot(
+  opts: {
+    chunkSize?: number
+    /** Called once per chunk. Resolve before the next chunk emits. */
+    onChunk: (notes: ReadonlyArray<NoteWithBodyWire>, chunkIndex: number) => void | Promise<void>
+    /** Called once with `0` after the last non-empty chunk. */
+    onEnd?: () => void | Promise<void>
+    /** Polled before each chunk. Returning true aborts mid-stream and
+     *  invokes `onAbort(reason)` instead of `onEnd`. Used by the host
+     *  to terminate the iterator on permission revocation. */
+    isAborted?: () => string | null
+    onAbort?: (reason: string) => void | Promise<void>
+  },
+): Promise<void> {
+  const requested = opts.chunkSize ?? DEFAULT_STREAM_CHUNK_SIZE
+  const chunkSize = Math.max(
+    MIN_STREAM_CHUNK_SIZE,
+    Math.min(MAX_STREAM_CHUNK_SIZE, Math.floor(requested) || DEFAULT_STREAM_CHUNK_SIZE),
+  )
+
+  // Take a snapshot of the notes array UP FRONT. Walking the live
+  // Zustand array while it mutates would yield stale duplicates or
+  // skip entries; the cached snapshot is also handed to `getAllNotes`
+  // callers so both paths see the same world.
+  const all = snapshotAllNotes()
+  let chunkIndex = 0
+  for (let i = 0; i < all.length; i += chunkSize) {
+    const reason = opts.isAborted?.() ?? null
+    if (reason !== null) {
+      await opts.onAbort?.(reason)
+      return
+    }
+    chunkIndex++
+    const slice = all.slice(i, i + chunkSize)
+    await opts.onChunk(slice, chunkIndex)
+    // Cooperative yield. queueMicrotask is enough — the worker
+    // postMessage queued before the next iteration also yields the
+    // main thread macrotask boundary.
+    await new Promise<void>((resolve) => queueMicrotask(resolve))
+  }
+  await opts.onEnd?.()
+}
+
+/**
+ * Build a single note's wire object. Used by the `getNote(id)` path on
+ * the host. Returns null when the id is unknown or the note is
+ * soft-deleted.
+ */
+export function snapshotNoteById(id: string): NoteWithBodyWire | null {
+  const note = useNoteStore.getState().notes.find((n) => n.id === id)
+  if (!note || note.isDeleted) return null
+  const folders = useFolderStore.getState().folders
+  return noteToWire(note, getFolderPathMap(folders))
+}
+
+/** Convert one in-memory Note into the wire shape. Frontmatter parses
+ *  to a plain object so the worker never sees raw YAML. */
+function noteToWire(note: Note, folderPathById: Map<string, string>): NoteWithBodyWire {
+  const folderPath = note.folderId !== null ? folderPathById.get(note.folderId) ?? '' : ''
+  const { hasFrontmatter, fields, body } = parseFrontmatter(note.content ?? '')
+  const frontmatter: Record<string, unknown> | null = hasFrontmatter
+    ? fieldsToFrontmatter(fields)
+    : null
+  return {
+    id: note.id,
+    title: note.title ?? 'Untitled',
+    folderPath,
+    body: hasFrontmatter ? body : (note.content ?? ''),
+    frontmatter,
+    updatedAt: note.updatedAt,
+  }
+}
+
+function fieldsToFrontmatter(
+  fields: ReadonlyArray<{ key: string; value: unknown; isUnknown: boolean }>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const f of fields) {
+    if (f.isUnknown) continue
+    if (!f.key) continue
+    // Last-write-wins for repeated keys, matching what the rest of the
+    // app does on serialise.
+    out[f.key] = f.value
+  }
+  return out
+}
+
+function getFolderPathMap(folders: ReadonlyArray<Folder>): Map<string, string> {
+  if (folderPathCache && folderPathCache.folders === folders) return folderPathCache.byId
+  const byId = new Map<string, string>()
+  const ix = new Map(folders.map((f) => [f.id, f] as const))
+  for (const f of folders) {
+    const parts: string[] = []
+    let cur: string | null = f.id
+    // Guard against pathological cycles in the persisted store.
+    let hops = 0
+    while (cur && hops++ < 256) {
+      const cf = ix.get(cur)
+      if (!cf) break
+      parts.unshift(cf.name)
+      cur = cf.parentId
+    }
+    byId.set(f.id, parts.join('/'))
+  }
+  folderPathCache = { folders, byId }
+  return byId
+}
+
+/**
+ * Project the serialised payload size of an array of notes. Used to
+ * decide whether `getAllNotes()` should reject with "use stream()".
+ * JSON.stringify is the same encoding postMessage's structured clone
+ * costs at the upper bound, and the value is bounded by the cache so
+ * we only pay it on first call per SHA.
+ */
+export function projectPayloadSize(notes: ReadonlyArray<NoteWithBodyWire>): number {
+  try {
+    return JSON.stringify(notes).length
+  } catch {
+    return Number.POSITIVE_INFINITY
+  }
+}

--- a/src/plugins/workerEntry.ts
+++ b/src/plugins/workerEntry.ts
@@ -23,8 +23,9 @@ import type {
   HostToWorker,
   WorkerToHost,
   HostBootMessage,
+  NoteWithBodyWire,
 } from './protocol'
-import type { PluginCtx, PluginDefinition } from './sdk'
+import type { PluginCtx, PluginDefinition, NoteWithBody } from './sdk'
 
 interface PluginState {
   manifest: PluginManifest
@@ -52,7 +53,30 @@ interface PendingFileOpen {
   resolve: (v: { bytes: Uint8Array; filename: string } | null) => void
   reject: (err: Error) => void
 }
-const pending = new Map<number, PendingFileSave | PendingFileOpen>()
+interface PendingVaultReadAll {
+  kind: 'vault.all'
+  resolve: (notes: ReadonlyArray<NoteWithBody>) => void
+  reject: (err: Error) => void
+}
+interface PendingVaultReadOne {
+  kind: 'vault.one'
+  resolve: (note: NoteWithBody | null) => void
+  reject: (err: Error) => void
+}
+interface PendingVaultReadStream {
+  kind: 'vault.stream'
+  /** Emits one chunk per host:vaultStreamChunk arrival, or completes
+   *  with null when the host signals end-of-stream / error. */
+  push: (chunk: ReadonlyArray<NoteWithBody> | null, error: string | null) => void
+}
+const pending = new Map<
+  number,
+  | PendingFileSave
+  | PendingFileOpen
+  | PendingVaultReadAll
+  | PendingVaultReadOne
+  | PendingVaultReadStream
+>()
 
 let nextRequestSeq = 0
 function allocRequestSeq(): number {
@@ -111,6 +135,59 @@ self.onmessage = async (event: MessageEvent<HostToWorker>) => {
             p.reject(new Error(msg.error ?? 'File open failed.'))
           }
         }
+        return
+      }
+
+      case 'host:vaultReadResult': {
+        const p = pending.get(msg.requestSeq)
+        if (!p) return
+        if (p.kind === 'vault.all') {
+          pending.delete(msg.requestSeq)
+          if (!msg.ok) {
+            p.reject(new Error(msg.error ?? 'vault.read.getAllNotes failed.'))
+            return
+          }
+          p.resolve((msg.notes ?? []) as ReadonlyArray<NoteWithBody>)
+          return
+        }
+        if (p.kind === 'vault.one') {
+          pending.delete(msg.requestSeq)
+          if (!msg.ok) {
+            p.reject(new Error(msg.error ?? 'vault.read.getNote failed.'))
+            return
+          }
+          // `note` may be undefined on the wire when the host sent the
+          // null variant (host normalises null → omitted spread); the
+          // SDK contract is null-when-not-found.
+          p.resolve(msg.note === undefined ? null : (msg.note as NoteWithBody | null))
+          return
+        }
+        // Wrong response kind for the pending request shape — emit a
+        // worker:error so the dev sees the protocol mismatch instead
+        // of a silently hung Promise.
+        emit({
+          type: 'worker:error',
+          seq: 0,
+          message: `vaultReadResult arrived for a non-read pending request (kind=${p.kind}).`,
+        })
+        return
+      }
+
+      case 'host:vaultStreamChunk': {
+        const p = pending.get(msg.requestSeq)
+        if (!p || p.kind !== 'vault.stream') return
+        if (msg.error) {
+          pending.delete(msg.requestSeq)
+          p.push(null, msg.error)
+          return
+        }
+        if (msg.notes.length === 0) {
+          // End-of-stream marker.
+          pending.delete(msg.requestSeq)
+          p.push(null, null)
+          return
+        }
+        p.push(msg.notes as ReadonlyArray<NoteWithBody>, null)
         return
       }
 
@@ -335,8 +412,115 @@ function buildCtx(parentSeq: number): PluginCtx {
       })
       return promise
     },
+    vault: {
+      read: {
+        getAllNotes() {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<ReadonlyArray<NoteWithBody>>((resolve, reject) => {
+            pending.set(requestSeq, { kind: 'vault.all', resolve, reject })
+          })
+          emit({
+            type: 'worker:requestVaultRead',
+            seq: requestSeq,
+            mode: 'all',
+          })
+          return promise
+        },
+        getNote(id: string) {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<NoteWithBody | null>((resolve, reject) => {
+            pending.set(requestSeq, { kind: 'vault.one', resolve, reject })
+          })
+          emit({
+            type: 'worker:requestVaultRead',
+            seq: requestSeq,
+            mode: 'one',
+            noteId: id,
+          })
+          return promise
+        },
+        stream(opts?: { chunkSize?: number }) {
+          return makeVaultStream(opts?.chunkSize)
+        },
+      },
+    },
   }
 }
+
+/**
+ * Build the AsyncIterable that backs `ctx.vault.read.stream()`.
+ *
+ * Implementation note: chunks arrive on a fan-in queue keyed by the
+ * request seq. The iterator's `next()` pulls from that queue, awaiting
+ * a host:vaultStreamChunk when empty. End-of-stream is signalled by
+ * `push(null, null)`; an error by `push(null, error)`. We DO NOT post
+ * a new envelope per chunk — the host paginates on its own cadence.
+ */
+function makeVaultStream(chunkSize: number | undefined): AsyncIterable<ReadonlyArray<NoteWithBody>> {
+  const requestSeq = allocRequestSeq()
+  const buffer: ReadonlyArray<NoteWithBody>[] = []
+  let done = false
+  let error: string | null = null
+  // Pending consumer waker. When `next()` is called with an empty
+  // buffer we park here; the chunk handler resolves us.
+  let wake: (() => void) | null = null
+
+  pending.set(requestSeq, {
+    kind: 'vault.stream',
+    push(chunk, err) {
+      if (err) {
+        error = err
+        done = true
+      } else if (chunk === null) {
+        done = true
+      } else {
+        buffer.push(chunk)
+      }
+      const w = wake
+      wake = null
+      w?.()
+    },
+  })
+
+  emit({
+    type: 'worker:requestVaultRead',
+    seq: requestSeq,
+    mode: 'stream',
+    ...(typeof chunkSize === 'number' ? { chunkSize } : {}),
+  })
+
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<ReadonlyArray<NoteWithBody>> {
+      return {
+        async next(): Promise<IteratorResult<ReadonlyArray<NoteWithBody>>> {
+          while (buffer.length === 0 && !done) {
+            await new Promise<void>((resolve) => {
+              wake = resolve
+            })
+          }
+          if (buffer.length > 0) {
+            return { value: buffer.shift() as ReadonlyArray<NoteWithBody>, done: false }
+          }
+          if (error !== null) throw new Error(error)
+          return { value: undefined as unknown as ReadonlyArray<NoteWithBody>, done: true }
+        },
+        async return(): Promise<IteratorResult<ReadonlyArray<NoteWithBody>>> {
+          // Plugin abandoned the iterator (e.g. `break` out of for-await).
+          // Mark complete; the host will still finish emitting chunks
+          // but the plugin no longer cares.
+          done = true
+          pending.delete(requestSeq)
+          return { value: undefined as unknown as ReadonlyArray<NoteWithBody>, done: true }
+        },
+      }
+    },
+  }
+}
+
+// Mark `NoteWithBodyWire` referenced so the import is not stripped by
+// TS' isolatedModules pass — the worker treats wire and SDK shapes as
+// structurally identical, but we still want the type-level link.
+type _NoteWithBodyWireAlias = NoteWithBodyWire
 
 function emit(msg: WorkerToHost): void {
   ;(self as unknown as { postMessage: (msg: unknown) => void }).postMessage(msg)

--- a/src/plugins/workerEntry.ts
+++ b/src/plugins/workerEntry.ts
@@ -26,7 +26,13 @@ import {
   type HostBootMessage,
   type NoteWithBodyWire,
 } from './protocol'
-import type { PluginCtx, PluginDefinition, NoteWithBody, Unsubscribe } from './sdk'
+import type {
+  DirectoryEntries,
+  NoteWithBody,
+  PluginCtx,
+  PluginDefinition,
+  Unsubscribe,
+} from './sdk'
 
 interface PluginState {
   manifest: PluginManifest
@@ -70,6 +76,11 @@ interface PendingVaultReadStream {
    *  with null when the host signals end-of-stream / error. */
   push: (chunk: ReadonlyArray<NoteWithBody> | null, error: string | null) => void
 }
+interface PendingDirectoryOpen {
+  kind: 'openDirectory'
+  resolve: (v: DirectoryEntries | null) => void
+  reject: (err: Error) => void
+}
 const pending = new Map<
   number,
   | PendingFileSave
@@ -77,6 +88,7 @@ const pending = new Map<
   | PendingVaultReadAll
   | PendingVaultReadOne
   | PendingVaultReadStream
+  | PendingDirectoryOpen
 >()
 
 let nextRequestSeq = 0
@@ -281,6 +293,26 @@ self.onmessage = async (event: MessageEvent<HostToWorker>) => {
       case 'host:activeNoteIdChanged':
         dispatchVault(msg.subscriptionId, msg.noteId)
         return
+
+      case 'host:directoryOpenResult': {
+        const p = pending.get(msg.requestSeq)
+        if (p && p.kind === 'openDirectory') {
+          pending.delete(msg.requestSeq)
+          if (msg.ok) {
+            // No entries → user cancelled the picker. Distinct from a
+            // permission rejection (ok=false) so the plugin can branch
+            // on `null` vs catching an error.
+            if (msg.entries === undefined) {
+              p.resolve(null)
+            } else {
+              p.resolve(msg.entries as DirectoryEntries)
+            }
+          } else {
+            p.reject(new Error(msg.error ?? 'Directory open failed.'))
+          }
+        }
+        return
+      }
 
       default:
         // Exhaustiveness — TypeScript will catch missed cases at build,
@@ -544,6 +576,20 @@ function buildCtx(parentSeq: number): PluginCtx {
         onActiveNoteChange(handler: (noteId: string | null) => void): Unsubscribe {
           return subscribeVault('activeNoteIdChanged', handler)
         },
+      },
+    },
+    fs: {
+      openDirectory(opts) {
+        const requestSeq = allocRequestSeq()
+        const promise = new Promise<DirectoryEntries | null>((resolve, reject) => {
+          pending.set(requestSeq, { kind: 'openDirectory', resolve, reject })
+        })
+        emit({
+          type: 'worker:requestDirectoryOpen',
+          seq: requestSeq,
+          ...(opts?.extensions ? { extensions: opts.extensions } : {}),
+        })
+        return promise
       },
     },
   }

--- a/src/plugins/workerEntry.ts
+++ b/src/plugins/workerEntry.ts
@@ -81,6 +81,11 @@ interface PendingDirectoryOpen {
   resolve: (v: DirectoryEntries | null) => void
   reject: (err: Error) => void
 }
+interface PendingFullscreenOpen {
+  kind: 'fullscreen-open'
+  resolve: () => void
+  reject: (err: Error) => void
+}
 const pending = new Map<
   number,
   | PendingFileSave
@@ -89,6 +94,7 @@ const pending = new Map<
   | PendingVaultReadOne
   | PendingVaultReadStream
   | PendingDirectoryOpen
+  | PendingFullscreenOpen
 >()
 
 let nextRequestSeq = 0
@@ -314,6 +320,24 @@ self.onmessage = async (event: MessageEvent<HostToWorker>) => {
         return
       }
 
+      case 'host:fullscreenOpenResult': {
+        const p = pending.get(msg.requestSeq)
+        if (p && p.kind === 'fullscreen-open') {
+          pending.delete(msg.requestSeq)
+          if (msg.ok) p.resolve()
+          else p.reject(new Error(msg.error ?? 'Could not open fullscreen view.'))
+        }
+        return
+      }
+
+      case 'host:fullscreenOpened':
+        await handleFullscreenOpened(msg.seq, msg.viewId)
+        return
+
+      case 'host:fullscreenClosed':
+        await handleFullscreenClosed(msg.seq, msg.viewId)
+        return
+
       default:
         // Exhaustiveness — TypeScript will catch missed cases at build,
         // this branch is the runtime tripwire if the protocol changes
@@ -479,6 +503,20 @@ async function handleRenderCodeBlock(
   }
 }
 
+async function handleFullscreenOpened(seq: number, viewId: string): Promise<void> {
+  if (state === null) return
+  if (typeof state.def.onFullscreenMount === 'function') {
+    await state.def.onFullscreenMount(viewId, buildCtx(seq))
+  }
+}
+
+async function handleFullscreenClosed(seq: number, viewId: string): Promise<void> {
+  if (state === null) return
+  if (typeof state.def.onFullscreenUnmount === 'function') {
+    await state.def.onFullscreenUnmount(viewId, buildCtx(seq))
+  }
+}
+
 function buildCtx(parentSeq: number): PluginCtx {
   if (state === null) throw new Error('buildCtx called before boot')
   const s = state
@@ -591,6 +629,25 @@ function buildCtx(parentSeq: number): PluginCtx {
         })
         return promise
       },
+    },
+    openFullscreen(viewId: string) {
+      const requestSeq = allocRequestSeq()
+      const promise = new Promise<void>((resolve, reject) => {
+        pending.set(requestSeq, { kind: 'fullscreen-open', resolve, reject })
+      })
+      emit({ type: 'worker:openFullscreen', seq: requestSeq, viewId })
+      return promise
+    },
+    closeFullscreen(viewId: string) {
+      emit({ type: 'worker:closeFullscreen', seq: allocRequestSeq(), viewId })
+    },
+    setFullscreenContent(viewId: string, node: unknown) {
+      emit({
+        type: 'worker:setFullscreenContent',
+        seq: parentSeq,
+        viewId,
+        node,
+      })
     },
   }
 }

--- a/src/plugins/workerEntry.ts
+++ b/src/plugins/workerEntry.ts
@@ -19,13 +19,14 @@
 //   5. Host begins sending events; worker dispatches them to handlers
 
 import { validateManifest, type PluginManifest } from './manifest'
-import type {
-  HostToWorker,
-  WorkerToHost,
-  HostBootMessage,
-  NoteWithBodyWire,
+import {
+  MAX_VAULT_SUBSCRIPTIONS_PER_EVENT,
+  type HostToWorker,
+  type WorkerToHost,
+  type HostBootMessage,
+  type NoteWithBodyWire,
 } from './protocol'
-import type { PluginCtx, PluginDefinition, NoteWithBody } from './sdk'
+import type { PluginCtx, PluginDefinition, NoteWithBody, Unsubscribe } from './sdk'
 
 interface PluginState {
   manifest: PluginManifest
@@ -81,6 +82,84 @@ const pending = new Map<
 let nextRequestSeq = 0
 function allocRequestSeq(): number {
   return ++nextRequestSeq
+}
+
+// ─── vault.events subscriptions ─────────────────────────────────────────
+//
+// One handler table per event type. The worker mints opaque
+// subscriptionIds (`vsub-<n>`) the host pairs against incoming
+// host:vaultChanged / host:noteSaved / host:activeNoteIdChanged
+// envelopes.
+//
+// On plugin teardown (worker termination) the host drops every
+// subscription on its side, so this in-worker map never has to be
+// drained — but plugins are still encouraged to call the returned
+// unsubscribe so a long-lived plugin does not accumulate handlers
+// across panel mounts.
+
+type VaultEventName = 'vaultChanged' | 'noteSaved' | 'activeNoteIdChanged'
+type AnyVaultHandler =
+  | (() => void)
+  | ((noteId: string) => void)
+  | ((noteId: string | null) => void)
+
+interface VaultSubEntry {
+  event: VaultEventName
+  handler: AnyVaultHandler
+}
+
+const vaultSubs = new Map<string, VaultSubEntry>()
+let nextSubSeq = 0
+
+function countSubsForEvent(event: VaultEventName): number {
+  let n = 0
+  for (const v of vaultSubs.values()) if (v.event === event) n++
+  return n
+}
+
+function subscribeVault(event: VaultEventName, handler: AnyVaultHandler): Unsubscribe {
+  if (countSubsForEvent(event) >= MAX_VAULT_SUBSCRIPTIONS_PER_EVENT) {
+    throw new Error(
+      `Too many ${event} subscriptions (max ${MAX_VAULT_SUBSCRIPTIONS_PER_EVENT} per plugin).`,
+    )
+  }
+  const subscriptionId = `vsub-${++nextSubSeq}`
+  vaultSubs.set(subscriptionId, { event, handler })
+  emit({
+    type: 'worker:subscribeVault',
+    seq: allocRequestSeq(),
+    event,
+    subscriptionId,
+  })
+  return () => {
+    if (!vaultSubs.has(subscriptionId)) return
+    vaultSubs.delete(subscriptionId)
+    emit({
+      type: 'worker:unsubscribeVault',
+      seq: allocRequestSeq(),
+      subscriptionId,
+    })
+  }
+}
+
+function dispatchVault(subscriptionId: string, payload: string | null | undefined): void {
+  const entry = vaultSubs.get(subscriptionId)
+  if (!entry) return
+  try {
+    if (entry.event === 'vaultChanged') {
+      ;(entry.handler as () => void)()
+    } else if (entry.event === 'noteSaved') {
+      ;(entry.handler as (noteId: string) => void)(payload as string)
+    } else {
+      ;(entry.handler as (noteId: string | null) => void)(payload ?? null)
+    }
+  } catch (err) {
+    emit({
+      type: 'worker:error',
+      seq: 0,
+      message: `vault.events handler threw: ${err instanceof Error ? err.message : String(err)}`,
+    })
+  }
 }
 
 self.onmessage = async (event: MessageEvent<HostToWorker>) => {
@@ -190,6 +269,18 @@ self.onmessage = async (event: MessageEvent<HostToWorker>) => {
         p.push(msg.notes as ReadonlyArray<NoteWithBody>, null)
         return
       }
+
+      case 'host:vaultChanged':
+        dispatchVault(msg.subscriptionId, undefined)
+        return
+
+      case 'host:noteSaved':
+        dispatchVault(msg.subscriptionId, msg.noteId)
+        return
+
+      case 'host:activeNoteIdChanged':
+        dispatchVault(msg.subscriptionId, msg.noteId)
+        return
 
       default:
         // Exhaustiveness — TypeScript will catch missed cases at build,
@@ -441,6 +532,17 @@ function buildCtx(parentSeq: number): PluginCtx {
         },
         stream(opts?: { chunkSize?: number }) {
           return makeVaultStream(opts?.chunkSize)
+        },
+      },
+      events: {
+        onVaultChange(handler: () => void): Unsubscribe {
+          return subscribeVault('vaultChanged', handler)
+        },
+        onNoteSaved(handler: (noteId: string) => void): Unsubscribe {
+          return subscribeVault('noteSaved', handler)
+        },
+        onActiveNoteChange(handler: (noteId: string | null) => void): Unsubscribe {
+          return subscribeVault('activeNoteIdChanged', handler)
         },
       },
     },

--- a/src/plugins/workerEntry.ts
+++ b/src/plugins/workerEntry.ts
@@ -86,6 +86,18 @@ interface PendingFullscreenOpen {
   resolve: () => void
   reject: (err: Error) => void
 }
+/** Pending vault.write request awaiting host reply. `create` resolves
+ *  with { id, conflictResolved }; the other ops resolve with void. */
+interface PendingVaultWriteCreate {
+  kind: 'vault.write.create'
+  resolve: (v: { id: string; conflictResolved: 'none' | 'suffix' }) => void
+  reject: (err: Error) => void
+}
+interface PendingVaultWriteVoid {
+  kind: 'vault.write.void'
+  resolve: () => void
+  reject: (err: Error) => void
+}
 const pending = new Map<
   number,
   | PendingFileSave
@@ -95,6 +107,8 @@ const pending = new Map<
   | PendingVaultReadStream
   | PendingDirectoryOpen
   | PendingFullscreenOpen
+  | PendingVaultWriteCreate
+  | PendingVaultWriteVoid
 >()
 
 let nextRequestSeq = 0
@@ -337,6 +351,39 @@ self.onmessage = async (event: MessageEvent<HostToWorker>) => {
       case 'host:fullscreenClosed':
         await handleFullscreenClosed(msg.seq, msg.viewId)
         return
+
+      case 'host:vaultWriteResult': {
+        const p = pending.get(msg.requestSeq)
+        if (!p) return
+        if (p.kind !== 'vault.write.create' && p.kind !== 'vault.write.void') {
+          // Mismatched pending shape — emit a worker:error so the dev
+          // sees the protocol mismatch instead of a silently hung Promise.
+          emit({
+            type: 'worker:error',
+            seq: 0,
+            message: `vaultWriteResult arrived for a non-write pending request (kind=${p.kind}).`,
+          })
+          return
+        }
+        pending.delete(msg.requestSeq)
+        if (!msg.ok) {
+          p.reject(new Error(msg.error ?? 'Vault write failed.'))
+          return
+        }
+        if (p.kind === 'vault.write.create') {
+          if (typeof msg.id !== 'string') {
+            p.reject(new Error('Vault write succeeded but host returned no note id.'))
+            return
+          }
+          p.resolve({
+            id: msg.id,
+            conflictResolved: msg.conflictResolved ?? 'none',
+          })
+        } else {
+          p.resolve()
+        }
+        return
+      }
 
       default:
         // Exhaustiveness — TypeScript will catch missed cases at build,
@@ -602,6 +649,70 @@ function buildCtx(parentSeq: number): PluginCtx {
         },
         stream(opts?: { chunkSize?: number }) {
           return makeVaultStream(opts?.chunkSize)
+        },
+      },
+      write: {
+        createNote(args) {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<{ id: string; conflictResolved: 'none' | 'suffix' }>(
+            (resolve, reject) => {
+              pending.set(requestSeq, { kind: 'vault.write.create', resolve, reject })
+            },
+          )
+          emit({
+            type: 'worker:requestVaultWrite',
+            seq: requestSeq,
+            op: {
+              kind: 'create',
+              title: args.title,
+              body: args.body,
+              ...(args.folderPath !== undefined ? { folderPath: args.folderPath } : {}),
+              ...(args.frontmatter !== undefined ? { frontmatter: args.frontmatter } : {}),
+            },
+          })
+          return promise
+        },
+        updateNote(id, patch) {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<void>((resolve, reject) => {
+            pending.set(requestSeq, { kind: 'vault.write.void', resolve, reject })
+          })
+          emit({
+            type: 'worker:requestVaultWrite',
+            seq: requestSeq,
+            op: {
+              kind: 'update',
+              id,
+              ...(patch.title !== undefined ? { title: patch.title } : {}),
+              ...(patch.body !== undefined ? { body: patch.body } : {}),
+              ...(patch.frontmatter !== undefined ? { frontmatter: patch.frontmatter } : {}),
+            },
+          })
+          return promise
+        },
+        deleteNote(id) {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<void>((resolve, reject) => {
+            pending.set(requestSeq, { kind: 'vault.write.void', resolve, reject })
+          })
+          emit({
+            type: 'worker:requestVaultWrite',
+            seq: requestSeq,
+            op: { kind: 'delete', id },
+          })
+          return promise
+        },
+        createFolder(path) {
+          const requestSeq = allocRequestSeq()
+          const promise = new Promise<void>((resolve, reject) => {
+            pending.set(requestSeq, { kind: 'vault.write.void', resolve, reject })
+          })
+          emit({
+            type: 'worker:requestVaultWrite',
+            seq: requestSeq,
+            op: { kind: 'createFolder', path },
+          })
+          return promise
         },
       },
       events: {

--- a/src/stores/pluginInstallStore.ts
+++ b/src/stores/pluginInstallStore.ts
@@ -32,9 +32,10 @@ export interface InstalledPluginRecord {
    *  re-grants it. The manifest's declared `permissions` list is the
    *  ceiling; revocation can only subtract from it. Honoured at
    *  dispatch time for every v1.2 capability (vault.read.all,
-   *  vault.events, fs.open-directory, …); existing subscribers are not
-   *  torn down on revocation — they just stop receiving events / get a
-   *  rejection with `Permission "<name>" was revoked.` on the next call. */
+   *  vault.write, vault.events, fs.open-directory, …); existing
+   *  subscribers are not torn down on revocation — they just stop
+   *  receiving events / get a rejection with
+   *  `Permission "<name>" was revoked.` on the next call. */
   revokedPermissions?: PluginPermission[]
 }
 
@@ -54,11 +55,15 @@ interface PluginInstallState {
    *  subtracts. Existing event-subscribers stay alive but stop
    *  receiving events. */
   setPermissionRevoked: (pluginId: string, permission: PluginPermission, revoked: boolean) => void
+  /** Read-side helper used by PluginHost's permission gate.
+   *  Returns false when the plugin id is unknown — an uninstalled
+   *  plugin cannot have revoked permissions. */
+  isPermissionRevoked: (pluginId: string, permission: string) => boolean
 }
 
 export const usePluginInstallStore = create<PluginInstallState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       records: {},
 
       install: (record) =>
@@ -100,6 +105,12 @@ export const usePluginInstallStore = create<PluginInstallState>()(
             },
           }
         }),
+
+      isPermissionRevoked: (pluginId, permission) => {
+        const rec = get().records[pluginId]
+        if (!rec) return false
+        return rec.revokedPermissions?.includes(permission as PluginPermission) ?? false
+      },
     }),
     {
       name: 'noteser-plugin-installs',

--- a/src/stores/pluginInstallStore.ts
+++ b/src/stores/pluginInstallStore.ts
@@ -10,7 +10,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { idbStorage } from '@/utils/idbStorage'
-import type { PluginManifest } from '@/plugins/manifest'
+import type { PluginManifest, PluginPermission } from '@/plugins/manifest'
 
 export interface InstalledPluginRecord {
   manifest: PluginManifest
@@ -27,6 +27,11 @@ export interface InstalledPluginRecord {
   /** When `false`, the bootstrap skips this plugin on app load.
    *  Lets a user pause a misbehaving plugin without uninstalling. */
   enabled: boolean
+  /** v1.2: per-install capability revocation list. Persisted across
+   *  reboots — a permission revoked here stays revoked until the user
+   *  re-grants it. The manifest's declared `permissions` list is the
+   *  ceiling; revocation can only subtract from it. */
+  revokedPermissions?: PluginPermission[]
 }
 
 interface PluginInstallState {
@@ -36,6 +41,11 @@ interface PluginInstallState {
   install: (record: InstalledPluginRecord) => void
   uninstall: (pluginId: string) => void
   setEnabled: (pluginId: string, enabled: boolean) => void
+  /** Mark a permission revoked for the given plugin. Idempotent. Used
+   *  by Settings → Plugins to disable a capability at runtime; the
+   *  PluginHost reads the same flag on boot to seed its in-memory
+   *  revocation set. */
+  setPermissionRevoked: (pluginId: string, permission: PluginPermission, revoked: boolean) => void
 }
 
 export const usePluginInstallStore = create<PluginInstallState>()(
@@ -62,6 +72,24 @@ export const usePluginInstallStore = create<PluginInstallState>()(
           if (!cur || cur.enabled === enabled) return state
           return {
             records: { ...state.records, [pluginId]: { ...cur, enabled } },
+          }
+        }),
+
+      setPermissionRevoked: (pluginId, permission, revoked) =>
+        set((state) => {
+          const cur = state.records[pluginId]
+          if (!cur) return state
+          const existing = cur.revokedPermissions ?? []
+          const alreadyRevoked = existing.includes(permission)
+          if (revoked === alreadyRevoked) return state
+          const next = revoked
+            ? [...existing, permission]
+            : existing.filter((p) => p !== permission)
+          return {
+            records: {
+              ...state.records,
+              [pluginId]: { ...cur, revokedPermissions: next },
+            },
           }
         }),
     }),

--- a/src/stores/pluginInstallStore.ts
+++ b/src/stores/pluginInstallStore.ts
@@ -30,7 +30,11 @@ export interface InstalledPluginRecord {
   /** v1.2: per-install capability revocation list. Persisted across
    *  reboots — a permission revoked here stays revoked until the user
    *  re-grants it. The manifest's declared `permissions` list is the
-   *  ceiling; revocation can only subtract from it. */
+   *  ceiling; revocation can only subtract from it. Honoured at
+   *  dispatch time for every v1.2 capability (vault.read.all,
+   *  vault.events, …); existing subscribers are not torn down on
+   *  revocation — they just stop receiving events / get a rejection
+   *  on the next call. */
   revokedPermissions?: PluginPermission[]
 }
 
@@ -41,10 +45,14 @@ interface PluginInstallState {
   install: (record: InstalledPluginRecord) => void
   uninstall: (pluginId: string) => void
   setEnabled: (pluginId: string, enabled: boolean) => void
-  /** Mark a permission revoked for the given plugin. Idempotent. Used
-   *  by Settings → Plugins to disable a capability at runtime; the
-   *  PluginHost reads the same flag on boot to seed its in-memory
-   *  revocation set. */
+  /** Toggle a permission's revoked state for the given plugin.
+   *  Idempotent. Used by Settings → Plugins; the PluginHost reads the
+   *  same flag on boot to seed its in-memory revocation set, and
+   *  re-checks on every v1.2 capability dispatch so a runtime change
+   *  takes effect without restarting the plugin. The manifest's
+   *  declared `permissions` list is unchanged — revocation only
+   *  subtracts. Existing event-subscribers stay alive but stop
+   *  receiving events. */
   setPermissionRevoked: (pluginId: string, permission: PluginPermission, revoked: boolean) => void
 }
 

--- a/src/stores/pluginInstallStore.ts
+++ b/src/stores/pluginInstallStore.ts
@@ -32,9 +32,9 @@ export interface InstalledPluginRecord {
    *  re-grants it. The manifest's declared `permissions` list is the
    *  ceiling; revocation can only subtract from it. Honoured at
    *  dispatch time for every v1.2 capability (vault.read.all,
-   *  vault.events, …); existing subscribers are not torn down on
-   *  revocation — they just stop receiving events / get a rejection
-   *  on the next call. */
+   *  vault.events, fs.open-directory, …); existing subscribers are not
+   *  torn down on revocation — they just stop receiving events / get a
+   *  rejection with `Permission "<name>" was revoked.` on the next call. */
   revokedPermissions?: PluginPermission[]
 }
 

--- a/src/stores/pluginStore.ts
+++ b/src/stores/pluginStore.ts
@@ -22,21 +22,43 @@ export interface LoadedPlugin {
   errors: string[]
 }
 
+/** v1.2 PR B — descriptor of the currently-mounted fullscreen view.
+ *  Only one is ever populated at a time. The PluginFullscreenView
+ *  modal subscribes to this; `pluginHostSingleton` writes to it from
+ *  the singleton fullscreen open/close handlers. */
+export interface ActiveFullscreenView {
+  pluginId: string
+  pluginName: string
+  viewId: string
+  title: string
+  node: unknown
+}
+
 interface PluginState {
   /** Plugins keyed by manifest.id. */
   loaded: Record<string, LoadedPlugin>
+
+  /** Active fullscreen view, or null when no plugin has one mounted. */
+  activeFullscreen: ActiveFullscreenView | null
 
   // ── mutations (called from pluginHostSingleton only) ─────────────
   addReady: (manifest: PluginManifest) => void
   remove: (pluginId: string) => void
   appendError: (pluginId: string, message: string) => void
   clear: () => void
+  setActiveFullscreen: (next: ActiveFullscreenView | null) => void
+  updateActiveFullscreenContent: (
+    pluginId: string,
+    viewId: string,
+    node: unknown,
+  ) => void
 }
 
 const MAX_ERRORS = 20
 
 export const usePluginStore = create<PluginState>()((set) => ({
   loaded: {},
+  activeFullscreen: null,
 
   addReady: (manifest) =>
     set((state) => ({
@@ -48,7 +70,14 @@ export const usePluginStore = create<PluginState>()((set) => ({
       if (!(pluginId in state.loaded)) return state
       const next = { ...state.loaded }
       delete next[pluginId]
-      return { loaded: next }
+      // If the removed plugin owns the active fullscreen view, drop
+      // it. Otherwise the modal would render against a torn-down
+      // worker.
+      const activeFullscreen =
+        state.activeFullscreen && state.activeFullscreen.pluginId === pluginId
+          ? null
+          : state.activeFullscreen
+      return { loaded: next, activeFullscreen }
     }),
 
   appendError: (pluginId, message) =>
@@ -59,7 +88,17 @@ export const usePluginStore = create<PluginState>()((set) => ({
       return { loaded: { ...state.loaded, [pluginId]: { ...cur, errors } } }
     }),
 
-  clear: () => set({ loaded: {} }),
+  clear: () => set({ loaded: {}, activeFullscreen: null }),
+
+  setActiveFullscreen: (next) => set({ activeFullscreen: next }),
+
+  updateActiveFullscreenContent: (pluginId, viewId, node) =>
+    set((state) => {
+      const cur = state.activeFullscreen
+      if (!cur) return state
+      if (cur.pluginId !== pluginId || cur.viewId !== viewId) return state
+      return { activeFullscreen: { ...cur, node } }
+    }),
 }))
 
 /** Flat list of every command across every loaded plugin, with the

--- a/src/utils/pluginAudit.ts
+++ b/src/utils/pluginAudit.ts
@@ -1,0 +1,159 @@
+// Plugin audit trail. Every destructive plugin action lands here so
+// the user (and bug reports) can see what a plugin did to their vault
+// after the fact.
+//
+// Storage strategy:
+//   - In-memory ring buffer (MAX_ENTRIES) keyed by ts. Single source of
+//     truth for the running session.
+//   - On every append, schedule a debounced flush to localStorage. The
+//     log persists across reloads so a "plugin trashed my notes!"
+//     report has a paper trail even after the user refreshes.
+//
+// We DELIBERATELY do not use the Zustand stores + idbStorage path the
+// rest of the app uses. The audit log must keep functioning even when
+// IndexedDB is busy migrating, when a plugin is mid-write, or when the
+// noteser stores are unloaded for tests. localStorage is synchronous,
+// small, and survives across tabs of the same origin — exactly the
+// guarantees we want for "what just happened" tracing.
+//
+// PR D (Plugin API v1.2) — see docs/plugins-v1.2-impl-notes.md.
+
+const STORAGE_KEY = 'noteser-plugin-audit'
+const MAX_ENTRIES = 500
+const FLUSH_DEBOUNCE_MS = 250
+
+/** Single audit log entry. Emitted by `recordPluginWrite` after the
+ *  host has accepted (or attempted) a plugin's vault mutation.
+ *  Stable on-disk shape — never break this without bumping
+ *  `STORAGE_VERSION`. */
+export interface PluginAuditEntry {
+  /** Wall-clock at the moment the host applied (or rejected) the op. */
+  ts: number
+  /** Plugin manifest id that requested the write. */
+  pluginId: string
+  /** One of the four `vault.write` operations. */
+  op: 'create' | 'update' | 'delete' | 'createFolder'
+  /** Note id (for create/update/delete) or folder path (for
+   *  createFolder). Allows the user to cross-reference the entry with
+   *  the trash or vault tree. */
+  target: string
+  /** Outcome of the op. `error` is populated only when ok===false. */
+  ok: boolean
+  error?: string
+  /** For `create` calls where the host had to append " (imported)" to
+   *  resolve a title collision — surfaced so the user can see the
+   *  rename. */
+  conflictResolved?: 'none' | 'suffix'
+}
+
+const STORAGE_VERSION = 1
+
+interface PersistedShape {
+  v: typeof STORAGE_VERSION
+  entries: PluginAuditEntry[]
+}
+
+let buffer: PluginAuditEntry[] | null = null
+let flushTimer: ReturnType<typeof setTimeout> | null = null
+
+/** Lazily-loaded ring buffer. First access hydrates from localStorage
+ *  if a prior session left anything behind, then bounds to MAX_ENTRIES. */
+function getBuffer(): PluginAuditEntry[] {
+  if (buffer !== null) return buffer
+  buffer = loadFromStorage()
+  return buffer
+}
+
+function loadFromStorage(): PluginAuditEntry[] {
+  if (typeof localStorage === 'undefined') return []
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as PersistedShape | PluginAuditEntry[] | null
+    if (Array.isArray(parsed)) {
+      // Legacy / un-versioned shape — treat the array as the entries.
+      return parsed.slice(-MAX_ENTRIES)
+    }
+    if (parsed && parsed.v === STORAGE_VERSION && Array.isArray(parsed.entries)) {
+      return parsed.entries.slice(-MAX_ENTRIES)
+    }
+  } catch {
+    // Corrupt JSON, version mismatch, or storage quota issue. Reset to
+    // an empty log rather than crash the host.
+  }
+  return []
+}
+
+function scheduleFlush(): void {
+  if (typeof localStorage === 'undefined') return
+  if (flushTimer !== null) return
+  flushTimer = setTimeout(() => {
+    flushTimer = null
+    try {
+      const payload: PersistedShape = {
+        v: STORAGE_VERSION,
+        entries: getBuffer(),
+      }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+    } catch {
+      // Quota exceeded or storage disabled — drop the flush silently.
+      // The in-memory buffer is still authoritative for the running
+      // session; we just lose persistence across reload.
+    }
+  }, FLUSH_DEBOUNCE_MS)
+}
+
+/** Append one entry to the audit log. Called from the host's vault.write
+ *  handler after the noteStore / folderStore mutation has been applied
+ *  (or rejected). Bounds the in-memory log to MAX_ENTRIES — oldest
+ *  entries roll off. */
+export function recordPluginWrite(entry: Omit<PluginAuditEntry, 'ts'> & { ts?: number }): void {
+  const buf = getBuffer()
+  const ts = typeof entry.ts === 'number' ? entry.ts : Date.now()
+  const full: PluginAuditEntry = {
+    ts,
+    pluginId: entry.pluginId,
+    op: entry.op,
+    target: entry.target,
+    ok: entry.ok,
+    ...(entry.error !== undefined ? { error: entry.error } : {}),
+    ...(entry.conflictResolved !== undefined
+      ? { conflictResolved: entry.conflictResolved }
+      : {}),
+  }
+  buf.push(full)
+  if (buf.length > MAX_ENTRIES) {
+    buf.splice(0, buf.length - MAX_ENTRIES)
+  }
+  scheduleFlush()
+}
+
+/** Snapshot of every audit entry currently held in memory. Returns a
+ *  freshly-allocated array so callers can sort / filter without
+ *  mutating the buffer. Newest entry last. */
+export function readPluginAudit(): ReadonlyArray<PluginAuditEntry> {
+  return getBuffer().slice()
+}
+
+/** Same as `readPluginAudit` but filtered to one plugin id. Used by
+ *  the per-plugin "Recent activity" view in Settings → Plugins. */
+export function readPluginAuditFor(pluginId: string): ReadonlyArray<PluginAuditEntry> {
+  return getBuffer().filter((e) => e.pluginId === pluginId)
+}
+
+/** Test-only: clear the in-memory buffer + persisted log. Production
+ *  code never calls this — the log is a permanent trail. */
+export function clearPluginAuditForTests(): void {
+  buffer = []
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer)
+    flushTimer = null
+  }
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      // ignore
+    }
+  }
+}


### PR DESCRIPTION
Merges the v1.2 work that landed across PRs #116, #117, #118, #119, #132, #139 onto a long-running branch, into `dev`.

Closes #112 (graph plugin gaps) and #113 (importer plugin gaps) since the API now supports them.

## What v1.2 ships
- **VNode set extension** (PR #116) — button, input, list, link (discriminated href, no raw URLs), radio, svg + 5 shape primitives, box. Sanitization, 32 unit tests.
- **Fullscreen surface** (PR #132) — manifest field + modal + Esc/X/focus trap; persists across active-note changes.
- **vault.read.all capability** (PR #117) — getAllNotes / getNote / chunked stream; FNV-1a SHA cache; revocation in Settings.
- **vault.write capability** (PR #139) — createNote / updateNote / deleteNote / createFolder; conflict suffix; destructive permission UI + 500-entry localStorage audit ring buffer + Plugin Activity panel.
- **fs.openDirectory capability** (PR #119) — showDirectoryPicker + webkitdirectory fallback; 50k cap; lazy Blob entries.
- **vault.events** (PR #118) — onVaultChange / onNoteSaved / onActiveNoteChange; 250 ms debounce; auto cleanup on plugin unload; 16-sub cap.

## Reference plugins added
- noteser-vnode-demo (exercises VNodes + fullscreen)
- noteser-vault-read-demo
- noteser-write-demo
- noteser-folder-demo
- noteser-event-demo

## Verification
- Final test suite at PR D close: 2527 pass, 17 skipped.
- All 6 sub-PRs Vercel preview deploys passed.
- Implementation notes for every deviation in docs/plugins-v1.2-impl-notes.md.

## Post-merge follow-ups
- #71 graph view as plugin (now buildable)
- #73 importer as plugin (now buildable)
- #70 AI/RAG as plugin (now buildable)
- #72 properties/tables as plugin (now buildable)