### PR TITLE
Wire VNode event delivery + wikilink intercept (post-v1.2 followup)

### DIFF
--- a/docs/plugins-v1.2-impl-notes.md
+++ b/docs/plugins-v1.2-impl-notes.md
@@ -733,3 +733,135 @@ the localStorage flush.
   import takes ~83 s; acceptable.
 - Per-plugin "Recent activity" drill-down view — `readPluginAuditFor`
   exists for it but the UI is the global list for now.
+
+## Post-v1.2: VNode event delivery + wikilink intercept
+
+Branch: `fix/plugin-vnode-event-delivery`. Closes two gaps left over
+from the v1.2 ship-train: the VNode event envelope was shaped (PR A
+under §2 of the plan) but neither the host-side dispatcher nor the
+worker-side handler registration API existed yet. Plugins that tried
+to use `{ tag: 'button', onClick: { kind: 'emit', event: ... } }` got
+silent drops — every PR-A reference plugin update flagged the same
+wall. The wikilink rendering shape worked structurally (host
+constructs the URL from the typed parts) but `wikilink://<noteId>` is
+an unrecognised scheme, so a click on a plugin-rendered note link did
+nothing.
+
+### Gap 1 — VNode event delivery
+
+The wire envelope (`HostVNodeEvent` in `src/plugins/protocol.ts`) was
+already correct: `event` + `payload` + `source: { kind:
+'panel' | 'fullscreen' | 'codeBlock', ... }`. Three new pieces wired
+both sides up:
+
+- `PluginHost.sendVNodeEvent(pluginId, source, event, payload)` —
+  constructs the envelope and posts to the worker. Rate-limited per
+  plugin at `MAX_VNODE_EVENTS_PER_SECOND` (16 events / sec / plugin)
+  in a 1-second sliding window. Past the cap the host SILENTLY drops
+  the event AND emits a single `vnodeEventRateLimited`
+  `PluginHostEvent` per window so a runaway loop surfaces in the dev
+  console without spamming the toast layer. The cap is tighter than
+  the general 60/sec ceiling — a render that emits one onClick is
+  typically one event per repaint, so 16 leaves three frames of
+  headroom at 60Hz and bottoms out runaway loops fast. Picked over
+  60/sec because the event family has no acknowledged use case for
+  high-rate streaming (the high-rate paths are setPanelContent +
+  vault.events, both already capped elsewhere).
+- `workerEntry.ts` handles `host:vnodeEvent` by fanning out to every
+  handler registered through the new `ctx.onVNodeEvent`. The set is
+  scoped to the worker module — the host's `unload()` calls
+  `worker.terminate()`, which drops the entire module and every
+  handler with it. No host-side bookkeeping needed beyond the
+  existing worker-termination path.
+- `ctx.onVNodeEvent(handler)` ships in BOTH `src/plugins/sdk.ts` and
+  `packages/noteser-plugin-sdk/src/sdk.ts`. Handler signature:
+  `({ event, payload, source }) => void`. ONE handler shape rather
+  than the plan-section-6 `(event, cb)` pair so the SDK contract
+  delivers the `source` discriminator (panel id / view id / block id)
+  to the same callback. Returns an `Unsubscribe` thunk. Backwards
+  compatible: plugins that never call `onVNodeEvent` keep working;
+  their fired events are simply dropped by the empty handler set.
+
+Surface wiring:
+
+- `PluginsPanel.tsx` — the `<PluginNode>` mount now passes an
+  `onEvent` callback that wraps `host.sendVNodeEvent` with
+  `{ kind: 'panel', panelId }`.
+- `PluginFullscreenView.tsx` — `handleEvent` is no longer a no-op; it
+  forwards via `{ kind: 'fullscreen', viewId }` using the
+  already-resolved `active.pluginId` / `active.viewId`.
+- `PluginCodeBlock.tsx` — same shape, with `{ kind: 'codeBlock',
+  blockId }`. The block id was already in scope (it identifies the
+  render request).
+
+### Gap 2 — `wikilink://` click intercept
+
+Browser navigation to an unrecognised scheme does nothing, so a
+plugin-rendered `<a href="wikilink://<encodedId>">` was clickable but
+inert. The renderer's `renderLink` now attaches an `onClick` that:
+
+- If the href starts with `wikilink://` AND the click is unmodified
+  (no meta / ctrl / shift / alt, primary button only), the handler
+  calls `e.preventDefault()` and dispatches
+  `useWorkspaceStore.getState().openNote(noteId)`. The noteId comes
+  from the typed `VNodeLink.href` shape (`{ kind: 'note', noteId }`),
+  NOT from re-decoding the URL — the URL parsing surface stays at one
+  chokepoint (`linkHrefToString`).
+- Modifier-clicks are NOT intercepted. The user's intent is "follow
+  the URL natively", which is a no-op for `wikilink://` but we don't
+  pretend otherwise — same shape as a browser's Ctrl+click on any
+  other custom-scheme link.
+- Anchor (`#fragment`) links are NOT intercepted; the browser's
+  native fragment-scroll owns that case.
+
+The plan's §2.6 `VNodeLink.href` does not permit external URLs at all
+(the discriminated union only allows `note` or `anchor`), so the
+"external links open via `target=_blank`" path from the task brief is
+structurally unreachable today and the renderer does not set
+`target="_blank"` on any plugin link. If a future v1.3 shape adds an
+opt-in raw-href variant the click handler will need a new branch
+there; for now the contract is "if it's not `wikilink://`, default
+browser behaviour".
+
+### Reference plugin update
+
+`public/plugins/noteser-vnode-demo` bumps to `0.3.0`. The plugin now:
+
+- Subscribes to `ctx.onVNodeEvent` from `onActivate` and notifies on
+  every event, stamping the event name + source kind in the toast.
+  Also `console.log`s every event for the manual smoke check.
+- Tracks the active note via `onActiveNoteChange` and renders a
+  `link` VNode pointing at it (`{ kind: 'note', noteId }`). Clicking
+  the link opens the note via the new wikilink intercept.
+- Bumped manifest version. No new permissions — the follow-up is
+  pure plumbing.
+
+### Tests
+
+- `src/plugins/__tests__/vnodeEventDelivery.test.ts` — `sendVNodeEvent`
+  posts the correct envelope per surface, rate-limit caps the
+  delivered count, per-plugin window does not starve sibling plugins,
+  `unload()` stops further deliveries.
+- `src/plugins/__tests__/pluginLinkWikilinkIntercept.test.tsx` —
+  plain click dispatches `openNote(noteId)` with the typed id;
+  modifier-clicks pass through; `#fragment` links are untouched;
+  `preventDefault` fires for wikilink clicks.
+
+### Files touched
+
+```
+docs/plugins-v1.2-impl-notes.md                                     (appended)
+packages/noteser-plugin-sdk/src/sdk.ts
+public/plugins/noteser-vnode-demo/main.js
+public/plugins/noteser-vnode-demo/manifest.json
+src/components/editor/PluginCodeBlock.tsx
+src/components/plugins/PluginFullscreenView.tsx
+src/components/sidebar/PluginsPanel.tsx
+src/plugins/PluginHost.ts
+src/plugins/PluginVNode.tsx
+src/plugins/protocol.ts
+src/plugins/sdk.ts
+src/plugins/workerEntry.ts
+src/plugins/__tests__/pluginLinkWikilinkIntercept.test.tsx          (new)
+src/plugins/__tests__/vnodeEventDelivery.test.ts                    (new)
+```

