### PR TITLE
Plugin: properties UI + Bases-style vault tables (#72)

### DIFF
--- a/public/plugins/noteser-properties/main.js
+++ b/public/plugins/noteser-properties/main.js
@@ -1,0 +1,707 @@
+// noteser-properties v0.1.0
+//
+// Closes issue #72. Two surfaces:
+//
+//   1. Sidebar "Properties+" panel — edit the active note's frontmatter
+//      (key + value rows; inline edit; "+ Add property" row). Saves
+//      flow through ctx.vault.write.updateNote({ frontmatter }) so the
+//      host's writeFrontmatter helper re-serialises the block and the
+//      body stays untouched.
+//
+//   2. Fullscreen "Vault tables" view — Obsidian Bases-style table of
+//      every note in the vault. Columns are inferred as the union of
+//      all frontmatter keys present anywhere. Top input filters by
+//      tag / status / anything (matches title, folderPath, every
+//      stringified frontmatter value). Column headers are buttons —
+//      click to sort. Click a row label to open the note (a `link`
+//      VNode, intercepted via the PR #142 wikilink path). A "Save
+//      current view as note" button exports the active table as
+//      markdown via ctx.vault.write.createNote.
+//
+// Frontmatter source: the host parses each note's frontmatter and
+// hands the plugin a `frontmatter` field on every NoteWithBody, so the
+// plugin does not re-parse YAML. js-yaml is intentionally NOT a
+// dependency.
+//
+// Type inference: per-column, we union every non-null value seen and
+// pick a single column type — 'number' when every value is finite, or
+// can be coerced via Number(); 'date' when every value matches an ISO
+// date pattern; 'tag-array' when every value is an array of strings
+// OR a 'tags'-shaped key string; otherwise 'string'.
+//
+// Self-contained ES module — the Worker dynamic-imports via Blob URL.
+// No relative imports, no SDK runtime dependency.
+
+// ─── Pure logic: kept mirrored in src/plugins/propertiesPluginLogic.ts
+// so the Jest tests can import the TS version. Any change here must be
+// applied there too. ─────────────────────────────────────────────────
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?$/
+
+/** Best-effort type inference for a single frontmatter value.
+ *  Returned strings are the canonical column types we sort by. */
+function inferValueType(v) {
+  if (v === null || v === undefined) return 'empty'
+  if (Array.isArray(v)) {
+    // Treat as a tag-array only when every element is string-like.
+    if (v.every((x) => typeof x === 'string')) return 'tag-array'
+    return 'string'
+  }
+  if (typeof v === 'boolean') return 'boolean'
+  if (typeof v === 'number' && Number.isFinite(v)) return 'number'
+  if (typeof v === 'string') {
+    if (v.length === 0) return 'empty'
+    if (ISO_DATE_RE.test(v)) return 'date'
+    // Strings that look like ints / floats — accept negatives, no exponent.
+    if (/^-?\d+(\.\d+)?$/.test(v)) return 'number'
+    return 'string'
+  }
+  return 'string'
+}
+
+/** Reduce a column's seen types to a single canonical type.
+ *  Precedence: tag-array > date > number > boolean > string. 'empty'
+ *  is ignored unless it is the only value seen (in which case the
+ *  column is dropped upstream). */
+function reduceColumnType(seen) {
+  if (seen.has('tag-array')) return 'tag-array'
+  // Mixed string/date or string/number falls back to 'string' to keep
+  // sort sane — the user's column is heterogeneous.
+  const real = new Set([...seen].filter((t) => t !== 'empty'))
+  if (real.size === 0) return 'string'
+  if (real.size === 1) return [...real][0]
+  // Allow date + string when 'tags' string sits next to 'date' ISO.
+  // Conservative path: mixed → string.
+  return 'string'
+}
+
+/** Infer a column descriptor per key, sorted with 'tags' first then
+ *  alphabetical. Drops keys that only ever held empty values. */
+function inferColumns(notes) {
+  const keyTypes = new Map() // key -> Set<type>
+  for (const n of notes) {
+    const fm = n.frontmatter || {}
+    for (const [k, v] of Object.entries(fm)) {
+      if (!keyTypes.has(k)) keyTypes.set(k, new Set())
+      keyTypes.get(k).add(inferValueType(v))
+    }
+  }
+  const cols = []
+  for (const [key, seen] of keyTypes) {
+    // Drop columns where every seen value was empty.
+    const hasReal = [...seen].some((t) => t !== 'empty')
+    if (!hasReal) continue
+    cols.push({ key, type: reduceColumnType(seen) })
+  }
+  cols.sort((a, b) => {
+    if (a.key === 'tags') return -1
+    if (b.key === 'tags') return 1
+    return a.key.localeCompare(b.key)
+  })
+  return cols
+}
+
+/** Stringify a single value for display + filter matching. Arrays
+ *  render as comma-separated; objects fall back to JSON. */
+function valueToText(v) {
+  if (v === null || v === undefined) return ''
+  if (Array.isArray(v)) return v.join(', ')
+  if (typeof v === 'object') {
+    try { return JSON.stringify(v) } catch { return '' }
+  }
+  return String(v)
+}
+
+/** True when the haystack contains the needle, case-insensitively. */
+function ciIncludes(haystack, needle) {
+  if (!needle) return true
+  return haystack.toLowerCase().includes(needle.toLowerCase())
+}
+
+/** Filter notes. Matches against title, folderPath, every column's
+ *  stringified value. Empty filter returns the input unchanged. */
+function filterNotes(notes, filter) {
+  const q = (filter || '').trim()
+  if (q.length === 0) return notes.slice()
+  return notes.filter((n) => {
+    if (ciIncludes(n.title || '', q)) return true
+    if (ciIncludes(n.folderPath || '', q)) return true
+    const fm = n.frontmatter || {}
+    for (const v of Object.values(fm)) {
+      if (ciIncludes(valueToText(v), q)) return true
+    }
+    return false
+  })
+}
+
+/** Comparator for a single column type. */
+function compareForType(type, a, b) {
+  const aEmpty = a === null || a === undefined || a === ''
+  const bEmpty = b === null || b === undefined || b === ''
+  if (aEmpty && bEmpty) return 0
+  if (aEmpty) return 1   // empties last
+  if (bEmpty) return -1
+  if (type === 'number') {
+    const na = typeof a === 'number' ? a : Number(a)
+    const nb = typeof b === 'number' ? b : Number(b)
+    if (Number.isNaN(na) && Number.isNaN(nb)) return 0
+    if (Number.isNaN(na)) return 1
+    if (Number.isNaN(nb)) return -1
+    return na - nb
+  }
+  if (type === 'date') {
+    const ta = Date.parse(String(a))
+    const tb = Date.parse(String(b))
+    if (Number.isNaN(ta) && Number.isNaN(tb)) return 0
+    if (Number.isNaN(ta)) return 1
+    if (Number.isNaN(tb)) return -1
+    return ta - tb
+  }
+  if (type === 'tag-array') {
+    const sa = Array.isArray(a) ? a.join(', ') : String(a)
+    const sb = Array.isArray(b) ? b.join(', ') : String(b)
+    return sa.localeCompare(sb)
+  }
+  return String(a).localeCompare(String(b))
+}
+
+/** Sort notes by the given column (or title when key === '_title').
+ *  Returns a new array. `direction` is 'asc' or 'desc'. */
+function sortNotes(notes, columns, sortKey, direction) {
+  const out = notes.slice()
+  if (sortKey === '_title') {
+    out.sort((a, b) => (a.title || '').localeCompare(b.title || ''))
+  } else if (sortKey === '_folder') {
+    out.sort((a, b) => (a.folderPath || '').localeCompare(b.folderPath || ''))
+  } else {
+    const col = columns.find((c) => c.key === sortKey)
+    const type = col ? col.type : 'string'
+    out.sort((a, b) => {
+      const va = a.frontmatter ? a.frontmatter[sortKey] : undefined
+      const vb = b.frontmatter ? b.frontmatter[sortKey] : undefined
+      return compareForType(type, va, vb)
+    })
+  }
+  if (direction === 'desc') out.reverse()
+  return out
+}
+
+/** Render the current table to a markdown table string. */
+function tableToMarkdown(columns, rows) {
+  const headers = ['Title', 'Folder', ...columns.map((c) => c.key)]
+  const lines = [
+    `| ${headers.join(' | ')} |`,
+    `| ${headers.map(() => '---').join(' | ')} |`,
+  ]
+  for (const r of rows) {
+    const cells = [
+      r.title || '',
+      r.folderPath || '',
+      ...columns.map((c) => {
+        const v = r.frontmatter ? r.frontmatter[c.key] : undefined
+        return valueToText(v).replace(/\|/g, '\\|')
+      }),
+    ]
+    lines.push(`| ${cells.join(' | ')} |`)
+  }
+  return lines.join('\n')
+}
+
+// ─── VNode helpers ──────────────────────────────────────────────────
+
+function txt(value) {
+  return { tag: 'text', value }
+}
+
+function btn(label, eventName, opts) {
+  const o = opts || {}
+  return {
+    tag: 'button',
+    label,
+    variant: o.variant || 'default',
+    onClick: { kind: 'emit', event: eventName, payload: o.payload },
+  }
+}
+
+function row(children, gap) {
+  return { tag: 'box', gap: gap !== undefined ? gap : 1, children }
+}
+
+// ─── Properties+ sidebar panel renderer ─────────────────────────────
+
+/** Build the Properties+ panel VNode for a snapshot of the active note. */
+function renderPropertiesPanel(state) {
+  if (!state.activeNote) {
+    return {
+      tag: 'box', gap: 2, children: [
+        txt('Properties+'),
+        {
+          tag: 'callout',
+          kind: 'info',
+          title: 'No note selected',
+          body: 'Open a note to edit its frontmatter properties here.',
+        },
+      ],
+    }
+  }
+  const fm = state.activeNote.frontmatter || {}
+  const entries = Object.entries(fm)
+
+  const children = [
+    txt(`Properties+ · ${state.activeNote.title || '(untitled)'}`),
+  ]
+
+  if (entries.length === 0) {
+    children.push({
+      tag: 'callout',
+      kind: 'note',
+      title: 'No properties yet',
+      body: 'This note has no frontmatter. Add a key + value below to create one.',
+    })
+  }
+
+  for (const [key, value] of entries) {
+    children.push(
+      row([
+        txt(key),
+        {
+          tag: 'input',
+          type: 'text',
+          value: valueToText(value),
+          placeholder: `Value for ${key}`,
+          onChange: {
+            kind: 'emit',
+            event: 'prop.edit',
+            payload: { key },
+          },
+        },
+        btn('Delete', 'prop.delete', { variant: 'ghost', payload: { key } }),
+      ], 1),
+    )
+  }
+
+  // Add property row.
+  if (state.addOpen) {
+    children.push(
+      row([
+        {
+          tag: 'input',
+          type: 'text',
+          value: state.draftKey || '',
+          placeholder: 'key (e.g. status)',
+          onChange: { kind: 'emit', event: 'prop.draft.key' },
+        },
+        {
+          tag: 'input',
+          type: 'text',
+          value: state.draftValue || '',
+          placeholder: 'value (e.g. draft)',
+          onChange: { kind: 'emit', event: 'prop.draft.value' },
+        },
+        btn('Save', 'prop.draft.save', { variant: 'primary' }),
+        btn('Cancel', 'prop.draft.cancel', { variant: 'ghost' }),
+      ], 1),
+    )
+  } else {
+    children.push(btn('+ Add property', 'prop.add.open', { variant: 'primary' }))
+  }
+
+  return { tag: 'box', gap: 2, children }
+}
+
+// ─── Vault tables fullscreen renderer ───────────────────────────────
+
+/** Build the Vault tables fullscreen VNode. */
+function renderTablesView(state) {
+  const columns = state.columns
+  const visible = sortNotes(filterNotes(state.notes, state.filter), columns, state.sortKey, state.sortDir)
+
+  const children = [
+    {
+      tag: 'callout',
+      kind: 'tip',
+      title: 'Vault tables',
+      body: `Showing ${visible.length} of ${state.notes.length} notes. Click a column header to sort; click a row title to open the note.`,
+    },
+    row([
+      {
+        tag: 'input',
+        type: 'search',
+        value: state.filter || '',
+        placeholder: 'filter by tag, status, anything...',
+        onChange: { kind: 'emit', event: 'tables.filter' },
+      },
+      btn('Save current view as note', 'tables.save', { variant: 'primary' }),
+      btn('Close', 'tables.close', { variant: 'ghost' }),
+    ], 2),
+  ]
+
+  // Header row of buttons. Reusing list-of-list because the renderer
+  // has no real table primitive — `box` of `box` rows is the
+  // closest we can get with the curated VNode set, and it lays out
+  // each row as a flex column. Wrapping every cell with a box
+  // doesn't get us horizontal cells, so we render each row as a
+  // wrapping `box` of inline children and rely on the renderer's
+  // gap classes.
+
+  const headerCells = [
+    btn(headerLabel('_title', 'Title', state),       'tables.sort', { variant: 'ghost', payload: { key: '_title' } }),
+    btn(headerLabel('_folder', 'Folder', state),     'tables.sort', { variant: 'ghost', payload: { key: '_folder' } }),
+    ...columns.map((c) =>
+      btn(headerLabel(c.key, c.key, state),          'tables.sort', { variant: 'ghost', payload: { key: c.key } }),
+    ),
+  ]
+  children.push(row(headerCells, 2))
+
+  // Data rows. Each row gets a `link` for the title (clickable —
+  // intercepted by PR #142 wikilink dispatch) plus a `text` per
+  // remaining column.
+  for (const note of visible) {
+    const cells = [
+      {
+        tag: 'link',
+        label: note.title || '(untitled)',
+        href: { kind: 'note', noteId: note.id },
+      },
+      txt(note.folderPath || ''),
+      ...columns.map((c) => txt(valueToText(note.frontmatter ? note.frontmatter[c.key] : undefined))),
+    ]
+    children.push(row(cells, 2))
+  }
+
+  if (visible.length === 0) {
+    children.push({
+      tag: 'callout',
+      kind: 'warn',
+      title: 'No matches',
+      body: 'No notes match the current filter. Clear the filter to see every note.',
+    })
+  }
+
+  return { tag: 'box', gap: 3, children }
+}
+
+function headerLabel(key, base, state) {
+  if (state.sortKey !== key) return base
+  return state.sortDir === 'asc' ? `${base} ▲` : `${base} ▼`
+}
+
+// ─── Plugin state ───────────────────────────────────────────────────
+
+const panelState = {
+  // Cached snapshot of the active note + its host-parsed frontmatter.
+  activeNote: null,            // { id, title, frontmatter }
+  // Pending in-flight edits keyed by property key. Lets the input keep
+  // the user's typed value visible until updateNote resolves.
+  pendingEdits: {},
+  // "+ Add property" row state.
+  addOpen: false,
+  draftKey: '',
+  draftValue: '',
+}
+
+const tablesState = {
+  // Fullscreen view state — captured + rendered when the modal mounts.
+  open: false,
+  notes: [],
+  columns: [],
+  filter: '',
+  sortKey: '_title',
+  sortDir: 'asc',
+}
+
+// ─── Wiring ─────────────────────────────────────────────────────────
+
+/** Parse the user's edited string back into a frontmatter-compatible
+ *  value, following the column's existing type. Falls back to string.
+ *  Tag-array columns split on commas. */
+function coerceEditedValue(prevValue, raw) {
+  if (raw === undefined || raw === null) return ''
+  const s = String(raw)
+  if (Array.isArray(prevValue)) {
+    return s.split(',').map((p) => p.trim()).filter((p) => p.length > 0)
+  }
+  if (typeof prevValue === 'number') {
+    const n = Number(s)
+    return Number.isFinite(n) ? n : s
+  }
+  if (typeof prevValue === 'boolean') {
+    if (s === 'true') return true
+    if (s === 'false') return false
+    return s
+  }
+  return s
+}
+
+async function refreshActiveNote(ctx) {
+  const active = ctx.activeNote
+  if (!active) {
+    panelState.activeNote = null
+    panelState.pendingEdits = {}
+    panelState.addOpen = false
+    ctx.setPanelContent('properties-plus', renderPropertiesPanel(panelState))
+    return
+  }
+  try {
+    const note = await ctx.vault.read.getNote(active.id)
+    if (!note) {
+      panelState.activeNote = null
+    } else {
+      panelState.activeNote = {
+        id: note.id,
+        title: note.title,
+        frontmatter: note.frontmatter || {},
+      }
+    }
+    panelState.pendingEdits = {}
+  } catch (err) {
+    ctx.notify(`Properties+: failed to read note — ${err && err.message ? err.message : String(err)}`)
+    panelState.activeNote = null
+  }
+  ctx.setPanelContent('properties-plus', renderPropertiesPanel(panelState))
+}
+
+async function commitPropertyEdit(ctx, key, rawValue) {
+  if (!panelState.activeNote) return
+  const prev = panelState.activeNote.frontmatter[key]
+  const next = coerceEditedValue(prev, rawValue)
+  const fm = { ...panelState.activeNote.frontmatter, [key]: next }
+  panelState.activeNote.frontmatter = fm
+  try {
+    await ctx.vault.write.updateNote(panelState.activeNote.id, { frontmatter: fm })
+  } catch (err) {
+    ctx.notify(`Properties+: save failed — ${err && err.message ? err.message : String(err)}`)
+  }
+  // Don't re-render after a single edit — the React-controlled input
+  // already shows what the user typed, and a setPanelContent here would
+  // rebuild the tree and reset the caret. Re-renders happen on
+  // delete / add / cancel / active-note swap, which all change the
+  // structure of the panel anyway.
+}
+
+async function commitPropertyDelete(ctx, key) {
+  if (!panelState.activeNote) return
+  const fm = { ...panelState.activeNote.frontmatter }
+  delete fm[key]
+  panelState.activeNote.frontmatter = fm
+  try {
+    await ctx.vault.write.updateNote(panelState.activeNote.id, { frontmatter: fm })
+  } catch (err) {
+    ctx.notify(`Properties+: delete failed — ${err && err.message ? err.message : String(err)}`)
+  }
+  ctx.setPanelContent('properties-plus', renderPropertiesPanel(panelState))
+}
+
+async function commitDraftAdd(ctx) {
+  if (!panelState.activeNote) return
+  const key = (panelState.draftKey || '').trim()
+  if (key.length === 0) {
+    ctx.notify('Properties+: provide a key before saving.')
+    return
+  }
+  const value = coerceEditedValue('', panelState.draftValue || '')
+  const fm = { ...panelState.activeNote.frontmatter, [key]: value }
+  panelState.activeNote.frontmatter = fm
+  panelState.addOpen = false
+  panelState.draftKey = ''
+  panelState.draftValue = ''
+  try {
+    await ctx.vault.write.updateNote(panelState.activeNote.id, { frontmatter: fm })
+  } catch (err) {
+    ctx.notify(`Properties+: add failed — ${err && err.message ? err.message : String(err)}`)
+  }
+  ctx.setPanelContent('properties-plus', renderPropertiesPanel(panelState))
+}
+
+async function loadTables(ctx) {
+  try {
+    const notes = await ctx.vault.read.getAllNotes()
+    tablesState.notes = notes.slice()
+    tablesState.columns = inferColumns(notes)
+  } catch (err) {
+    if (err && /use stream/i.test(String(err.message || err))) {
+      // Fall back to streaming for large vaults.
+      const collected = []
+      try {
+        for await (const chunk of ctx.vault.read.stream({ chunkSize: 200 })) {
+          for (const n of chunk) collected.push(n)
+        }
+        tablesState.notes = collected
+        tablesState.columns = inferColumns(collected)
+      } catch (streamErr) {
+        ctx.notify(
+          `Vault tables: stream failed — ${streamErr && streamErr.message ? streamErr.message : String(streamErr)}`,
+        )
+        return
+      }
+    } else {
+      ctx.notify(`Vault tables: getAllNotes failed — ${err && err.message ? err.message : String(err)}`)
+      return
+    }
+  }
+  ctx.setFullscreenContent('tables', renderTablesView(tablesState))
+}
+
+async function saveTableAsNote(ctx) {
+  const visible = sortNotes(filterNotes(tablesState.notes, tablesState.filter), tablesState.columns, tablesState.sortKey, tablesState.sortDir)
+  const md = tableToMarkdown(tablesState.columns, visible)
+  const stamp = new Date().toISOString().slice(0, 19).replace('T', ' ')
+  const body =
+    `# Vault tables snapshot\n\n` +
+    `Generated ${stamp}. Filter: \`${tablesState.filter || '(none)'}\`. Sort: \`${tablesState.sortKey} ${tablesState.sortDir}\`.\n\n` +
+    md + '\n'
+  try {
+    const result = await ctx.vault.write.createNote({
+      title: `Vault tables ${stamp}`,
+      body,
+    })
+    const suffix = result.conflictResolved === 'suffix' ? ' (host renamed to avoid a title collision)' : ''
+    ctx.notify(`Saved table as note "${result.id}"${suffix}.`)
+  } catch (err) {
+    ctx.notify(`Save view failed — ${err && err.message ? err.message : String(err)}`)
+  }
+}
+
+export default {
+  id: 'noteser-properties',
+  name: 'Properties+',
+  version: '0.1.0',
+  author: 'Noteser',
+  description:
+    "Sidebar editor for a note's frontmatter properties plus an Obsidian Bases-style vault-wide table view. Reads + writes notes via the v1.2 vault capabilities.",
+  permissions: ['vault.read.all', 'vault.write', 'vault.events'],
+  surfaces: {
+    sidebarPanels: [{ id: 'properties-plus', title: 'Properties+' }],
+    fullscreenViews: [{ id: 'tables', title: 'Vault tables' }],
+    commands: [{ id: 'open-tables', title: 'Open Vault tables' }],
+  },
+
+  onActivate(ctx) {
+    // Refresh the panel when the active note changes anywhere (sidebar
+    // click, palette open, tab switch).
+    ctx.vault.events.onActiveNoteChange(() => {
+      void refreshActiveNote(ctx)
+    })
+    // When ANY note is saved we re-pull the active note so external
+    // edits to the same frontmatter surface in the panel.
+    ctx.vault.events.onNoteSaved((noteId) => {
+      if (panelState.activeNote && panelState.activeNote.id === noteId) {
+        void refreshActiveNote(ctx)
+      }
+      // If the tables modal is open, the in-memory snapshot is stale.
+      // Re-derive columns + rows from the freshly-changed vault.
+      if (tablesState.open) {
+        void loadTables(ctx)
+      }
+    })
+
+    // Wire every VNode event the host forwards from either surface.
+    ctx.onVNodeEvent(({ event, payload, source }) => {
+      // ─── Properties+ panel events ──────────────────────────────
+      if (source.kind === 'panel' && source.panelId === 'properties-plus') {
+        const p = (payload && typeof payload === 'object') ? payload : {}
+        if (event === 'prop.edit') {
+          void commitPropertyEdit(ctx, p.key, p.value)
+          return
+        }
+        if (event === 'prop.delete') {
+          void commitPropertyDelete(ctx, p.key)
+          return
+        }
+        if (event === 'prop.add.open') {
+          panelState.addOpen = true
+          ctx.setPanelContent('properties-plus', renderPropertiesPanel(panelState))
+          return
+        }
+        if (event === 'prop.draft.key') {
+          panelState.draftKey = String(p.value || '')
+          // Don't re-render on every keystroke — let the input keep its
+          // local value and only re-render on save / cancel. Re-rendering
+          // would discard the controlled-input cursor position.
+          return
+        }
+        if (event === 'prop.draft.value') {
+          panelState.draftValue = String(p.value || '')
+          return
+        }
+        if (event === 'prop.draft.save') {
+          void commitDraftAdd(ctx)
+          return
+        }
+        if (event === 'prop.draft.cancel') {
+          panelState.addOpen = false
+          panelState.draftKey = ''
+          panelState.draftValue = ''
+          ctx.setPanelContent('properties-plus', renderPropertiesPanel(panelState))
+          return
+        }
+      }
+
+      // ─── Vault tables fullscreen events ────────────────────────
+      if (source.kind === 'fullscreen' && source.viewId === 'tables') {
+        const p = (payload && typeof payload === 'object') ? payload : {}
+        if (event === 'tables.filter') {
+          tablesState.filter = String(p.value || '')
+          ctx.setFullscreenContent('tables', renderTablesView(tablesState))
+          return
+        }
+        if (event === 'tables.sort') {
+          const key = String(p.key || '')
+          if (!key) return
+          if (tablesState.sortKey === key) {
+            tablesState.sortDir = tablesState.sortDir === 'asc' ? 'desc' : 'asc'
+          } else {
+            tablesState.sortKey = key
+            tablesState.sortDir = 'asc'
+          }
+          ctx.setFullscreenContent('tables', renderTablesView(tablesState))
+          return
+        }
+        if (event === 'tables.save') {
+          void saveTableAsNote(ctx)
+          return
+        }
+        if (event === 'tables.close') {
+          ctx.closeFullscreen('tables')
+          return
+        }
+      }
+    })
+  },
+
+  onPanelMount(panelId, ctx) {
+    if (panelId !== 'properties-plus') return
+    void refreshActiveNote(ctx)
+  },
+
+  onActiveNoteChange(_note, ctx) {
+    // Mirror the vault.events.onActiveNoteChange wiring above — the
+    // host fires both signals; either one is enough to drive the
+    // panel. Keeping this handler too means the panel still works
+    // when the user grants the panel surface but revokes vault.events.
+    void refreshActiveNote(ctx)
+  },
+
+  async onCommand(commandId, ctx) {
+    if (commandId !== 'open-tables') return
+    try {
+      await ctx.openFullscreen('tables')
+    } catch (err) {
+      ctx.notify(err && err.message ? err.message : 'Could not open Vault tables.')
+    }
+  },
+
+  async onFullscreenMount(viewId, ctx) {
+    if (viewId !== 'tables') return
+    tablesState.open = true
+    tablesState.filter = ''
+    tablesState.sortKey = '_title'
+    tablesState.sortDir = 'asc'
+    await loadTables(ctx)
+  },
+
+  onFullscreenUnmount(viewId) {
+    if (viewId !== 'tables') return
+    tablesState.open = false
+  },
+}

--- a/public/plugins/noteser-properties/manifest.json
+++ b/public/plugins/noteser-properties/manifest.json
@@ -1,0 +1,20 @@
+{
+  "id": "noteser-properties",
+  "name": "Properties+",
+  "version": "0.1.0",
+  "author": "Noteser",
+  "description": "Sidebar editor for a note's frontmatter properties plus an Obsidian Bases-style vault-wide table view. Reads + writes notes via the v1.2 vault capabilities.",
+  "main": "./main.js",
+  "permissions": ["vault.read.all", "vault.write", "vault.events"],
+  "surfaces": {
+    "sidebarPanels": [
+      { "id": "properties-plus", "title": "Properties+" }
+    ],
+    "fullscreenViews": [
+      { "id": "tables", "title": "Vault tables" }
+    ],
+    "commands": [
+      { "id": "open-tables", "title": "Open Vault tables" }
+    ]
+  }
+}

--- a/src/plugins/__tests__/propertiesPlugin.test.ts
+++ b/src/plugins/__tests__/propertiesPlugin.test.ts
@@ -1,0 +1,345 @@
+// Tests for the `noteser-properties` plugin's pure inference / filter
+// / sort code. The production code is in
+// `public/plugins/noteser-properties/main.js`; this test file imports
+// the TypeScript mirror in `./propertiesPluginLogic.ts` so we don't
+// have to bring the Worker bridge up to exercise the math.
+//
+// Any change to the production logic in main.js must land in the
+// mirror or these tests will go stale silently. Keep the two in lock
+// step.
+
+import {
+  inferValueType,
+  inferColumns,
+  filterNotes,
+  sortNotes,
+  coerceEditedValue,
+  tableToMarkdown,
+  compareForType,
+  type NoteFixture,
+} from '../propertiesPluginLogic'
+
+const noteOf = (
+  id: string,
+  title: string,
+  frontmatter: Record<string, unknown> | null,
+  folderPath = '',
+): NoteFixture => ({
+  id,
+  title,
+  folderPath,
+  body: '',
+  frontmatter,
+  updatedAt: 0,
+})
+
+describe('inferValueType', () => {
+  it('classifies plain strings as "string"', () => {
+    expect(inferValueType('draft')).toBe('string')
+    expect(inferValueType('hello world')).toBe('string')
+  })
+
+  it('classifies finite numbers + numeric strings as "number"', () => {
+    expect(inferValueType(42)).toBe('number')
+    expect(inferValueType(-1.5)).toBe('number')
+    expect(inferValueType('17')).toBe('number')
+    expect(inferValueType('-3.14')).toBe('number')
+  })
+
+  it('classifies ISO date strings as "date"', () => {
+    expect(inferValueType('2026-06-06')).toBe('date')
+    expect(inferValueType('2026-06-06T13:45')).toBe('date')
+    expect(inferValueType('2026-06-06T13:45:30.123Z')).toBe('date')
+  })
+
+  it('rejects bogus date strings', () => {
+    expect(inferValueType('2026/06/06')).toBe('string')
+    expect(inferValueType('not a date')).toBe('string')
+  })
+
+  it('classifies arrays of strings as "tag-array"', () => {
+    expect(inferValueType(['a', 'b'])).toBe('tag-array')
+    expect(inferValueType([])).toBe('tag-array')
+  })
+
+  it('classifies arrays with non-strings as "string" (heterogeneous)', () => {
+    expect(inferValueType(['a', 1])).toBe('string')
+  })
+
+  it('classifies booleans as "boolean"', () => {
+    expect(inferValueType(true)).toBe('boolean')
+    expect(inferValueType(false)).toBe('boolean')
+  })
+
+  it('treats null / undefined / empty string as "empty"', () => {
+    expect(inferValueType(null)).toBe('empty')
+    expect(inferValueType(undefined)).toBe('empty')
+    expect(inferValueType('')).toBe('empty')
+  })
+
+  it('treats NaN / Infinity as "string"', () => {
+    expect(inferValueType(Number.NaN)).toBe('string')
+    expect(inferValueType(Number.POSITIVE_INFINITY)).toBe('string')
+  })
+})
+
+describe('inferColumns', () => {
+  it('unions keys across every note', () => {
+    const notes = [
+      noteOf('1', 'A', { tags: ['x'], status: 'draft' }),
+      noteOf('2', 'B', { priority: 3, due: '2026-06-06' }),
+    ]
+    const cols = inferColumns(notes)
+    const keys = cols.map((c) => c.key)
+    expect(keys).toEqual(expect.arrayContaining(['tags', 'status', 'priority', 'due']))
+  })
+
+  it('puts `tags` first then sorts the rest alphabetically', () => {
+    const notes = [
+      noteOf('1', 'A', { priority: 1, tags: ['a'], status: 'open' }),
+    ]
+    expect(inferColumns(notes).map((c) => c.key)).toEqual([
+      'tags',
+      'priority',
+      'status',
+    ])
+  })
+
+  it('reduces homogeneous columns to their type', () => {
+    const notes = [
+      noteOf('1', 'A', { priority: 3, due: '2026-06-06', tags: ['x'] }),
+      noteOf('2', 'B', { priority: 1, due: '2026-06-08', tags: ['y'] }),
+    ]
+    const cols = inferColumns(notes)
+    const map = Object.fromEntries(cols.map((c) => [c.key, c.type]))
+    expect(map.priority).toBe('number')
+    expect(map.due).toBe('date')
+    expect(map.tags).toBe('tag-array')
+  })
+
+  it('falls back to "string" for heterogeneous columns', () => {
+    const notes = [
+      noteOf('1', 'A', { mixed: 'plain' }),
+      noteOf('2', 'B', { mixed: 7 }),
+    ]
+    const cols = inferColumns(notes)
+    expect(cols.find((c) => c.key === 'mixed')!.type).toBe('string')
+  })
+
+  it('drops columns that only ever held empties', () => {
+    const notes = [
+      noteOf('1', 'A', { blank: '', kept: 'yes' }),
+      noteOf('2', 'B', { blank: null, kept: 'still' }),
+    ]
+    const keys = inferColumns(notes).map((c) => c.key)
+    expect(keys).not.toContain('blank')
+    expect(keys).toContain('kept')
+  })
+
+  it('handles notes with no frontmatter', () => {
+    const notes = [
+      noteOf('1', 'A', null),
+      noteOf('2', 'B', { kept: 'yes' }),
+    ]
+    expect(inferColumns(notes).map((c) => c.key)).toEqual(['kept'])
+  })
+})
+
+describe('filterNotes', () => {
+  const vault = [
+    noteOf('1', 'Alpha', { tags: ['rust'], status: 'draft' }, 'Projects'),
+    noteOf('2', 'Beta',  { tags: ['typescript'], status: 'published', priority: 3 }, 'Projects/Web'),
+    noteOf('3', 'Gamma', { tags: ['idea'], priority: 1 }, 'Inbox'),
+    noteOf('4', 'Delta', null, ''),
+  ]
+
+  it('returns every note when the filter is empty or whitespace', () => {
+    expect(filterNotes(vault, '').length).toBe(4)
+    expect(filterNotes(vault, '   ').length).toBe(4)
+  })
+
+  it('matches a tag value', () => {
+    const out = filterNotes(vault, 'rust')
+    expect(out.map((n) => n.id)).toEqual(['1'])
+  })
+
+  it('matches a status value', () => {
+    const out = filterNotes(vault, 'published')
+    expect(out.map((n) => n.id)).toEqual(['2'])
+  })
+
+  it('matches a title', () => {
+    const out = filterNotes(vault, 'Gam')
+    expect(out.map((n) => n.id)).toEqual(['3'])
+  })
+
+  it('matches a folder path', () => {
+    const out = filterNotes(vault, 'Projects/Web')
+    expect(out.map((n) => n.id)).toEqual(['2'])
+  })
+
+  it('is case-insensitive', () => {
+    expect(filterNotes(vault, 'RUST').map((n) => n.id)).toEqual(['1'])
+    expect(filterNotes(vault, 'projects').map((n) => n.id).sort()).toEqual(['1', '2'])
+  })
+
+  it('matches a numeric frontmatter value coerced to string', () => {
+    expect(filterNotes(vault, '3').map((n) => n.id)).toEqual(['2'])
+  })
+
+  it('returns an empty array on no match', () => {
+    expect(filterNotes(vault, 'nope-no-such-thing')).toEqual([])
+  })
+})
+
+describe('sortNotes', () => {
+  const cols = [
+    { key: 'priority', type: 'number' as const },
+    { key: 'due', type: 'date' as const },
+    { key: 'tags', type: 'tag-array' as const },
+    { key: 'status', type: 'string' as const },
+  ]
+
+  const vault = [
+    noteOf('1', 'Charlie', { priority: 3, due: '2026-06-08', tags: ['rust'],       status: 'draft' }, 'Projects'),
+    noteOf('2', 'Alpha',   { priority: 1, due: '2026-06-06', tags: ['idea'],       status: 'open' },  'Inbox'),
+    noteOf('3', 'Bravo',   { priority: 2, due: '2026-06-07', tags: ['typescript'], status: 'open' },  'Projects/Web'),
+  ]
+
+  it('sorts by title (asc) with the special _title key', () => {
+    expect(sortNotes(vault, cols, '_title', 'asc').map((n) => n.title)).toEqual([
+      'Alpha', 'Bravo', 'Charlie',
+    ])
+  })
+
+  it('sorts by title (desc)', () => {
+    expect(sortNotes(vault, cols, '_title', 'desc').map((n) => n.title)).toEqual([
+      'Charlie', 'Bravo', 'Alpha',
+    ])
+  })
+
+  it('sorts by folder path with the special _folder key', () => {
+    expect(sortNotes(vault, cols, '_folder', 'asc').map((n) => n.id)).toEqual([
+      '2', '1', '3', // Inbox < Projects < Projects/Web
+    ])
+  })
+
+  it('sorts by a numeric column ascending', () => {
+    expect(sortNotes(vault, cols, 'priority', 'asc').map((n) => n.id)).toEqual([
+      '2', '3', '1',
+    ])
+  })
+
+  it('sorts by a numeric column descending', () => {
+    expect(sortNotes(vault, cols, 'priority', 'desc').map((n) => n.id)).toEqual([
+      '1', '3', '2',
+    ])
+  })
+
+  it('sorts by a date column chronologically', () => {
+    expect(sortNotes(vault, cols, 'due', 'asc').map((n) => n.id)).toEqual([
+      '2', '3', '1',
+    ])
+  })
+
+  it('sorts by a tag-array column by joined-string', () => {
+    expect(sortNotes(vault, cols, 'tags', 'asc').map((n) => n.id)).toEqual([
+      '2', '1', '3', // idea < rust < typescript
+    ])
+  })
+
+  it('pushes empties to the end of an ascending sort', () => {
+    const sparse = [
+      noteOf('a', 'A', { priority: 5 }),
+      noteOf('b', 'B', null),
+      noteOf('c', 'C', { priority: 2 }),
+    ]
+    expect(sortNotes(sparse, cols, 'priority', 'asc').map((n) => n.id)).toEqual([
+      'c', 'a', 'b',
+    ])
+  })
+
+  it('falls back to string sort when the column is unknown', () => {
+    // Not in cols → 'string' type by default.
+    const out = sortNotes(vault, cols, 'no-such-key', 'asc')
+    expect(out).toHaveLength(3)
+  })
+
+  it('does not mutate the input array', () => {
+    const before = vault.map((n) => n.id)
+    sortNotes(vault, cols, 'priority', 'desc')
+    expect(vault.map((n) => n.id)).toEqual(before)
+  })
+})
+
+describe('compareForType', () => {
+  it('handles NaN-coerced strings in number columns', () => {
+    expect(compareForType('number', 'abc', 5)).toBe(1)  // abc → NaN → last
+    expect(compareForType('number', 5, 'abc')).toBe(-1)
+  })
+
+  it('handles unparseable date strings in date columns', () => {
+    expect(compareForType('date', 'nope', '2026-06-06')).toBe(1)
+    expect(compareForType('date', '2026-06-06', 'nope')).toBe(-1)
+  })
+
+  it('sorts boolean strings as plain strings', () => {
+    // No special boolean comparator — we sort as strings.
+    expect(Math.sign(compareForType('string', 'false', 'true'))).toBe(-1)
+  })
+})
+
+describe('coerceEditedValue', () => {
+  it('coerces back to a number when the previous value was numeric', () => {
+    expect(coerceEditedValue(3, '7')).toBe(7)
+    expect(coerceEditedValue(0, '-1.5')).toBe(-1.5)
+  })
+
+  it('falls back to the raw string when the numeric coercion fails', () => {
+    expect(coerceEditedValue(3, 'oops')).toBe('oops')
+  })
+
+  it('splits comma-separated strings back to arrays', () => {
+    expect(coerceEditedValue(['a'], 'rust, typescript ,go')).toEqual([
+      'rust', 'typescript', 'go',
+    ])
+  })
+
+  it('drops empty entries from coerced arrays', () => {
+    expect(coerceEditedValue(['a'], 'a,,b')).toEqual(['a', 'b'])
+  })
+
+  it('parses booleans back from their string forms', () => {
+    expect(coerceEditedValue(true, 'false')).toBe(false)
+    expect(coerceEditedValue(false, 'true')).toBe(true)
+  })
+
+  it('returns the raw string for plain string columns', () => {
+    expect(coerceEditedValue('draft', 'published')).toBe('published')
+  })
+})
+
+describe('tableToMarkdown', () => {
+  it('renders a header row + a separator + one row per note', () => {
+    const cols = [
+      { key: 'tags', type: 'tag-array' as const },
+      { key: 'status', type: 'string' as const },
+    ]
+    const rows = [
+      noteOf('1', 'A', { tags: ['x', 'y'], status: 'draft' }, 'Projects'),
+      noteOf('2', 'B', { tags: [], status: 'open' }, ''),
+    ]
+    const md = tableToMarkdown(cols, rows)
+    expect(md).toContain('| Title | Folder | tags | status |')
+    expect(md).toContain('| --- | --- | --- | --- |')
+    expect(md).toContain('| A | Projects | x, y | draft |')
+    expect(md).toContain('| B |  |  | open |')
+  })
+
+  it('escapes pipes in cell values', () => {
+    const cols = [{ key: 'notes', type: 'string' as const }]
+    const rows = [noteOf('1', 'A', { notes: 'left | right' })]
+    const md = tableToMarkdown(cols, rows)
+    expect(md).toContain('left \\| right')
+  })
+})

--- a/src/plugins/propertiesPluginLogic.ts
+++ b/src/plugins/propertiesPluginLogic.ts
@@ -1,0 +1,207 @@
+// Pure logic mirror for the `noteser-properties` plugin's
+// frontmatter type inference, filter, and sort code. The plugin's
+// `main.js` runs unbundled in the Worker and is intentionally
+// self-contained (no relative imports, no SDK runtime dependency),
+// so the production code lives there. This file mirrors the same
+// pure functions in TypeScript so the Jest tests can import + assert
+// without driving the Worker bridge.
+//
+// Any change to the inference / filter / sort code in
+// `public/plugins/noteser-properties/main.js` MUST land here too.
+
+export interface NoteFixture {
+  id: string
+  title: string
+  folderPath: string
+  body: string
+  frontmatter: Record<string, unknown> | null
+  updatedAt: number
+}
+
+export type ColumnType = 'string' | 'number' | 'date' | 'tag-array' | 'boolean' | 'empty'
+
+export interface Column {
+  key: string
+  type: ColumnType
+}
+
+const ISO_DATE_RE =
+  /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?$/
+
+export function inferValueType(v: unknown): ColumnType {
+  if (v === null || v === undefined) return 'empty'
+  if (Array.isArray(v)) {
+    if (v.every((x) => typeof x === 'string')) return 'tag-array'
+    return 'string'
+  }
+  if (typeof v === 'boolean') return 'boolean'
+  if (typeof v === 'number' && Number.isFinite(v)) return 'number'
+  if (typeof v === 'string') {
+    if (v.length === 0) return 'empty'
+    if (ISO_DATE_RE.test(v)) return 'date'
+    if (/^-?\d+(\.\d+)?$/.test(v)) return 'number'
+    return 'string'
+  }
+  return 'string'
+}
+
+export function reduceColumnType(seen: Set<ColumnType>): ColumnType {
+  if (seen.has('tag-array')) return 'tag-array'
+  const real = new Set([...seen].filter((t) => t !== 'empty'))
+  if (real.size === 0) return 'string'
+  if (real.size === 1) return [...real][0]
+  return 'string'
+}
+
+export function inferColumns(notes: ReadonlyArray<NoteFixture>): Column[] {
+  const keyTypes = new Map<string, Set<ColumnType>>()
+  for (const n of notes) {
+    const fm = n.frontmatter || {}
+    for (const [k, v] of Object.entries(fm)) {
+      if (!keyTypes.has(k)) keyTypes.set(k, new Set())
+      keyTypes.get(k)!.add(inferValueType(v))
+    }
+  }
+  const cols: Column[] = []
+  for (const [key, seen] of keyTypes) {
+    const hasReal = [...seen].some((t) => t !== 'empty')
+    if (!hasReal) continue
+    cols.push({ key, type: reduceColumnType(seen) })
+  }
+  cols.sort((a, b) => {
+    if (a.key === 'tags') return -1
+    if (b.key === 'tags') return 1
+    return a.key.localeCompare(b.key)
+  })
+  return cols
+}
+
+export function valueToText(v: unknown): string {
+  if (v === null || v === undefined) return ''
+  if (Array.isArray(v)) return v.join(', ')
+  if (typeof v === 'object') {
+    try {
+      return JSON.stringify(v)
+    } catch {
+      return ''
+    }
+  }
+  return String(v)
+}
+
+function ciIncludes(haystack: string, needle: string): boolean {
+  if (!needle) return true
+  return haystack.toLowerCase().includes(needle.toLowerCase())
+}
+
+export function filterNotes(
+  notes: ReadonlyArray<NoteFixture>,
+  filter: string,
+): NoteFixture[] {
+  const q = (filter || '').trim()
+  if (q.length === 0) return notes.slice()
+  return notes.filter((n) => {
+    if (ciIncludes(n.title || '', q)) return true
+    if (ciIncludes(n.folderPath || '', q)) return true
+    const fm = n.frontmatter || {}
+    for (const v of Object.values(fm)) {
+      if (ciIncludes(valueToText(v), q)) return true
+    }
+    return false
+  })
+}
+
+export function compareForType(type: ColumnType, a: unknown, b: unknown): number {
+  const aEmpty = a === null || a === undefined || a === ''
+  const bEmpty = b === null || b === undefined || b === ''
+  if (aEmpty && bEmpty) return 0
+  if (aEmpty) return 1
+  if (bEmpty) return -1
+  if (type === 'number') {
+    const na = typeof a === 'number' ? a : Number(a)
+    const nb = typeof b === 'number' ? b : Number(b)
+    if (Number.isNaN(na) && Number.isNaN(nb)) return 0
+    if (Number.isNaN(na)) return 1
+    if (Number.isNaN(nb)) return -1
+    return na - nb
+  }
+  if (type === 'date') {
+    const ta = Date.parse(String(a))
+    const tb = Date.parse(String(b))
+    if (Number.isNaN(ta) && Number.isNaN(tb)) return 0
+    if (Number.isNaN(ta)) return 1
+    if (Number.isNaN(tb)) return -1
+    return ta - tb
+  }
+  if (type === 'tag-array') {
+    const sa = Array.isArray(a) ? a.join(', ') : String(a)
+    const sb = Array.isArray(b) ? b.join(', ') : String(b)
+    return sa.localeCompare(sb)
+  }
+  return String(a).localeCompare(String(b))
+}
+
+export function sortNotes(
+  notes: ReadonlyArray<NoteFixture>,
+  columns: ReadonlyArray<Column>,
+  sortKey: string,
+  direction: 'asc' | 'desc',
+): NoteFixture[] {
+  const out = notes.slice()
+  if (sortKey === '_title') {
+    out.sort((a, b) => (a.title || '').localeCompare(b.title || ''))
+  } else if (sortKey === '_folder') {
+    out.sort((a, b) => (a.folderPath || '').localeCompare(b.folderPath || ''))
+  } else {
+    const col = columns.find((c) => c.key === sortKey)
+    const type = col ? col.type : 'string'
+    out.sort((a, b) => {
+      const va = a.frontmatter ? a.frontmatter[sortKey] : undefined
+      const vb = b.frontmatter ? b.frontmatter[sortKey] : undefined
+      return compareForType(type, va, vb)
+    })
+  }
+  if (direction === 'desc') out.reverse()
+  return out
+}
+
+export function coerceEditedValue(prevValue: unknown, raw: unknown): unknown {
+  if (raw === undefined || raw === null) return ''
+  const s = String(raw)
+  if (Array.isArray(prevValue)) {
+    return s.split(',').map((p) => p.trim()).filter((p) => p.length > 0)
+  }
+  if (typeof prevValue === 'number') {
+    const n = Number(s)
+    return Number.isFinite(n) ? n : s
+  }
+  if (typeof prevValue === 'boolean') {
+    if (s === 'true') return true
+    if (s === 'false') return false
+    return s
+  }
+  return s
+}
+
+export function tableToMarkdown(
+  columns: ReadonlyArray<Column>,
+  rows: ReadonlyArray<NoteFixture>,
+): string {
+  const headers = ['Title', 'Folder', ...columns.map((c) => c.key)]
+  const lines = [
+    `| ${headers.join(' | ')} |`,
+    `| ${headers.map(() => '---').join(' | ')} |`,
+  ]
+  for (const r of rows) {
+    const cells = [
+      r.title || '',
+      r.folderPath || '',
+      ...columns.map((c) => {
+        const v = r.frontmatter ? r.frontmatter[c.key] : undefined
+        return valueToText(v).replace(/\|/g, '\\|')
+      }),
+    ]
+    lines.push(`| ${cells.join(' | ')} |`)
+  }
+  return lines.join('\n')
+}


### PR DESCRIPTION
## Summary

Closes #72 by building a `noteser-properties` reference plugin under
`public/plugins/`. Two surfaces, both via the Plugin API v1.2 stack
that landed across PRs A–F + the post-v1.2 VNode event delivery
follow-up (#142):

- **Sidebar `Properties+` panel** — renders the active note's
  frontmatter as a key/value list. One `input` VNode per property;
  "+ Add property" opens a key + value draft row. Every commit
  calls `ctx.vault.write.updateNote(id, { frontmatter })` so the
  host's existing writeFrontmatter helper re-serialises the block
  and the note body stays untouched. Subscribes to
  `ctx.vault.events.onActiveNoteChange` + `onNoteSaved` so the
  panel re-pulls the host-parsed frontmatter on every relevant
  change.
- **Fullscreen `Vault tables` view** — Obsidian Bases-style table
  over the whole vault. `ctx.vault.read.getAllNotes()` (falls back
  to `ctx.vault.read.stream()` when the vault is too large for the
  single-envelope path), columns inferred as the union of every
  note's frontmatter keys. Filter input matches across title,
  folder path, every stringified value. Column headers are `button`
  VNodes — click to sort, click again to flip direction. Each row
  renders the title as a `link` VNode so the PR #142 wikilink
  intercept opens the note. "Save current view as note" calls
  `ctx.vault.write.createNote` with the rendered markdown table.

Coexists with the existing core `PropertiesPanel` — both stay
selectable per Jon's rule.

## Why a plugin (not core)

The plugin platform was specifically scoped to unlock these four
issues (#70, #71, #72, #73) as plugins rather than core code; the
v1.2 plan doc calls #72 out by name in §13. Shipping as a plugin
keeps:

- Bases parity on the surface that Obsidian users already know
- The vault.write audit trail engaged for every property edit
- The pluggable boundary clean — future schemas (Templater, Tasks
  cross-references) can replace this without touching core

## Frontmatter inference notes

- Source: `NoteWithBody.frontmatter` from the host. The plugin
  never re-parses YAML; `js-yaml` is intentionally NOT a
  dependency (the plan's "already a dep — check `package.json`"
  hint checked — it isn't; the host's lightweight parser already
  hands us a typed object).
- Per-column type: `string` / `number` / `date` (ISO date pattern)
  / `tag-array` / `boolean`. Heterogeneous columns reduce to
  `string` so sort stays sane on a mixed vault.
- Numeric-shaped strings (e.g. frontmatter `priority: 3` written
  bare) classify as `number` so a "priority" column sorts
  numerically even though the underlying values arrive as JS
  strings from some other plugin's writes.
- Columns whose every value was empty are dropped — they would
  otherwise add noise to vaults with one-off bare `key:` lines.
- `tags` always renders first; remaining columns alphabetical.

## Filter / sort UX

- Filter is a single search input. Case-insensitive substring
  match across title, folder path, and every stringified
  frontmatter value (arrays joined with `, `, objects JSON-ified).
  Empty / whitespace filter keeps every note.
- Click a header to sort by that column. Clicking the same header
  again flips ascending↔descending; clicking a different header
  resets to ascending. The active sort is shown in the header
  label with a `▲`/`▼` glyph.
- Empties (null / undefined / empty string / missing key) always
  sort last in ascending direction, reversed by `desc`.
- Title and folder-path get their own special sort keys (`_title`,
  `_folder`) so they remain sortable even on vaults whose
  frontmatter never declares those keys.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` zero errors
- [x] `npm test -- --ci` green (2608 passing, 17 pre-existing
      skips — the new suite adds 44 tests covering inference,
      filter, sort, value coercion, and markdown export)
- [ ] Manual smoke: install plugin via Settings → Plugins, open a
      note with frontmatter, confirm Properties+ panel renders +
      lets you edit. Run "Open Vault tables" from the palette,
      confirm table appears, sort by a column, click a row to
      open that note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)