### PR TITLE
Settings → About: surface beta channel link

### DIFF
--- a/src/components/modals/settings/panels/AboutPanel.tsx
+++ b/src/components/modals/settings/panels/AboutPanel.tsx
@@ -99,6 +99,18 @@ export function AboutPanel() {
             noteser.thetechjon.com
           </a>
         </p>
+        <p>
+          <a
+            href="https://beta.noteser.app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-obsidianAccentPurple hover:underline"
+            data-testid="settings-beta-link"
+          >
+            beta.noteser.app
+          </a>
+          <span className="text-obsidianSecondaryText"> (beta channel: tracks the dev branch, new features land here first)</span>
+        </p>
         <p className="text-xs text-obsidianSecondaryText pt-2">
           MIT licence.
         </p>


### PR DESCRIPTION
Adds beta.noteser.app under the Settings → About panel between noteser.thetechjon.com and the licence line, with a one-sentence caveat that the beta channel tracks dev. First step of the rollout decided 2026-06-07; footer/changelog mentions to follow once this lands on main and Jon is ready.