--- a/packages/noteser-plugin-sdk/src/sdk.ts
+++ b/packages/noteser-plugin-sdk/src/sdk.ts
@@ -302,6 +302,37 @@ export interface PluginCtx {
   }
 
   /**
+   * v1.2 — register a handler for every VNode event a rendered surface
+   * fires back. The renderer attached event intents to VNode shapes
+   * (`{ kind: 'emit', event, payload? }` on a button's `onClick`, a
+   * radio's `onChange`, etc.); the host packages those firings into
+   * `host:vnodeEvent` envelopes and the worker dispatches them here.
+   *
+   * `source` tells the handler WHICH rendered surface produced the
+   * event so a plugin that uses the same event name in two surfaces
+   * (e.g. a "save" button in both the sidebar panel and a fullscreen
+   * modal) can disambiguate without renaming.
+   *
+   * Multiple registrations stack — every handler fires for every
+   * event. Returns an `Unsubscribe` thunk; the host also auto-drops
+   * every handler on plugin unload (the worker itself is terminated).
+   *
+   * Backwards-compatible: existing v1.2 plugins that never call this
+   * API see no behaviour change — events fired by their rendered
+   * controls are simply discarded by the worker.
+   */
+  onVNodeEvent(
+    handler: (args: {
+      event: string
+      payload: unknown
+      source:
+        | { kind: 'panel'; panelId: string }
+        | { kind: 'codeBlock'; blockId: string }
+        | { kind: 'fullscreen'; viewId: string }
+    }) => void,
+  ): Unsubscribe
+
+  /**
    * v1.2 PR B — request that the host mount one of this plugin's
    * declared fullscreen views. The view id must appear in
    * `surfaces.fullscreenViews` of the manifest. Only one fullscreen

--- a/public/plugins/noteser-vnode-demo/main.js
+++ b/public/plugins/noteser-vnode-demo/main.js
@@ -1,22 +1,44 @@
-// noteser-vnode-demo v0.2.0
+// noteser-vnode-demo v0.3.0
 //
-// Reference plugin for Plugin API v1.2 PR A + PR B.
+// Reference plugin for Plugin API v1.2 PR A + PR B + the VNode event
+// delivery follow-up.
 //
 // PR A added the new VNode shapes (button, input, list, link, radio,
 // svg, box). The sidebar panel below renders one of each.
 //
 // PR B added the fullscreen view surface. The "VNode demo: show
-// fullscreen" command opens a modal with a box that contains a
-// callout, a button, and a tiny SVG so a human can confirm:
-//   - opening returns a Promise that resolves once the modal is up
-//   - onFullscreenMount fires + setFullscreenContent populates the body
-//   - Esc + X both close + onFullscreenUnmount fires
-//   - opening a second time while one is open rejects with a clear
-//     message
+// fullscreen" command opens a modal containing a callout, button, and
+// SVG.
+//
+// The follow-up wires `host:vnodeEvent` delivery + adds
+// `ctx.onVNodeEvent`. This version subscribes via that API and logs
+// every event the host forwards. Clicking the button, typing in the
+// input, picking a radio, or clicking the SVG circle all surface as
+// notify toasts so a human can confirm the round-trip end-to-end.
+//
+// The "Open the first note" link demonstrates the wikilink:// click
+// intercept. The plugin asks the host for the active note's id via
+// onActiveNoteChange and renders a link to it; clicking dispatches
+// openNote(noteId) instead of the browser trying to navigate to an
+// unknown scheme.
 //
 // Self-contained ES module. Worker dynamic-imports via Blob URL.
 
 function panelView(state) {
+  const items = [
+    { tag: 'text', value: 'List item one' },
+    { tag: 'text', value: 'List item two' },
+  ]
+  if (state.activeNoteId) {
+    items.push({
+      tag: 'link',
+      label: `Open the current note (${state.activeNoteId.slice(0, 8)}…)`,
+      href: { kind: 'note', noteId: state.activeNoteId },
+    })
+  } else {
+    items.push({ tag: 'text', value: '(open a note to see a wikilink demo link)' })
+  }
+
   return {
     tag: 'box',
     gap: 3,
@@ -27,7 +49,7 @@ function panelView(state) {
         tag: 'callout',
         kind: 'info',
         title: 'What this panel is for',
-        body: 'Every new VNode shape in PR A renders here. Click the button, type in the input, pick a radio. The worker logs each event so you can confirm the wire works.',
+        body: 'Every new VNode shape in PR A renders here. Click the button, type in the input, pick a radio. Each event surfaces as a toast — the host forwards them via the VNode event delivery wire.',
       },
 
       {
@@ -59,15 +81,7 @@ function panelView(state) {
       {
         tag: 'list',
         ordered: false,
-        items: [
-          { tag: 'text', value: 'List item one' },
-          { tag: 'text', value: 'List item two' },
-          {
-            tag: 'link',
-            label: 'Open a note by id',
-            href: { kind: 'note', noteId: 'sample-note-id' },
-          },
-        ],
+        items,
       },
 
       {
@@ -102,7 +116,7 @@ function fullscreenView() {
         tag: 'callout',
         kind: 'tip',
         title: 'PR B fullscreen demo',
-        body: 'This box is rendered inside the host fullscreen modal. Press Esc or click the X to close. The plugin gets onFullscreenUnmount when you do.',
+        body: 'This box is rendered inside the host fullscreen modal. Press Esc or click the X to close. Click the button and the worker will log a fullscreen-source event.',
       },
       {
         tag: 'button',
@@ -136,13 +150,17 @@ function fullscreenView() {
   }
 }
 
+// Mutable panel state. The renderer rebuilds the tree from this snapshot
+// every time the plugin pushes a new setPanelContent.
+const panelState = { text: '', mode: 'a', activeNoteId: null }
+
 export default {
   id: 'noteser-vnode-demo',
   name: 'VNode demo',
-  version: '0.2.0',
+  version: '0.3.0',
   author: 'Noteser',
   description:
-    'Reference plugin for v1.2 PRs A and B. Exercises every new VNode shape inside a sidebar panel, and opens a fullscreen view from the command palette.',
+    'Reference plugin for v1.2 PRs A, B, and the VNode event delivery follow-up. Renders every new VNode shape in a sidebar panel, opens a fullscreen view from the palette, and logs every VNode event the host forwards.',
   surfaces: {
     sidebarPanels: [{ id: 'demo', title: 'VNode demo' }],
     commands: [
@@ -153,10 +171,51 @@ export default {
     ],
   },
 
+  onActivate(ctx) {
+    // Subscribe to every VNode event the host forwards. The handler
+    // receives { event, payload, source } — `source.kind` tells us
+    // which rendered surface produced the event so we can branch.
+    ctx.onVNodeEvent(({ event, payload, source }) => {
+      // Surface as a toast so the human running the demo can see the
+      // round-trip without opening devtools.
+      const label =
+        source.kind === 'panel'
+          ? `panel "${source.panelId}"`
+          : source.kind === 'fullscreen'
+          ? `fullscreen "${source.viewId}"`
+          : `code block "${source.blockId}"`
+      ctx.notify(`event "${event}" from ${label}`)
+
+      // Update local state on the controlled inputs so the next render
+      // reflects what the user typed / picked.
+      if (event === 'demo.text' && payload && typeof payload === 'object') {
+        panelState.text = String(payload.value ?? '')
+        ctx.setPanelContent('demo', panelView(panelState))
+      }
+      if (event === 'demo.mode' && payload && typeof payload === 'object') {
+        panelState.mode = String(payload.value ?? 'a')
+        ctx.setPanelContent('demo', panelView(panelState))
+      }
+    })
+
+    // Console log every event too, for the devtools smoke check the
+    // task plan calls out.
+    ctx.onVNodeEvent((args) => {
+      // eslint-disable-next-line no-console
+      console.log('[noteser-vnode-demo] vnodeEvent', args)
+    })
+  },
+
   onPanelMount(panelId, ctx) {
     if (panelId !== 'demo') return
-    const state = { text: '', mode: 'a' }
-    ctx.setPanelContent('demo', panelView(state))
+    panelState.activeNoteId = ctx.activeNote?.id ?? null
+    ctx.setPanelContent('demo', panelView(panelState))
+  },
+
+  onActiveNoteChange(note, ctx) {
+    panelState.activeNoteId = note?.id ?? null
+    // Push a fresh tree so the wikilink demo link follows the active note.
+    ctx.setPanelContent('demo', panelView(panelState))
   },
 
   async onCommand(commandId, ctx) {

--- a/public/plugins/noteser-vnode-demo/manifest.json
+++ b/public/plugins/noteser-vnode-demo/manifest.json
@@ -1,9 +1,9 @@
 {
   "id": "noteser-vnode-demo",
   "name": "VNode demo",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Noteser",
-  "description": "Reference plugin for v1.2 PRs A and B. Exercises every new VNode shape inside a sidebar panel, and opens a fullscreen view from the command palette.",
+  "description": "Reference plugin for v1.2 PRs A, B, and the VNode event delivery follow-up. Renders every new VNode shape in a sidebar panel, opens a fullscreen view from the palette, and logs every VNode event the host forwards.",
   "main": "./main.js",
   "surfaces": {
     "sidebarPanels": [

--- a/src/components/editor/PluginCodeBlock.tsx
+++ b/src/components/editor/PluginCodeBlock.tsx
@@ -10,9 +10,9 @@
 // source) so that two structurally-identical blocks share the same
 // pending render request and the same cached result.
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { getPluginHost } from '@/plugins/pluginHostSingleton'
-import { PluginNode } from '@/plugins/PluginVNode'
+import { PluginNode, type PluginVNodeEvent } from '@/plugins/PluginVNode'
 import type { PluginHostEvent } from '@/plugins/PluginHost'
 
 interface Props {
@@ -49,6 +49,18 @@ export const PluginCodeBlock = ({ pluginId, language, source }: Props) => {
     }
   }, [pluginId, language, source, blockId])
 
+  // VNode event dispatch — wraps the renderer's event tuple with the
+  // `codeBlock` source descriptor and forwards through the plugin host.
+  // Rate-limited per plugin in PluginHost.sendVNodeEvent.
+  const handleEvent = useCallback(
+    (e: PluginVNodeEvent) => {
+      const host = getPluginHost()
+      if (!host) return
+      host.sendVNodeEvent(pluginId, { kind: 'codeBlock', blockId }, e.event, e.payload)
+    },
+    [pluginId, blockId],
+  )
+
   if (error) {
     return (
       <pre className="my-2 rounded-lg border border-red-500/30 bg-red-500/5 p-3 text-xs text-red-200">
@@ -67,7 +79,7 @@ export const PluginCodeBlock = ({ pluginId, language, source }: Props) => {
 
   return (
     <div className="my-2 rounded-lg border border-obsidianBorder bg-obsidianDarkGray p-3 text-sm text-obsidianText overflow-x-auto">
-      <PluginNode node={node} />
+      <PluginNode node={node} onEvent={handleEvent} />
     </div>
   )
 }

--- a/src/components/plugins/PluginFullscreenView.tsx
+++ b/src/components/plugins/PluginFullscreenView.tsx
@@ -166,19 +166,18 @@ export const PluginFullscreenView = () => {
   // VNode event dispatch — forward into the wire protocol with the
   // `fullscreen` source kind PR A pre-shipped. The host queues these
   // via the PluginHost rate limiter and posts them as
-  // `host:vnodeEvent` envelopes.
-  const handleEvent = (event: PluginVNodeEvent) => {
+  // `host:vnodeEvent` envelopes; the worker routes to whatever the
+  // plugin registered via `ctx.onVNodeEvent`. Wired in the
+  // "Post-v1.2: VNode event delivery + wikilink intercept" follow-up.
+  const handleEvent = (e: PluginVNodeEvent) => {
     const host = getPluginHost()
     if (!host) return
-    // PluginHost exposes a typed sendVNodeEvent helper in a later
-    // PR; for now we go through the wire envelope directly via the
-    // worker postMessage on the host side. PR A wired the contract
-    // but not the dispatcher; the panel surface (PluginsPanel) does
-    // not deliver events either yet. PR B keeps parity — events are
-    // structurally correct and the modal does not crash on click,
-    // but the worker does not receive them until the event
-    // registration API ships.
-    void event
+    host.sendVNodeEvent(
+      active.pluginId,
+      { kind: 'fullscreen', viewId: active.viewId },
+      e.event,
+      e.payload,
+    )
   }
 
   return (

--- a/src/components/sidebar/PluginsPanel.tsx
+++ b/src/components/sidebar/PluginsPanel.tsx
@@ -18,10 +18,10 @@
 // in the real VNode → React mapper (see docs/plugins-plan.md
 // "VNode" section).
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { usePluginStore, selectAllPluginPanels, type PluginPanelEntry } from '@/stores/pluginStore'
 import { getPluginHost } from '@/plugins/pluginHostSingleton'
-import { PluginNode } from '@/plugins/PluginVNode'
+import { PluginNode, type PluginVNodeEvent } from '@/plugins/PluginVNode'
 import type { PluginHostEvent } from '@/plugins/PluginHost'
 
 export const PluginsPanel = () => {
@@ -57,6 +57,23 @@ export const PluginsPanel = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [panels.map((p) => `${p.pluginId}:${p.panelId}`).join('|')])
 
+  // Build a `PluginNode` event handler scoped to a single (pluginId,
+  // panelId). The renderer hands us the wire-level `PluginVNodeEvent`
+  // (just `event` + `payload`); we wrap it with the `source` descriptor
+  // and forward to the host. Rate-limited per plugin in PluginHost.
+  //
+  // Declared above the early return so the hook order stays stable —
+  // rules-of-hooks forbids calling useCallback past a conditional.
+  const makeHandler = useCallback(
+    (pluginId: string, panelId: string) =>
+      (e: PluginVNodeEvent) => {
+        const host = getPluginHost()
+        if (!host) return
+        host.sendVNodeEvent(pluginId, { kind: 'panel', panelId }, e.event, e.payload)
+      },
+    [],
+  )
+
   if (panels.length === 0) {
     return (
       <div className="p-4 text-sm text-obsidianSecondaryText">
@@ -86,7 +103,7 @@ export const PluginsPanel = () => {
               {node === undefined ? (
                 <span className="text-obsidianSecondaryText">(awaiting first render…)</span>
               ) : (
-                <PluginNode node={node} />
+                <PluginNode node={node} onEvent={makeHandler(p.pluginId, p.panelId)} />
               )}
             </div>
           </section>

--- a/src/plugins/PluginHost.ts
+++ b/src/plugins/PluginHost.ts
@@ -11,8 +11,10 @@ import {
   isWorkerToHost,
   MAX_ENVELOPE_BYTES,
   MAX_MESSAGES_PER_SECOND,
+  MAX_VNODE_EVENTS_PER_SECOND,
   VAULT_EVENT_DEBOUNCE_MS,
   type HostToWorker,
+  type HostVNodeEvent,
   type WorkerToHost,
   type NoteWithBodyWire,
 } from './protocol'
@@ -120,6 +122,7 @@ export type PluginHostEvent =
       op: VaultWriteOp
     }
   | { type: 'rateLimited'; pluginId: string }
+  | { type: 'vnodeEventRateLimited'; pluginId: string }
 
 /** Discriminated union over the four vault.write ops carried in a
  *  `worker:requestVaultWrite` envelope. Identical shape to the wire
@@ -158,6 +161,14 @@ interface WorkerEntry {
     noteSaved: PendingEvent<Set<string>>
     activeNoteIdChanged: PendingEvent<{ noteId: string | null }>
   }
+  /** Per-plugin VNode event rate-limit window. The host forwards at
+   *  most `MAX_VNODE_EVENTS_PER_SECOND` host:vnodeEvent envelopes per
+   *  1-second sliding window. The first event past the cap also emits
+   *  a `vnodeEventRateLimited` PluginHostEvent so the dev console can
+   *  spot a runaway loop. */
+  vnodeEventWindowStart: number
+  vnodeEventsInWindow: number
+  vnodeEventRateLimitWarned: boolean
 }
 
 interface VaultSubscription {
@@ -251,6 +262,9 @@ export class PluginHost {
       worker,
       vaultSubs: new Map(),
       vaultDebounce: makePendingState(),
+      vnodeEventWindowStart: nowMs(),
+      vnodeEventsInWindow: 0,
+      vnodeEventRateLimitWarned: false,
     }
     this.workers.set(pluginId, entry)
 
@@ -379,6 +393,57 @@ export class PluginHost {
       language: args.language,
       source: args.source,
       blockId: args.blockId,
+    })
+  }
+
+  /**
+   * v1.2 — forward a VNode event from a rendered surface (panel,
+   * fullscreen modal, code-block) into the plugin's worker. The
+   * worker's `host:vnodeEvent` handler routes the event to whatever
+   * the plugin registered via `ctx.onVNodeEvent`.
+   *
+   * Rate-limited per plugin at `MAX_VNODE_EVENTS_PER_SECOND` over a
+   * 1-second sliding window. Events past the cap are silently dropped
+   * on the host side; the first drop within a window also emits a
+   * `vnodeEventRateLimited` PluginHostEvent (one per window) so the
+   * dev console can flag a runaway loop without spamming the user.
+   *
+   * No-op when the plugin is not loaded. The `source` discriminator
+   * follows the wire shape in `protocol.ts:HostVNodeEvent` exactly —
+   * the renderer-side surfaces (`PluginsPanel`, `PluginFullscreenView`,
+   * `PluginCodeBlock`) wrap this call with their own source descriptor.
+   */
+  sendVNodeEvent(
+    pluginId: string,
+    source: HostVNodeEvent['source'],
+    event: string,
+    payload: unknown,
+  ): void {
+    const entry = this.workers.get(pluginId)
+    if (!entry) return
+    if (typeof event !== 'string' || event.length === 0) return
+
+    const now = nowMs()
+    if (now - entry.vnodeEventWindowStart >= 1000) {
+      entry.vnodeEventWindowStart = now
+      entry.vnodeEventsInWindow = 0
+      entry.vnodeEventRateLimitWarned = false
+    }
+    entry.vnodeEventsInWindow++
+    if (entry.vnodeEventsInWindow > MAX_VNODE_EVENTS_PER_SECOND) {
+      if (!entry.vnodeEventRateLimitWarned) {
+        entry.vnodeEventRateLimitWarned = true
+        this.emit({ type: 'vnodeEventRateLimited', pluginId })
+      }
+      return
+    }
+
+    this.send(pluginId, {
+      type: 'host:vnodeEvent',
+      seq: ++this.seqCounter,
+      event,
+      payload,
+      source,
     })
   }
 

