### PR TITLE
Beta channel: footer link + changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 User-facing release notes for [Noteser](https://noteser.app). For the full
 commit log see the [GitHub history](https://github.com/ipapakonstantinou/noteser/commits/main).
 
+## 2026-06-07
+
+- **Public beta channel.** `beta.noteser.app` is now linked from the welcome
+  view and from Settings → About. The beta channel tracks the `dev` branch.
+  New features land there first; the stable channel at `noteser.app` updates
+  when a release is cut.
+
 ## 2026-06-01
 
 - **Open your existing vault — top-of-page CTA.** Visitors who already have a

--- a/src/components/editor/WelcomePane.tsx
+++ b/src/components/editor/WelcomePane.tsx
@@ -390,6 +390,7 @@ export const WelcomePane = ({ tabId }: { tabId: string }) => {
             <Link href="/help/getting-started" className="text-obsidianAccentPurple hover:underline">Docs</Link>
             <Link href="/changelog" className="text-obsidianAccentPurple hover:underline">Changelog</Link>
             <a href="https://github.com/ipapakonstantinou/noteser" target="_blank" rel="noopener noreferrer" className="text-obsidianAccentPurple hover:underline">GitHub</a>
+            <a href="https://beta.noteser.app" target="_blank" rel="noopener noreferrer" className="text-obsidianAccentPurple hover:underline">Try the beta</a>
           </div>
           <div>
             Close this tab to dismiss the welcome view. You can always reopen it from


### PR DESCRIPTION
Second half of the rollout Jon greenlit 2026-06-07 (PR #148 surfaced the link under Settings → About, this PR makes it visible on the welcome view + records the rollout in the changelog).