### PR TITLE
fix(source-control): created notes nest under their folder in the change tree

### DIFF
--- a/src/__tests__/sourceControlTree.test.ts
+++ b/src/__tests__/sourceControlTree.test.ts
@@ -15,10 +15,41 @@ jest.mock('idb-keyval', () => ({
 }))
 
 import { groupChangesByFolder } from '../components/sidebar/SourceControlPanel'
-import type { SyncChange } from '../utils/syncChanges'
+import { classifyPendingChanges, type SyncChange } from '../utils/syncChanges'
+import type { Note, Folder } from '@/types'
 
 function ch(id: string, gitPath: string | null, title = id): SyncChange {
   return { noteId: id, gitPath, title, kind: 'modified' }
+}
+
+function n(input: Partial<Note> & { id: string; title: string }): Note {
+  return {
+    id: input.id,
+    title: input.title,
+    content: input.content ?? '',
+    folderId: input.folderId ?? null,
+    createdAt: 0,
+    updatedAt: input.updatedAt ?? 0,
+    isDeleted: input.isDeleted ?? false,
+    deletedAt: null,
+    isPinned: false,
+    templateId: null,
+    gitPath: input.gitPath ?? null,
+    gitLastPushedSha: input.gitLastPushedSha ?? null,
+  } as Note
+}
+
+function f(input: Partial<Folder> & { id: string; name: string }): Folder {
+  return {
+    id: input.id,
+    name: input.name,
+    parentId: input.parentId ?? null,
+    createdAt: 0,
+    updatedAt: 0,
+    isDeleted: input.isDeleted ?? false,
+    deletedAt: null,
+    order: input.order ?? 0,
+  } as Folder
 }
 
 test('flat root files land in the root.leaves array', () => {
@@ -74,10 +105,14 @@ test('kind is preserved per leaf across the three input arrays', () => {
   expect(byId.get('c')).toBe('deleted')
 })
 
-test('a note with null gitPath uses its title as the file segment', () => {
-  // Newly-created notes have no gitPath yet — they should still
-  // appear at the root level keyed by title (no synthetic folder
-  // chain just because the title contains slashes / etc).
+test('a SyncChange with null gitPath falls back to the title at the root', () => {
+  // Unit-level guarantee about groupChangesByFolder itself: when given a
+  // null-gitPath input directly, it still groups by title at root (no
+  // synthetic chain just because the title might contain slashes). The
+  // integration test below exercises the real path — classifyPendingChanges
+  // now populates a synthetic gitPath from the folder hierarchy so this
+  // null-input case shouldn't happen in production for a folder-aware
+  // caller. Kept to lock down the helper's pure behaviour.
   const root = groupChangesByFolder(
     [ch('a', null, 'My Note')],
     [],
@@ -85,4 +120,39 @@ test('a note with null gitPath uses its title as the file segment', () => {
   )
   expect(root.children.size).toBe(0)
   expect(root.leaves.map(l => l.noteId)).toEqual(['a'])
+})
+
+// fix/created-note-source-control-tree-bug: integration test covering
+// the real production path. A newly-created daily note in Notes/Daily
+// must nest under that folder in the tree (not pile up at the repo root)
+// even though its `Note.gitPath` is null. The fix lives in
+// classifyPendingChanges, which synthesises a gitPath from the folder
+// hierarchy when folders are supplied.
+test('created note in a nested folder nests under that folder in the tree', () => {
+  const folders: Folder[] = [
+    f({ id: 'notes', name: 'Notes' }),
+    f({ id: 'daily', name: 'Daily', parentId: 'notes' }),
+  ]
+  const notes: Note[] = [
+    // A newly-created daily note: no gitPath yet.
+    n({ id: 'today', title: '2026-06-16', content: 'today', folderId: 'daily' }),
+    // A modified note that's already pushed — should also nest correctly.
+    n({ id: 'yest',  title: '2026-06-07', content: 'yest', folderId: 'daily', gitPath: 'Notes/Daily/2026-06-07.md', updatedAt: 200 }),
+  ]
+  const changes = classifyPendingChanges(notes, 100, folders)
+  const root = groupChangesByFolder(changes.created, changes.modified, changes.deleted)
+
+  // Nothing should land at root — both notes belong inside Notes/Daily.
+  expect(root.leaves).toEqual([])
+  expect(root.children.has('Notes')).toBe(true)
+  const notesNode = root.children.get('Notes')!
+  expect(notesNode.leaves).toEqual([])
+  expect(notesNode.children.has('Daily')).toBe(true)
+  const dailyNode = notesNode.children.get('Daily')!
+  const ids = dailyNode.leaves.map(l => l.noteId).sort()
+  expect(ids).toEqual(['today', 'yest'])
+  // And the kinds came through as expected.
+  const byId = new Map(dailyNode.leaves.map(l => [l.noteId, l.kind]))
+  expect(byId.get('today')).toBe('created')
+  expect(byId.get('yest')).toBe('modified')
 })

--- a/src/__tests__/syncChanges.test.ts
+++ b/src/__tests__/syncChanges.test.ts
@@ -7,14 +7,14 @@
  */
 
 import { classifyPendingChanges, totalPendingCount } from '../utils/syncChanges'
-import type { Note } from '@/types'
+import type { Note, Folder } from '@/types'
 
 function n(input: Partial<Note> & { id: string; title: string }): Note {
   return {
     id: input.id,
     title: input.title,
     content: input.content ?? '',
-    folderId: null,
+    folderId: input.folderId ?? null,
     createdAt: 0,
     updatedAt: input.updatedAt ?? 0,
     isDeleted: input.isDeleted ?? false,
@@ -25,6 +25,19 @@ function n(input: Partial<Note> & { id: string; title: string }): Note {
     gitLastPushedSha: input.gitLastPushedSha ?? null,
     contentLoaded: input.contentLoaded,
   } as Note
+}
+
+function f(input: Partial<Folder> & { id: string; name: string }): Folder {
+  return {
+    id: input.id,
+    name: input.name,
+    parentId: input.parentId ?? null,
+    createdAt: 0,
+    updatedAt: 0,
+    isDeleted: input.isDeleted ?? false,
+    deletedAt: null,
+    order: input.order ?? 0,
+  } as Folder
 }
 
 describe('classifyPendingChanges', () => {
@@ -136,5 +149,82 @@ describe('classifyPendingChanges', () => {
       null,
     )
     expect(totalPendingCount(c)).toBe(2)
+  })
+})
+
+// fix/created-note-source-control-tree-bug: a created note (gitPath null)
+// used to surface in the Source Control tree at the repo root because
+// classifyPendingChanges left its gitPath null and groupChangesByFolder
+// then fell back to the title (which has no `/`). When `folders` is
+// threaded through, the classifier synthesises a path from the folder
+// hierarchy so the panel groups the new note under the folder it'll be
+// pushed to. Verified manually against the 2026-06-08 screenshot of a
+// fresh "2026-06-16" daily note appearing at root instead of under
+// Notes/Daily.
+describe('classifyPendingChanges — synthetic gitPath for created notes', () => {
+  test('created note in root folder → "<title>.md"', () => {
+    const c = classifyPendingChanges(
+      [n({ id: 'a', title: '2026-06-16', content: 'x' })],
+      null,
+      [],
+    )
+    expect(c.created.map(x => x.gitPath)).toEqual(['2026-06-16.md'])
+  })
+
+  test('created note in nested Notes/Daily → "Notes/Daily/<title>.md"', () => {
+    const folders: Folder[] = [
+      f({ id: 'notes', name: 'Notes' }),
+      f({ id: 'daily', name: 'Daily', parentId: 'notes' }),
+    ]
+    const c = classifyPendingChanges(
+      [n({ id: 'a', title: '2026-06-16', content: 'x', folderId: 'daily' })],
+      null,
+      folders,
+    )
+    expect(c.created.map(x => x.gitPath)).toEqual(['Notes/Daily/2026-06-16.md'])
+  })
+
+  test('created note with no title → "Untitled.md"', () => {
+    const c = classifyPendingChanges(
+      [n({ id: 'a', title: '' })],
+      null,
+      [],
+    )
+    expect(c.created.map(x => x.gitPath)).toEqual(['Untitled.md'])
+  })
+
+  test('modified note with existing gitPath → unchanged', () => {
+    const c = classifyPendingChanges(
+      [n({ id: 'a', title: 'Edit', gitPath: 'Notes/Edit.md', updatedAt: 200 })],
+      100,
+      [f({ id: 'somewhere', name: 'Somewhere' })],
+    )
+    // Stored gitPath wins — synthetic derivation only fires for created notes.
+    expect(c.modified.map(x => x.gitPath)).toEqual(['Notes/Edit.md'])
+  })
+
+  test('created note: folders=undefined falls back to bare "<title>.md" (legacy callers)', () => {
+    const c = classifyPendingChanges(
+      [n({ id: 'a', title: 'Standalone', content: 'x', folderId: 'orphan' })],
+      null,
+    )
+    expect(c.created.map(x => x.gitPath)).toEqual(['Standalone.md'])
+  })
+
+  test('created note whose folderId points to a deleted folder → stops the walk', () => {
+    // A folder mid-walk that's been soft-deleted shouldn't pollute the
+    // synthetic path. Walk halts at the deleted folder, leaving any
+    // higher ancestors out — matches buildFolderPath's behaviour.
+    const folders: Folder[] = [
+      f({ id: 'parent', name: 'Parent' }),
+      f({ id: 'child', name: 'Child', parentId: 'parent', isDeleted: true }),
+    ]
+    const c = classifyPendingChanges(
+      [n({ id: 'a', title: 'Stray', content: 'x', folderId: 'child' })],
+      null,
+      folders,
+    )
+    // Walk halts at 'child' (deleted) → only filename remains.
+    expect(c.created.map(x => x.gitPath)).toEqual(['Stray.md'])
   })
 })

--- a/src/components/editor/EditorFooter.tsx
+++ b/src/components/editor/EditorFooter.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from 'react'
 import { ArrowPathIcon, FireIcon, SignalIcon, SignalSlashIcon } from '@heroicons/react/24/outline'
 import { extractTags } from '@/utils/tags'
-import { useGitHubStore, useNoteStore, useUIStore, useSettingsStore } from '@/stores'
+import { useGitHubStore, useNoteStore, useUIStore, useSettingsStore, useFolderStore } from '@/stores'
 import { classifyPendingChanges, totalPendingCount } from '@/utils/syncChanges'
 import { computeStreakFromDateStrings, dailyDateSet } from '@/utils/dailyStreak'
 import { useCollaboration } from '@/hooks/useCollaboration'
@@ -20,6 +20,7 @@ export const EditorFooter = ({ note }: EditorFooterProps) => {
   const lastSyncedAt = useGitHubStore(s => s.lastSyncedAt)
   const isSyncing = useGitHubStore(s => s.isSyncing)
   const notes = useNoteStore(s => s.notes)
+  const folders = useFolderStore(s => s.folders)
   const setCurrentView = useUIStore(s => s.setCurrentView)
 
   const tagCount = extractTags(note.content).length
@@ -41,8 +42,8 @@ export const EditorFooter = ({ note }: EditorFooterProps) => {
   // Reuses the same classifier the Source Control panel uses so the
   // numbers always agree.
   const pendingCount = useMemo(
-    () => syncRepo ? totalPendingCount(classifyPendingChanges(notes, lastSyncedAt)) : 0,
-    [syncRepo, notes, lastSyncedAt],
+    () => syncRepo ? totalPendingCount(classifyPendingChanges(notes, lastSyncedAt, folders)) : 0,
+    [syncRepo, notes, lastSyncedAt, folders],
   )
 
   const formatDate = (timestamp: number) =>

--- a/src/components/sidebar/SourceControlPanel.tsx
+++ b/src/components/sidebar/SourceControlPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react'
 import { ChevronDownIcon, ChevronRightIcon, ArrowTopRightOnSquareIcon, ArrowUturnLeftIcon } from '@heroicons/react/24/outline'
-import { useNoteStore, useGitHubStore, useWorkspaceStore, useUIStore } from '@/stores'
+import { useNoteStore, useGitHubStore, useWorkspaceStore, useUIStore, useFolderStore } from '@/stores'
 import {
   classifyPendingChanges,
   totalPendingCount,
@@ -81,13 +81,19 @@ function repoWebUrl(repo: { owner: string; name: string; branch: string }): stri
 
 export function SourceControlPanel() {
   const notes = useNoteStore(s => s.notes)
+  const folders = useFolderStore(s => s.folders)
   const lastSyncedAt = useGitHubStore(s => s.lastSyncedAt)
   const syncRepo = useGitHubStore(s => s.syncRepo)
   const openNote = useWorkspaceStore(s => s.openNote)
 
+  // Pass `folders` so created (never-pushed) notes carry a synthetic
+  // gitPath derived from their folder hierarchy — that's what lets
+  // groupChangesByFolder below nest them under the right directory
+  // instead of dumping them at the root (the
+  // fix/created-note-source-control-tree-bug fix).
   const changes = useMemo(
-    () => classifyPendingChanges(notes, lastSyncedAt),
-    [notes, lastSyncedAt],
+    () => classifyPendingChanges(notes, lastSyncedAt, folders),
+    [notes, lastSyncedAt, folders],
   )
   const total = totalPendingCount(changes)
 

--- a/src/utils/aiCommitMessage.ts
+++ b/src/utils/aiCommitMessage.ts
@@ -15,7 +15,7 @@
 
 import { runPrompt } from './aiClient'
 import { classifyPendingChanges, totalPendingCount, type SyncChangeSets } from './syncChanges'
-import { useNoteStore, useGitHubStore } from '@/stores'
+import { useNoteStore, useGitHubStore, useFolderStore } from '@/stores'
 
 const SYSTEM_PROMPT =
   'You write short, factual git commit messages for a personal note-taking app. ' +
@@ -36,8 +36,9 @@ const SYSTEM_PROMPT =
 // Errors are swallowed by design — never block a sync.
 export async function draftAiCommitMessage(): Promise<string | null> {
   const notes = useNoteStore.getState().notes
+  const folders = useFolderStore.getState().folders
   const lastSyncedAt = useGitHubStore.getState().lastSyncedAt
-  const changes = classifyPendingChanges(notes, lastSyncedAt)
+  const changes = classifyPendingChanges(notes, lastSyncedAt, folders)
   const total = totalPendingCount(changes)
   if (total === 0) return null
 

--- a/src/utils/syncChanges.ts
+++ b/src/utils/syncChanges.ts
@@ -22,14 +22,24 @@
 // work). The order of priority above also handles the "deleted note that
 // was never pushed" edge case — it's not in any bucket.
 
-import type { Note } from '@/types'
+import type { Note, Folder } from '@/types'
 
 export type ChangeKind = 'created' | 'modified' | 'deleted'
 
 export interface SyncChange {
   noteId: string
   title: string
-  /** Repo-relative path the note was last pushed to, or null when never pushed. */
+  /** Repo-relative path the change will live at on the remote.
+   *  - For a synced note (created/modified/deleted): the stored `Note.gitPath`.
+   *  - For a CREATED (never-pushed) note when `folders` is supplied: a
+   *    SYNTHETIC path derived from the note's folder hierarchy + title + `.md`,
+   *    mirroring where the note WILL land on the next push. This lets the
+   *    Source Control tree group new notes under their folder instead of
+   *    dumping them all at the repo root (the bug fix in
+   *    fix/created-note-source-control-tree-bug).
+   *  - Null only when the note has no path AND no folders were supplied
+   *    (legacy callers that didn't thread folders through).
+   */
   gitPath: string | null
   kind: ChangeKind
 }
@@ -43,10 +53,11 @@ export interface SyncChangeSets {
 export function classifyPendingChanges(
   notes: Note[],
   lastSyncedAt: number | null,
+  folders?: Folder[],
 ): SyncChangeSets {
   const out: SyncChangeSets = { created: [], modified: [], deleted: [] }
   for (const n of notes) {
-    const change = classifyOne(n, lastSyncedAt)
+    const change = classifyOne(n, lastSyncedAt, folders)
     if (change) out[change.kind].push(change)
   }
   // Sort each bucket alphabetically by title so the panel stays stable
@@ -58,7 +69,7 @@ export function classifyPendingChanges(
   return out
 }
 
-function classifyOne(n: Note, lastSyncedAt: number | null): SyncChange | null {
+function classifyOne(n: Note, lastSyncedAt: number | null, folders?: Folder[]): SyncChange | null {
   // A not-yet-loaded shell (progressive clone) is a placeholder, not a local
   // change — its body has not been fetched, so it is in sync with remote by
   // definition. Never count it as pending (it is also excluded from push).
@@ -67,27 +78,59 @@ function classifyOne(n: Note, lastSyncedAt: number | null): SyncChange | null {
   // Deleted-but-was-pushed → counts as a pending delete. Deleted but never
   // pushed = nothing for the user to see (already invisible).
   if (n.isDeleted) {
-    return hasPath ? mk(n, 'deleted') : null
+    return hasPath ? mk(n, 'deleted', folders) : null
   }
   // Created = no remote path. We surface even empty notes so the user
   // sees their freshly-created file in Source Control immediately.
   if (!hasPath) {
-    return mk(n, 'created')
+    return mk(n, 'created', folders)
   }
   // Modified = updatedAt > lastSyncedAt. Cheap heuristic — see file header.
   if (lastSyncedAt == null) {
     // Never synced + has gitPath shouldn't happen normally; treat as modified.
-    return mk(n, 'modified')
+    return mk(n, 'modified', folders)
   }
-  if (n.updatedAt > lastSyncedAt) return mk(n, 'modified')
+  if (n.updatedAt > lastSyncedAt) return mk(n, 'modified', folders)
   return null
 }
 
-function mk(n: Note, kind: ChangeKind): SyncChange {
+// Build the repo-relative path a created note WILL live at on the next push.
+// Walks `folders` up to the root via parentId, prepending each segment, then
+// appends "<title>.md". Mirrors `notePath()` in githubSync/internal.ts (and
+// would happily share that helper if it didn't drag the sanitizer + git stack
+// into this UX-only module — keeping this inline keeps syncChanges
+// dependency-free outside of @/types). Falls back to a bare "<title>.md" when
+// the parent folder can't be located (orphaned note, or folders not passed).
+function deriveCreatedGitPath(note: Note, folders: Folder[] | undefined): string {
+  const filename = `${note.title || 'Untitled'}.md`
+  if (!folders || !note.folderId) return filename
+  const byId = new Map(folders.map(f => [f.id, f]))
+  const segments: string[] = []
+  let cur: Folder | undefined = byId.get(note.folderId)
+  // Cap the walk so a corrupted parent cycle can't spin forever.
+  for (let i = 0; cur && i < 32; i++) {
+    if (cur.isDeleted) break
+    segments.unshift(cur.name)
+    cur = cur.parentId ? byId.get(cur.parentId) : undefined
+  }
+  segments.push(filename)
+  return segments.join('/')
+}
+
+function mk(n: Note, kind: ChangeKind, folders?: Folder[]): SyncChange {
+  // Created notes have no stored gitPath yet — derive a SYNTHETIC one from
+  // the folder hierarchy so the Source Control tree nests them under the
+  // folder they'll be pushed to. Without this, the panel's
+  // groupChangesByFolder falls back to `change.title` (the bug visible
+  // 2026-06-08: a new daily note "2026-06-16" landed at the repo root
+  // instead of under Notes/Daily). The push side reads `note.gitPath`
+  // directly (see pushPath()), so this synthetic path is purely a display
+  // hint — it doesn't leak into push decisions.
+  const gitPath = n.gitPath ?? (kind === 'created' ? deriveCreatedGitPath(n, folders) : null)
   return {
     noteId: n.id,
     title: n.title || 'Untitled',
-    gitPath: n.gitPath ?? null,
+    gitPath,
     kind,
   }
 }


### PR DESCRIPTION
## Summary

- A newly-created note (no `gitPath` yet) used to appear at the root of the Source Control change tree instead of nesting under its folder. Visible 2026-06-08: a freshly-created "2026-06-16" daily note landed at root while modified "2026-06-07.md" nested under `Notes/Daily`.
- Root cause: `classifyPendingChanges` left `SyncChange.gitPath` null, and the panel's `groupChangesByFolder` then fell back to `change.title` — a bare string with no `/`, so the change pulled into the root.
- Fix at the source: `classifyPendingChanges` now takes an optional `folders: Folder[]` and synthesises a `gitPath` for created notes by walking `folderId` up the parent chain and appending `"<title>.md"`. The three call sites (`SourceControlPanel`, `EditorFooter`, `aiCommitMessage`) thread folders through. `groupChangesByFolder` itself is unchanged.
- Safe with push: the synthetic path lives only on `SyncChange` (a display-layer struct). `syncPush.ts` derives its own path via `pushPath(note, folders)`, reading `Note.gitPath` directly, so the fix cannot leak into push decisions or affect create-vs-update behaviour.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test -- --ci` green (2734 tests pass, including new ones)
- [x] New `syncChanges.test.ts` cases: created note in root, in nested folder, with no title, modified note unchanged, undefined-folders legacy fallback, deleted-folder mid-walk
- [x] New `sourceControlTree.test.ts` integration: created note in `Notes/Daily` nests under `Notes/Daily` in the tree alongside modified siblings (no root leaves)
- [ ] Manual: create a fresh daily note → open Source Control panel → confirm it nests under `Notes/Daily`