--- a/src/plugins/PluginVNode.tsx
+++ b/src/plugins/PluginVNode.tsx
@@ -31,7 +31,8 @@
 //
 // All shapes carry `tag` as discriminator.
 
-import type { CSSProperties, ReactNode } from 'react'
+import type { CSSProperties, MouseEvent, ReactNode } from 'react'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
 
 // ─── v1 shapes (unchanged) ────────────────────────────────────────────────
 
@@ -486,15 +487,58 @@ function renderLink(v: VNodeLink): ReactNode | null {
   // and #fragment, but the named guard keeps the security contract
   // explicit at the render site.
   if (!isSafePluginHref(href)) return null
+  // Pull the noteId off the typed `href.kind === 'note'` branch so the
+  // click handler can dispatch openNote without re-decoding the URL.
+  // Same goes for the anchor fragment — keeps the security contract on
+  // the typed shape, not on string parsing.
+  const noteId = v.href.kind === 'note' ? v.href.noteId : null
   return (
     <a
       href={href}
       className="text-blue-500 underline hover:text-blue-400"
       rel="noopener noreferrer"
+      onClick={(e) => handlePluginLinkClick(e, href, noteId)}
     >
       {v.label}
     </a>
   )
+}
+
+/**
+ * Click handler for plugin-rendered `<a>` shapes. The renderer emits
+ * two URL forms via `linkHrefToString`:
+ *   - `wikilink://<encodedNoteId>` for `{ kind: 'note' }` links
+ *   - `#<encodedFragment>` for `{ kind: 'anchor' }` links
+ *
+ * Browser navigation to `wikilink://` does nothing (unknown scheme), so
+ * the renderer must intercept the click and dispatch the host's
+ * `workspaceStore.openNote(noteId)` action instead. The `noteId` lives
+ * on the typed `VNodeLink.href.kind === 'note'` branch — we pass it
+ * down here rather than re-decoding the URL string so the parsing
+ * surface stays at one chokepoint (`linkHrefToString`).
+ *
+ * Anchor (`#fragment`) links keep default browser behaviour, which is
+ * the native anchor-scroll inside the document.
+ *
+ * Documented in `docs/plugins-v1.2-impl-notes.md` under "Post-v1.2:
+ * VNode event delivery + wikilink intercept".
+ */
+function handlePluginLinkClick(
+  e: MouseEvent<HTMLAnchorElement>,
+  href: string,
+  noteId: string | null,
+): void {
+  // Anchor / fragment links — let the browser do its thing.
+  if (!href.startsWith('wikilink://')) return
+  // Modifier-click should follow native semantics (no-op for an
+  // unrecognised scheme); we only intercept the unmodified primary
+  // click so a power user is not surprised.
+  if (e.defaultPrevented) return
+  if (e.button !== 0) return
+  if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return
+  e.preventDefault()
+  if (noteId === null) return
+  useWorkspaceStore.getState().openNote(noteId)
 }
 
 function renderRadio(v: VNodeRadio, ctx: RenderContext): ReactNode | null {

--- a/src/plugins/__tests__/pluginLinkWikilinkIntercept.test.tsx
+++ b/src/plugins/__tests__/pluginLinkWikilinkIntercept.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Click intercept on plugin-rendered `<a href="wikilink://...">`.
+ *
+ * A plugin emits a `{ tag: 'link', href: { kind: 'note', noteId } }`
+ * VNode; the renderer turns that into an anchor with a
+ * `wikilink://<encodedId>` href. Browser navigation to an unrecognised
+ * scheme is a no-op, so the renderer must intercept the click and
+ * dispatch the host's `useWorkspaceStore.openNote(noteId)` action.
+ *
+ * Tests:
+ *   - Primary-button click on a note link calls openNote with the
+ *     noteId off the typed shape (not from URL parsing).
+ *   - Modifier-clicks (cmd / ctrl / shift / alt) are NOT intercepted —
+ *     the user's intent is "follow the URL natively", which is a no-op
+ *     for `wikilink://` but we don't pretend otherwise.
+ *   - Anchor (`#fragment`) links are not intercepted; the browser's
+ *     native fragment-scroll handles them.
+ *
+ * Documented in `docs/plugins-v1.2-impl-notes.md` under "Post-v1.2:
+ * VNode event delivery + wikilink intercept".
+ */
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { PluginNode } from '@/plugins/PluginVNode'
+import { useWorkspaceStore } from '@/stores/workspaceStore'
+
+describe('plugin link — wikilink click intercept', () => {
+  let openNoteSpy: jest.Mock
+  let originalOpenNote: ReturnType<typeof useWorkspaceStore.getState>['openNote']
+  beforeEach(() => {
+    originalOpenNote = useWorkspaceStore.getState().openNote
+    openNoteSpy = jest.fn()
+    useWorkspaceStore.setState({ openNote: openNoteSpy })
+  })
+  afterEach(() => {
+    useWorkspaceStore.setState({ openNote: originalOpenNote })
+  })
+
+  test('plain click on a wikilink dispatches openNote(noteId)', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'link',
+          label: 'Open note',
+          href: { kind: 'note', noteId: 'note-123' },
+        }}
+      />,
+    )
+    const link = screen.getByRole('link', { name: 'Open note' })
+    expect(link.getAttribute('href')).toBe('wikilink://note-123')
+
+    fireEvent.click(link, { button: 0 })
+
+    expect(openNoteSpy).toHaveBeenCalledTimes(1)
+    expect(openNoteSpy).toHaveBeenCalledWith('note-123')
+  })
+
+  test('the noteId comes from the typed shape, not URL decoding', () => {
+    // A noteId with characters that need percent-encoding round-trips
+    // unchanged through openNote — the click path never decodes the URL.
+    render(
+      <PluginNode
+        node={{
+          tag: 'link',
+          label: 'Open',
+          href: { kind: 'note', noteId: 'has space and / slash' },
+        }}
+      />,
+    )
+    const link = screen.getByRole('link', { name: 'Open' })
+    fireEvent.click(link, { button: 0 })
+    expect(openNoteSpy).toHaveBeenCalledWith('has space and / slash')
+  })
+
+  test('cmd/ctrl/shift/alt-click is not intercepted', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'link',
+          label: 'Open',
+          href: { kind: 'note', noteId: 'abc' },
+        }}
+      />,
+    )
+    const link = screen.getByRole('link', { name: 'Open' })
+    fireEvent.click(link, { button: 0, metaKey: true })
+    fireEvent.click(link, { button: 0, ctrlKey: true })
+    fireEvent.click(link, { button: 0, shiftKey: true })
+    fireEvent.click(link, { button: 0, altKey: true })
+    expect(openNoteSpy).not.toHaveBeenCalled()
+  })
+
+  test('anchor (#fragment) links are not intercepted', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'link',
+          label: 'Jump',
+          href: { kind: 'anchor', fragment: 'section-1' },
+        }}
+      />,
+    )
+    const link = screen.getByRole('link', { name: 'Jump' })
+    expect(link.getAttribute('href')).toBe('#section-1')
+
+    fireEvent.click(link, { button: 0 })
+
+    // No openNote dispatch — the browser's native fragment-scroll owns
+    // this case.
+    expect(openNoteSpy).not.toHaveBeenCalled()
+  })
+
+  test('preventDefault is called for wikilink clicks (browser navigation suppressed)', () => {
+    render(
+      <PluginNode
+        node={{
+          tag: 'link',
+          label: 'Open',
+          href: { kind: 'note', noteId: 'abc' },
+        }}
+      />,
+    )
+    const link = screen.getByRole('link', { name: 'Open' })
+    // fireEvent.click returns false when a handler called preventDefault.
+    const notPrevented = fireEvent.click(link, { button: 0 })
+    expect(notPrevented).toBe(false)
+  })
+})

