### PR TITLE
Sidebar tab buttons: default cursor on hover

### DIFF
--- a/src/components/sidebar/PinnedMiniStrip.tsx
+++ b/src/components/sidebar/PinnedMiniStrip.tsx
@@ -180,7 +180,7 @@ export const PinnedMiniStrip = ({
             aria-label={def.title}
             data-testid={`sidebar-pinned-tab-${id}`}
             className={[
-              'relative flex items-center justify-center py-1.5 max-md:py-2.5 px-3 rounded cursor-grab active:cursor-grabbing transition-colors',
+              'relative flex items-center justify-center py-1.5 max-md:py-2.5 px-3 rounded cursor-default active:cursor-grabbing transition-colors',
               showInsertBefore ? 'border-l-2 border-obsidianAccentPurple -ml-[2px]' : '',
               showInsertAfter ? 'border-r-2 border-obsidianAccentPurple -mr-[2px]' : '',
               active

--- a/src/components/sidebar/RightMiniStrip.tsx
+++ b/src/components/sidebar/RightMiniStrip.tsx
@@ -147,7 +147,7 @@ export const RightMiniStrip = ({
             aria-label={def.title}
             data-testid={`right-sidebar-pinned-tab-${id}`}
             className={[
-              'relative flex items-center justify-center py-1.5 max-md:py-2.5 px-3 rounded cursor-grab active:cursor-grabbing transition-colors',
+              'relative flex items-center justify-center py-1.5 max-md:py-2.5 px-3 rounded cursor-default active:cursor-grabbing transition-colors',
               showInsertBefore ? 'border-l-2 border-obsidianAccentPurple -ml-[2px]' : '',
               showInsertAfter ? 'border-r-2 border-obsidianAccentPurple -mr-[2px]' : '',
               active

--- a/src/components/sidebar/SidebarSection.tsx
+++ b/src/components/sidebar/SidebarSection.tsx
@@ -128,7 +128,7 @@ export const SidebarSection = ({
             e.dataTransfer.effectAllowed = 'move'
           }}
           className={`flex items-center gap-1.5 px-2 py-1.5 text-xs font-medium uppercase tracking-wide text-obsidianSecondaryText hover:bg-obsidianDarkGray transition-colors w-full text-left ${
-            draggablePanelId ? 'cursor-grab active:cursor-grabbing' : ''
+            draggablePanelId ? 'cursor-default active:cursor-grabbing' : ''
           }`}
           aria-expanded={!collapsed}
           aria-controls={`sidebar-section-content-${id}`}


### PR DESCRIPTION
Jon (Telegram 2026-06-07): the sidebar tab strips were showing the grab cursor on hover, implying the icons could always be dragged. Drops cursor-grab from PinnedMiniStrip, RightMiniStrip, SidebarSection so hover shows the default arrow; cursor-grabbing kicks in only while the mouse is down (active:).