--- a/src/plugins/__tests__/vnodeEventDelivery.test.ts
+++ b/src/plugins/__tests__/vnodeEventDelivery.test.ts
@@ -1,0 +1,274 @@
+/**
+ * @jest-environment node
+ *
+ * VNode event delivery — host → worker pipeline.
+ *
+ * Plugin API v1.2 shipped the VNode event ENVELOPE shape and the VNode
+ * shapes (button / input / radio / link) that emit events. The dispatch
+ * + routing pipeline was deferred to this follow-up.
+ *
+ * Tests:
+ *   - `PluginHost.sendVNodeEvent` posts the correct `host:vnodeEvent`
+ *     envelope per surface (panel / fullscreen / codeBlock).
+ *   - Per-plugin rate limit caps delivery at `MAX_VNODE_EVENTS_PER_SECOND`.
+ *   - `unload()` terminates the worker, so subsequent `sendVNodeEvent`
+ *     calls do nothing (no envelope posted, no callback invoked).
+ *
+ * Real Web Workers are unavailable in node + jsdom; we inject a
+ * FakeWorker via `PluginHostOptions.createWorker` that captures every
+ * envelope and surfaces them to the test for assertion. The worker-side
+ * dispatcher is unit-tested separately (it is a Set fan-out plus a
+ * try/catch wrapper — no IO).
+ */
+
+import { PluginHost, type MinimalWorker } from '@/plugins/PluginHost'
+import {
+  MAX_VNODE_EVENTS_PER_SECOND,
+  type HostToWorker,
+  type HostVNodeEvent,
+  type WorkerToHost,
+} from '@/plugins/protocol'
+import type { PluginManifest } from '@/plugins/manifest'
+
+const manifest: PluginManifest = {
+  id: 'demo',
+  name: 'Demo',
+  version: '1.0.0',
+  surfaces: {
+    sidebarPanels: [{ id: 'main', title: 'Main' }],
+    fullscreenViews: [{ id: 'big', title: 'Big' }],
+  },
+}
+
+interface FakeWorkerHandle {
+  worker: MinimalWorker
+  sent: HostToWorker[]
+}
+
+function makeFakeWorker(): FakeWorkerHandle {
+  const sent: HostToWorker[] = []
+  let handler: ((event: MessageEvent) => void) | null = null
+
+  const worker: MinimalWorker = {
+    onmessage: null,
+    postMessage(message: unknown) {
+      sent.push(message as HostToWorker)
+      const msg = message as HostToWorker
+      if (msg.type === 'host:boot') {
+        queueMicrotask(() => {
+          handler?.({
+            data: {
+              type: 'worker:ready',
+              seq: msg.seq,
+              manifest,
+            } satisfies WorkerToHost,
+          } as MessageEvent)
+        })
+      }
+    },
+    terminate() {
+      handler = null
+    },
+  } as MinimalWorker
+
+  Object.defineProperty(worker, 'onmessage', {
+    configurable: true,
+    get(): ((event: MessageEvent) => void) | null {
+      return handler
+    },
+    set(v: ((event: MessageEvent) => void) | null) {
+      handler = v
+    },
+  })
+
+  return { worker, sent }
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('PluginHost.sendVNodeEvent', () => {
+  test('posts a host:vnodeEvent envelope with the panel source for a sidebar event', async () => {
+    const fake = makeFakeWorker()
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'demo', pluginSource: '' })
+
+    host.sendVNodeEvent(
+      'demo',
+      { kind: 'panel', panelId: 'main' },
+      'click',
+      { from: 'button' },
+    )
+
+    const sent = fake.sent.find((m) => m.type === 'host:vnodeEvent') as
+      | HostVNodeEvent
+      | undefined
+    expect(sent).toBeDefined()
+    expect(sent?.event).toBe('click')
+    expect(sent?.payload).toEqual({ from: 'button' })
+    expect(sent?.source).toEqual({ kind: 'panel', panelId: 'main' })
+  })
+
+  test('posts a fullscreen source descriptor for fullscreen events', async () => {
+    const fake = makeFakeWorker()
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'demo', pluginSource: '' })
+
+    host.sendVNodeEvent(
+      'demo',
+      { kind: 'fullscreen', viewId: 'big' },
+      'submit',
+      undefined,
+    )
+
+    const sent = fake.sent.find((m) => m.type === 'host:vnodeEvent') as
+      | HostVNodeEvent
+      | undefined
+    expect(sent?.source).toEqual({ kind: 'fullscreen', viewId: 'big' })
+  })
+
+  test('posts a codeBlock source descriptor for code-block events', async () => {
+    const fake = makeFakeWorker()
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'demo', pluginSource: '' })
+
+    host.sendVNodeEvent(
+      'demo',
+      { kind: 'codeBlock', blockId: 'b1' },
+      'graphpick',
+      { id: 'n1' },
+    )
+
+    const sent = fake.sent.find((m) => m.type === 'host:vnodeEvent') as
+      | HostVNodeEvent
+      | undefined
+    expect(sent?.source).toEqual({ kind: 'codeBlock', blockId: 'b1' })
+    expect(sent?.payload).toEqual({ id: 'n1' })
+  })
+
+  test('drops empty event names without posting an envelope', async () => {
+    const fake = makeFakeWorker()
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'demo', pluginSource: '' })
+
+    host.sendVNodeEvent('demo', { kind: 'panel', panelId: 'main' }, '', null)
+    expect(fake.sent.some((m) => m.type === 'host:vnodeEvent')).toBe(false)
+  })
+
+  test('no-op when the plugin id is unknown (post-unload safety)', async () => {
+    const fake = makeFakeWorker()
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'demo', pluginSource: '' })
+    host.unload('demo')
+
+    host.sendVNodeEvent(
+      'demo',
+      { kind: 'panel', panelId: 'main' },
+      'click',
+      null,
+    )
+    expect(fake.sent.some((m) => m.type === 'host:vnodeEvent')).toBe(false)
+  })
+})
+
+describe('PluginHost.sendVNodeEvent — rate limit', () => {
+  test('drops events past MAX_VNODE_EVENTS_PER_SECOND in a 1-second window', async () => {
+    const fake = makeFakeWorker()
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'demo', pluginSource: '' })
+
+    // Fire one above the cap. The fake's sent[] captures every
+    // postMessage so we count the host:vnodeEvent envelopes only.
+    const overage = MAX_VNODE_EVENTS_PER_SECOND + 5
+    for (let i = 0; i < overage; i++) {
+      host.sendVNodeEvent(
+        'demo',
+        { kind: 'panel', panelId: 'main' },
+        `e${i}`,
+        null,
+      )
+    }
+    await flushMicrotasks()
+
+    const delivered = fake.sent.filter((m) => m.type === 'host:vnodeEvent')
+    expect(delivered).toHaveLength(MAX_VNODE_EVENTS_PER_SECOND)
+  })
+
+  test('emits a vnodeEventRateLimited PluginHostEvent once per window when the cap is hit', async () => {
+    const fake = makeFakeWorker()
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    const rateLimits: string[] = []
+    host.on((e) => {
+      if (e.type === 'vnodeEventRateLimited') rateLimits.push(e.pluginId)
+    })
+    await host.load({ pluginId: 'demo', pluginSource: '' })
+
+    for (let i = 0; i < MAX_VNODE_EVENTS_PER_SECOND * 2; i++) {
+      host.sendVNodeEvent(
+        'demo',
+        { kind: 'panel', panelId: 'main' },
+        'click',
+        null,
+      )
+    }
+
+    // Exactly one warning per window despite many drops.
+    expect(rateLimits).toEqual(['demo'])
+  })
+
+  test('rate-limit window is per-plugin (one busy plugin does not starve another)', async () => {
+    const fakeA = makeFakeWorker()
+    const fakeB = makeFakeWorker()
+    const host = new PluginHost({
+      createWorker: (() => {
+        let n = 0
+        return () => (n++ === 0 ? fakeA.worker : fakeB.worker)
+      })(),
+    })
+    await host.load({ pluginId: 'a', pluginSource: '' })
+    await host.load({ pluginId: 'b', pluginSource: '' })
+
+    for (let i = 0; i < MAX_VNODE_EVENTS_PER_SECOND * 2; i++) {
+      host.sendVNodeEvent('a', { kind: 'panel', panelId: 'p' }, 'click', null)
+    }
+    // Plugin B should not be affected by A's storm.
+    host.sendVNodeEvent('b', { kind: 'panel', panelId: 'p' }, 'click', null)
+
+    const deliveredA = fakeA.sent.filter((m) => m.type === 'host:vnodeEvent')
+    const deliveredB = fakeB.sent.filter((m) => m.type === 'host:vnodeEvent')
+    expect(deliveredA).toHaveLength(MAX_VNODE_EVENTS_PER_SECOND)
+    expect(deliveredB).toHaveLength(1)
+  })
+})
+
+describe('PluginHost.sendVNodeEvent — cleanup on unload', () => {
+  test('unload terminates the worker and subsequent sendVNodeEvent posts nothing', async () => {
+    const fake = makeFakeWorker()
+    let terminated = 0
+    const origTerminate = fake.worker.terminate.bind(fake.worker)
+    fake.worker.terminate = () => {
+      terminated++
+      origTerminate()
+    }
+    const host = new PluginHost({ createWorker: () => fake.worker })
+    await host.load({ pluginId: 'demo', pluginSource: '' })
+
+    // Sanity: one event delivers fine.
+    host.sendVNodeEvent('demo', { kind: 'panel', panelId: 'main' }, 'e1', null)
+    expect(
+      fake.sent.filter((m) => m.type === 'host:vnodeEvent'),
+    ).toHaveLength(1)
+
+    host.unload('demo')
+    expect(terminated).toBe(1)
+
+    // Any further events must not post anything; the entry is gone.
+    host.sendVNodeEvent('demo', { kind: 'panel', panelId: 'main' }, 'e2', null)
+    host.sendVNodeEvent('demo', { kind: 'panel', panelId: 'main' }, 'e3', null)
+    expect(
+      fake.sent.filter((m) => m.type === 'host:vnodeEvent'),
+    ).toHaveLength(1)
+  })
+})

--- a/src/plugins/protocol.ts
+++ b/src/plugins/protocol.ts
@@ -22,6 +22,20 @@ export const MAX_ENVELOPE_BYTES = 256 * 1024 // 256 KB
 /** Per-plugin rate limit. Host drops + warns above this. */
 export const MAX_MESSAGES_PER_SECOND = 60
 
+/** Per-plugin cap on VNode events the host forwards to the worker in a
+ *  1-second sliding window. A run of click / change events from a busy
+ *  surface (radio + input + svg circle in the same render) easily
+ *  exceeds a single keystroke; the cap is tighter than the general
+ *  60/sec ceiling so an accidental loop in a plugin's render function
+ *  cannot spiral into a worker-pinning event flood. Anything above the
+ *  cap is silently dropped on the host side — the plugin's `onVNodeEvent`
+ *  handler simply stops being invoked until the window closes.
+ *
+ *  16 events/sec is roughly one event per repaint at 60Hz with three
+ *  surface render passes per frame headroom. Plenty for interactive
+ *  controls; too few for a runaway loop. */
+export const MAX_VNODE_EVENTS_PER_SECOND = 16
+
 /** Debounce window (ms) the host applies to every `vault.events`
  *  dispatch (vaultChanged / noteSaved / activeNoteIdChanged). Plugins
  *  cannot lower this — the cap is host-side so a runaway plugin cannot

--- a/src/plugins/sdk.ts
+++ b/src/plugins/sdk.ts
@@ -250,6 +250,37 @@ export interface PluginCtx {
   }
 
   /**
+   * v1.2 — register a handler for every VNode event a rendered surface
+   * fires back. The renderer attached event intents to VNode shapes
+   * (`{ kind: 'emit', event, payload? }` on a button's `onClick`, a
+   * radio's `onChange`, etc.); the host packages those firings into
+   * `host:vnodeEvent` envelopes and the worker dispatches them here.
+   *
+   * `source` tells the handler WHICH rendered surface produced the
+   * event so a plugin that uses the same event name in two surfaces
+   * (e.g. a "save" button in both the sidebar panel and a fullscreen
+   * modal) can disambiguate without renaming.
+   *
+   * Multiple registrations stack — every handler fires for every
+   * event. Returns an `Unsubscribe` thunk; the host also auto-drops
+   * every handler on plugin unload (the worker itself is terminated).
+   *
+   * Backwards-compatible: existing v1.2 plugins that never call this
+   * API see no behaviour change — events fired by their rendered
+   * controls are simply discarded by the worker.
+   */
+  onVNodeEvent(
+    handler: (args: {
+      event: string
+      payload: unknown
+      source:
+        | { kind: 'panel'; panelId: string }
+        | { kind: 'codeBlock'; blockId: string }
+        | { kind: 'fullscreen'; viewId: string }
+    }) => void,
+  ): Unsubscribe
+
+  /**
    * v1.2 PR B — request that the host mount one of this plugin's
    * declared fullscreen views. The view id must appear in
    * `surfaces.fullscreenViews` of the manifest. Only one fullscreen

--- a/src/plugins/workerEntry.ts
+++ b/src/plugins/workerEntry.ts
@@ -116,6 +116,57 @@ function allocRequestSeq(): number {
   return ++nextRequestSeq
 }
 
+// ─── VNode event handlers (v1.2) ────────────────────────────────────────
+//
+// Plugins call `ctx.onVNodeEvent(handler)` to receive every event a
+// rendered surface (sidebar panel, fullscreen modal, code block) fires
+// back. The renderer attached the event names to the VNode shapes; the
+// host bundles them into a `host:vnodeEvent` envelope and posts here.
+//
+// Handler shape: `({ event, payload, source }) => void`. ONE handler
+// per registration; the plugin owns its own dispatch table. Returning
+// `Unsubscribe` removes it. On plugin teardown the worker module is
+// terminated so the handlers vanish along with everything else; we do
+// not need to drain the set manually.
+//
+// Multiple registrations stack — each handler fires for every event.
+// Plugins typically register one, but the SDK contract allows N so a
+// plugin that wraps `onVNodeEvent` for telemetry doesn't have to be
+// the only owner.
+
+type VNodeEventSource =
+  | { kind: 'panel'; panelId: string }
+  | { kind: 'codeBlock'; blockId: string }
+  | { kind: 'fullscreen'; viewId: string }
+
+type VNodeEventHandler = (args: {
+  event: string
+  payload: unknown
+  source: VNodeEventSource
+}) => void
+
+const vnodeEventHandlers = new Set<VNodeEventHandler>()
+
+function dispatchVNodeEvent(
+  event: string,
+  payload: unknown,
+  source: VNodeEventSource,
+): void {
+  // Snapshot before iterating — a handler that calls `unsubscribe()`
+  // would otherwise mutate the set mid-iteration.
+  for (const handler of Array.from(vnodeEventHandlers)) {
+    try {
+      handler({ event, payload, source })
+    } catch (err) {
+      emit({
+        type: 'worker:error',
+        seq: 0,
+        message: `onVNodeEvent handler threw: ${err instanceof Error ? err.message : String(err)}`,
+      })
+    }
+  }
+}
+
 // ─── vault.events subscriptions ─────────────────────────────────────────
 //
 // One handler table per event type. The worker mints opaque
@@ -301,6 +352,10 @@ self.onmessage = async (event: MessageEvent<HostToWorker>) => {
         p.push(msg.notes as ReadonlyArray<NoteWithBody>, null)
         return
       }
+
+      case 'host:vnodeEvent':
+        dispatchVNodeEvent(msg.event, msg.payload, msg.source)
+        return
 
       case 'host:vaultChanged':
         dispatchVault(msg.subscriptionId, undefined)
@@ -740,6 +795,16 @@ function buildCtx(parentSeq: number): PluginCtx {
         })
         return promise
       },
+    },
+    onVNodeEvent(handler) {
+      // No envelope round-trip — registration is worker-local. The host
+      // already posts every event for the plugin (the renderer attaches
+      // event names per surface). Stacking handlers is allowed; the
+      // dispatcher fans out to every one of them in registration order.
+      vnodeEventHandlers.add(handler)
+      return () => {
+        vnodeEventHandlers.delete(handler)
+      }
     },
     openFullscreen(viewId: string) {
       const requestSeq = allocRequestSeq()


### PR DESCRIPTION
## Summary

Plugin API v1.2 (PRs A–F + integration #141) shipped the VNode event ENVELOPE shape and the VNode shapes (`button` / `input` / `radio` / clickable `svg`) that emit events, but the dispatch + routing pipeline was never wired. Four feature plugins (#70 / #71 / #72 / #73) hit the same wall trying to use the API today. This PR closes two distinct gaps in a single piece of plumbing.

### Gap 1 — VNode events did not reach the plugin

- `PluginFullscreenView.handleEvent` was a documented no-op.
- `PluginsPanel`'s `<PluginNode>` mount had no `onEvent` prop.
- `PluginHost` had no `sendVNodeEvent` method.
- `workerEntry.ts` had no inbound handler for `host:vnodeEvent`.
- `PluginCtx` had no `onVNodeEvent` registration API.

The wire envelope (`HostVNodeEvent` in `src/plugins/protocol.ts`) was already correct with the `source.kind: 'panel' | 'codeBlock' | 'fullscreen'` discriminator — PR A pre-shipped the shape. This PR wires both ends.

### Gap 2 — `wikilink://` clicks on plugin-rendered note links did nothing

A plugin emits `{ tag: 'link', href: { kind: 'note', noteId } }`; the renderer produces `<a href="wikilink://<encodedId>">`. Browser navigation to an unrecognised scheme is a no-op, so the click was inert.

## What landed

### Dispatch + routing

- `PluginHost.sendVNodeEvent(pluginId, source, event, payload)` constructs the envelope and posts to the worker.
- `workerEntry.ts` handles `host:vnodeEvent` by fanning out to every handler registered via `ctx.onVNodeEvent`. Handlers live in a worker-local `Set`; `unload()` calls `worker.terminate()`, which drops the entire module and every handler with it.
- `PluginsPanel`, `PluginFullscreenView`, and `PluginCodeBlock` now pass an `onEvent` callback to `<PluginNode>` with the right `source` descriptor (`{ kind: 'panel', panelId }` / `{ kind: 'fullscreen', viewId }` / `{ kind: 'codeBlock', blockId }`).

### SDK addition

`ctx.onVNodeEvent(handler): Unsubscribe` ships in BOTH `src/plugins/sdk.ts` and `packages/noteser-plugin-sdk/src/sdk.ts`.

Handler signature:

```ts
(args: {
  event: string
  payload: unknown
  source:
    | { kind: 'panel'; panelId: string }
    | { kind: 'codeBlock'; blockId: string }
    | { kind: 'fullscreen'; viewId: string }
}) => void
```

ONE handler shape with the `source` discriminator rather than the plan-section-6 `(event, cb)` pair so plugins that reuse an event name across surfaces can disambiguate without renaming.

### Wikilink intercept

The renderer's `renderLink` now attaches an `onClick`:
- If `href` starts with `wikilink://` AND the click is unmodified (no meta / ctrl / shift / alt, primary button), call `e.preventDefault()` and `useWorkspaceStore.getState().openNote(noteId)`. The noteId comes from the typed `VNodeLink.href.kind === 'note'` branch — NOT URL parsing — so the parsing surface stays at one chokepoint.
- Modifier-clicks pass through (native semantics, no-op for an unknown scheme).
- Anchor (`#fragment`) links are untouched (native fragment-scroll owns that case).

## Rate-limit choice

`MAX_VNODE_EVENTS_PER_SECOND = 16` events / sec / plugin, sliding 1-second window. Tighter than the general `MAX_MESSAGES_PER_SECOND` ceiling of 60.

- 16 events/sec is one event per repaint at 60Hz with three frames of headroom — plenty for interactive controls.
- Tight enough to bottom out a runaway loop fast (a render that emits one onClick is typically one event per repaint; a real workload never approaches the cap).
- A drop within a window emits a single `vnodeEventRateLimited` `PluginHostEvent` (one per window) so a runaway loop surfaces in the dev console without spamming the toast layer.

The event family has no acknowledged use case for high-rate streaming — the high-rate paths are `setPanelContent` + `vault.events`, both already capped elsewhere.

## Backwards compatibility

Plugins that never call `ctx.onVNodeEvent` see no behaviour change. Their rendered controls fire events into an empty handler set in the worker, which silently drops them — exactly the pre-PR behaviour.

The `PluginVNode.tsx` renderer adds an `onClick` to every `<a>` it emits, but the handler is a pass-through for any non-`wikilink://` href, so existing tests of the link shape still pass.

## Reference plugin

`public/plugins/noteser-vnode-demo` bumps to `0.3.0`:
- Subscribes via `ctx.onVNodeEvent` from `onActivate` — toasts every event with the source kind, and `console.log`s every event for the manual smoke check.
- Tracks the active note via `onActiveNoteChange` and renders a `link` VNode to it, so the wikilink intercept can be smoke-tested by clicking the link in the panel.
- No new permissions.

## Test plan

- [ ] `npm run lint` is clean.
- [ ] `npx tsc --noEmit` reports zero errors.
- [ ] `npm test -- --ci` is green (207 suites pass, 2564 tests).
- [ ] Install the updated `noteser-vnode-demo` plugin, open the demo panel, click the button — devtools shows the `[noteser-vnode-demo] vnodeEvent` log line with `source.kind: 'panel'`.
- [ ] In the demo panel, click the "Open the current note" link — the host opens that note (wikilink intercept fires).
- [ ] Run the "VNode demo: show fullscreen" command, click the button inside the modal — devtools logs the event with `source.kind: 'fullscreen'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)