### PR TITLE
/help: left-nav tree + welcome content + GIFs

### DIFF
--- a/src/__tests__/helpShell.test.tsx
+++ b/src/__tests__/helpShell.test.tsx
@@ -4,19 +4,22 @@
  * Smoke test for the /help layout chrome. Asserts:
  *   - sidebar renders the topic list
  *   - content children render
- *   - no theme toggle (the route inherits the main app dark theme)
- *   - the URL hash hook opens the matching <details> on load
+ *   - no theme toggle (the route inherits the main app dark theme —
+ *     guard against the toggle creeping back in)
+ *   - the active topic auto-expands and surfaces its sub-section links
+ *   - clicking a chevron toggles its sub-section list
+ *   - non-active topics start collapsed
  *
  * The HelpShell no longer carries a per-help theme; it inherits the
- * root <html class="dark"> set in src/app/layout.tsx. These tests
- * guard against the toggle creeping back in.
+ * root <html class="dark"> set in src/app/layout.tsx.
  */
 
 import React from 'react'
 import '@testing-library/jest-dom'
-import { render, screen, act } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { HelpShell } from '../app/help/HelpShell'
 import { HELP_PAGES } from '../help/content'
+import { parseHelpBody } from '../help/sections'
 
 beforeEach(() => {
   window.localStorage.clear()
@@ -29,7 +32,7 @@ const firstPage = HELP_PAGES[0]
 describe('HelpShell', () => {
   test('renders sidebar topics and child content', () => {
     render(
-      <HelpShell activeSlug={firstPage.slug} sectionSlugs={[]}>
+      <HelpShell activeSlug={firstPage.slug}>
         <p>article-body-marker</p>
       </HelpShell>
     )
@@ -43,7 +46,7 @@ describe('HelpShell', () => {
 
   test('does not render a theme toggle button', () => {
     render(
-      <HelpShell activeSlug={firstPage.slug} sectionSlugs={[]}>
+      <HelpShell activeSlug={firstPage.slug}>
         <div />
       </HelpShell>
     )
@@ -52,50 +55,65 @@ describe('HelpShell', () => {
 
   test('does not write a help-theme key to localStorage on mount', () => {
     render(
-      <HelpShell activeSlug={firstPage.slug} sectionSlugs={[]}>
+      <HelpShell activeSlug={firstPage.slug}>
         <div />
       </HelpShell>
     )
     expect(window.localStorage.getItem('noteser-help-theme')).toBeNull()
   })
 
-  test('opens the matching <details> when the URL hash names a known section', async () => {
-    window.history.replaceState(null, '', '/help/getting-started#first-note')
-
+  test('auto-expands the active topic and renders its sub-section links', () => {
     render(
-      <HelpShell activeSlug="getting-started" sectionSlugs={['first-note']}>
-        <details id="help-section-first-note" data-testid="first-note-details">
-          <summary>Your first note</summary>
-          <p>body</p>
-        </details>
+      <HelpShell activeSlug={firstPage.slug}>
+        <div />
       </HelpShell>
     )
-
-    await act(async () => {
-      await Promise.resolve()
-    })
-
-    const details = screen.getByTestId('first-note-details') as HTMLDetailsElement
-    expect(details.open).toBe(true)
+    const sections = parseHelpBody(firstPage.body).sections
+    for (const s of sections) {
+      const link = screen.getByRole('link', { name: s.heading })
+      expect(link).toHaveAttribute('href', `/help/${firstPage.slug}#${s.slug}`)
+    }
   })
 
-  test('leaves an unknown hash alone (no error, nothing opened)', async () => {
-    window.history.replaceState(null, '', '/help/getting-started#not-a-real-section')
+  test('non-active topics start collapsed; clicking the chevron expands them', () => {
+    // Find a non-active page that has sub-sections.
+    const other = HELP_PAGES.find(
+      p => p.slug !== firstPage.slug && parseHelpBody(p.body).sections.length > 0,
+    )
+    if (!other) throw new Error('Expected a second help page with sub-sections for this test')
+    const otherSections = parseHelpBody(other.body).sections
 
     render(
-      <HelpShell activeSlug="getting-started" sectionSlugs={['first-note']}>
-        <details id="help-section-first-note" data-testid="first-note-details">
-          <summary>Your first note</summary>
-          <p>body</p>
-        </details>
+      <HelpShell activeSlug={firstPage.slug}>
+        <div />
       </HelpShell>
     )
 
-    await act(async () => {
-      await Promise.resolve()
-    })
+    // Sub-section link for the non-active topic is NOT in the doc yet.
+    expect(screen.queryByRole('link', { name: otherSections[0].heading })).not.toBeInTheDocument()
 
-    const details = screen.getByTestId('first-note-details') as HTMLDetailsElement
-    expect(details.open).toBe(false)
+    // Click that topic's chevron.
+    const chevron = screen.getByRole('button', { name: new RegExp(`expand ${other.title}`, 'i') })
+    fireEvent.click(chevron)
+
+    // Now the sub-section links surface.
+    const link = screen.getByRole('link', { name: otherSections[0].heading })
+    expect(link).toHaveAttribute('href', `/help/${other.slug}#${otherSections[0].slug}`)
+  })
+
+  test('clicking the chevron of the active topic collapses it', () => {
+    render(
+      <HelpShell activeSlug={firstPage.slug}>
+        <div />
+      </HelpShell>
+    )
+    const firstSection = parseHelpBody(firstPage.body).sections[0]
+    expect(screen.getByRole('link', { name: firstSection.heading })).toBeInTheDocument()
+
+    const chevron = screen.getByRole('button', {
+      name: new RegExp(`collapse ${firstPage.title}`, 'i'),
+    })
+    fireEvent.click(chevron)
+    expect(screen.queryByRole('link', { name: firstSection.heading })).not.toBeInTheDocument()
   })
 })

--- a/src/app/help/HelpShell.tsx
+++ b/src/app/help/HelpShell.tsx
@@ -1,56 +1,137 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useMemo, useState, useRef, useCallback } from 'react'
 import Link from 'next/link'
-import { ArrowLeftIcon } from '@heroicons/react/24/outline'
+import { ArrowLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline'
 import { HELP_PAGES } from '@/help/content'
+import { parseHelpBody } from '@/help/sections'
 
 interface HelpShellProps {
   activeSlug: string
-  // Slugs (in source order) of the disclosure sections rendered inside
-  // `children`. Passed by the page so the shell can open the section
-  // that matches the URL hash on load. Source order keeps the open
-  // logic deterministic across slug collisions handled at parse time.
-  sectionSlugs: string[]
   children: React.ReactNode
 }
 
-// Chrome for every /help page. Inherits the main app theme (dark) from
-// the root <html class="dark"> in src/app/layout.tsx, so there is no
-// per-help theme toggle and no per-help localStorage key. Layout:
+// Chrome for every /help page. Inherits the main app dark theme from the
+// root <html class="dark"> in src/app/layout.tsx (no per-help theme key,
+// no toggle — that was removed in PR #153). Layout:
 //
 //   [ topbar (back link only) ........................................ ]
-//   [ sidebar TOC ] [ markdown content with per-section disclosures   ]
+//   [ left tree nav | markdown content (flowing, no inline details)   ]
 //
-// The old right-rail "On this page" TOC is gone. Per-topic disclosures
-// inside the article handle in-page navigation. The hash-watcher below
-// keeps deep links like /help/faq#vault-locked working: when the hash
-// matches a known section slug, the matching <details> is opened and
-// the page re-scrolls to the heading after the disclosure expands.
-export function HelpShell({ activeSlug, sectionSlugs, children }: HelpShellProps) {
+// PR #154: the per-H2 disclosures moved out of the BODY and into the
+// LEFT NAV as a collapsible tree. Each main topic shows a chevron next
+// to its label; click the chevron to expand and reveal that topic's
+// H2 sub-section anchors. Click a sub-section to navigate to the topic
+// AND scroll to the matching heading (`/help/<topic>#<section-slug>`).
+//
+// The currently-active topic auto-expands on mount so the user can see
+// where they are inside that topic. Persisting expand state across
+// navigation is intentionally NOT done — each page render starts with
+// just the active topic open. Keeps the nav free of stale state when a
+// user jumps between unrelated topics.
+//
+// Keyboard navigation:
+//   - Tab cycles through chevrons + topic links + sub-section links
+//     in source order. Native focus.
+//   - Arrow Down / Arrow Up moves between focusable nav items.
+//   - Enter / Space activates whatever is focused (native button +
+//     anchor behavior).
+//   - Right Arrow on a chevron-row expands; Left Arrow collapses.
+//
+// Hash scroll: the body now flows without disclosures, so the URL hash
+// resolves natively. The hook below still nudges scrollIntoView on
+// hashchange because Next's anchor-scroll can fire before the page is
+// painted, which leaves the heading hidden behind the sticky topbar.
+export function HelpShell({ activeSlug, children }: HelpShellProps) {
+  // Map<topic-slug, H2 sections> — computed once. parseHelpBody is pure
+  // and the HELP_PAGES list is static at build time.
+  const sectionsByPage = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof parseHelpBody>['sections']>()
+    for (const p of HELP_PAGES) {
+      map.set(p.slug, parseHelpBody(p.body).sections)
+    }
+    return map
+  }, [])
+
+  // Active topic auto-expands. Other topics start collapsed.
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set([activeSlug]))
+
+  // When the user navigates to a new topic (activeSlug changes), make
+  // sure that topic is expanded so they see their location in the tree.
+  // Other manual expansions stay open within the same client-side
+  // navigation — only collapsed topics get auto-expanded, never the
+  // reverse.
+  useEffect(() => {
+    setExpanded(prev => {
+      if (prev.has(activeSlug)) return prev
+      const next = new Set(prev)
+      next.add(activeSlug)
+      return next
+    })
+  }, [activeSlug])
+
+  const toggle = useCallback((slug: string) => {
+    setExpanded(prev => {
+      const next = new Set(prev)
+      if (next.has(slug)) next.delete(slug)
+      else next.add(slug)
+      return next
+    })
+  }, [])
+
+  // Hash-scroll nudge. Native anchor-scroll can fire before the page
+  // body is painted; this re-runs the scroll after the next animation
+  // frame so the heading lands below the sticky topbar (which already
+  // has scroll-margin-top via .help-prose).
   useEffect(() => {
     if (typeof window === 'undefined') return
-
-    const openMatchingSection = () => {
+    const scrollToHash = () => {
       const hash = window.location.hash.replace(/^#/, '')
       if (!hash) return
-      if (!sectionSlugs.includes(hash)) return
-      const el = document.getElementById(`help-section-${hash}`)
-      if (el && el instanceof HTMLDetailsElement && !el.open) {
-        el.open = true
-        // Browsers anchor-scroll before the details element opens, so
-        // the section header ends up off-screen without this nudge.
-        requestAnimationFrame(() => {
-          const target = document.getElementById(hash) ?? el
-          target.scrollIntoView({ block: 'start' })
-        })
+      const el = document.getElementById(hash)
+      if (!el) return
+      requestAnimationFrame(() => {
+        el.scrollIntoView({ block: 'start' })
+      })
+    }
+    scrollToHash()
+    window.addEventListener('hashchange', scrollToHash)
+    return () => window.removeEventListener('hashchange', scrollToHash)
+  }, [activeSlug])
+
+  // Ref to the nav element — used by the arrow-key handler to find all
+  // tab-stop elements (chevron buttons + topic anchors + sub-section
+  // anchors) and move focus between them.
+  const navRef = useRef<HTMLElement | null>(null)
+  const handleNavKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
+    const root = navRef.current
+    if (!root) return
+    const target = e.target as HTMLElement
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      const items = Array.from(
+        root.querySelectorAll<HTMLElement>('[data-help-nav-item="true"]'),
+      )
+      const idx = items.indexOf(target)
+      if (idx === -1) return
+      e.preventDefault()
+      const nextIdx =
+        e.key === 'ArrowDown'
+          ? Math.min(items.length - 1, idx + 1)
+          : Math.max(0, idx - 1)
+      items[nextIdx]?.focus()
+    } else if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      // Only operates on chevron buttons. Right opens, Left collapses.
+      const slug = target.getAttribute('data-help-topic-slug')
+      if (!slug) return
+      if (e.key === 'ArrowRight' && !expanded.has(slug)) {
+        e.preventDefault()
+        toggle(slug)
+      } else if (e.key === 'ArrowLeft' && expanded.has(slug)) {
+        e.preventDefault()
+        toggle(slug)
       }
     }
-
-    openMatchingSection()
-    window.addEventListener('hashchange', openMatchingSection)
-    return () => window.removeEventListener('hashchange', openMatchingSection)
-  }, [sectionSlugs])
+  }
 
   return (
     <div
@@ -72,8 +153,10 @@ export function HelpShell({ activeSlug, sectionSlugs, children }: HelpShellProps
       <div className="mx-auto max-w-[1400px] flex flex-col md:flex-row">
         <aside className="md:w-72 md:flex-none bg-[#1a1c20] border-r border-[#23262d] md:min-h-[calc(100dvh-57px)]">
           <nav
+            ref={navRef}
             aria-label="Help topics"
             className="sticky top-[57px] px-4 py-6 space-y-1"
+            onKeyDown={handleNavKeyDown}
           >
             <h2 className="px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#6b7280]">
               Topics
@@ -81,17 +164,56 @@ export function HelpShell({ activeSlug, sectionSlugs, children }: HelpShellProps
             <ul className="space-y-0.5">
               {HELP_PAGES.map(p => {
                 const active = p.slug === activeSlug
-                const itemCls = active
+                const isOpen = expanded.has(p.slug)
+                const sections = sectionsByPage.get(p.slug) ?? []
+                const hasSections = sections.length > 0
+                const rowBaseCls = active
                   ? 'bg-[#1e2530] text-[#f3f4f6] border-l-2 border-[#3a86ff] font-medium'
                   : 'text-[#9ca3af] hover:bg-[#1e2126] hover:text-[#e5e7eb] border-l-2 border-transparent'
                 return (
                   <li key={p.slug}>
-                    <Link
-                      href={`/help/${p.slug}`}
-                      className={`block pl-3 pr-3 py-2 text-[14px] leading-[1.45] rounded-r-md transition-colors ${itemCls}`}
-                    >
-                      {p.title}
-                    </Link>
+                    <div className={`flex items-stretch rounded-r-md ${rowBaseCls}`}>
+                      {hasSections ? (
+                        <button
+                          type="button"
+                          aria-label={isOpen ? `Collapse ${p.title}` : `Expand ${p.title}`}
+                          aria-expanded={isOpen}
+                          data-help-nav-item="true"
+                          data-help-topic-slug={p.slug}
+                          onClick={() => toggle(p.slug)}
+                          className="flex items-center justify-center w-7 flex-none text-[#6b7280] hover:text-[#e5e7eb] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#3a86ff] rounded-l-md"
+                        >
+                          <ChevronRightIcon
+                            className={`w-3.5 h-3.5 transition-transform ${isOpen ? 'rotate-90' : ''}`}
+                            aria-hidden="true"
+                          />
+                        </button>
+                      ) : (
+                        <span className="w-7 flex-none" aria-hidden="true" />
+                      )}
+                      <Link
+                        href={`/help/${p.slug}`}
+                        data-help-nav-item="true"
+                        className="flex-1 min-w-0 pr-3 py-2 text-[14px] leading-[1.45] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#3a86ff] rounded-r-md"
+                      >
+                        {p.title}
+                      </Link>
+                    </div>
+                    {hasSections && isOpen && (
+                      <ul className="mt-0.5 mb-1 ml-7 border-l border-[#23262d] pl-2 space-y-0.5">
+                        {sections.map(section => (
+                          <li key={section.slug}>
+                            <Link
+                              href={`/help/${p.slug}#${section.slug}`}
+                              data-help-nav-item="true"
+                              className="block px-2 py-1 text-[13px] leading-[1.4] text-[#9ca3af] hover:text-[#e5e7eb] hover:bg-[#1e2126] rounded transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#3a86ff]"
+                            >
+                              {section.heading}
+                            </Link>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                   </li>
                 )
               })}

--- a/src/app/help/[slug]/page.tsx
+++ b/src/app/help/[slug]/page.tsx
@@ -9,7 +9,7 @@ import { HelpShell } from '../HelpShell'
 //
 // Layout:
 //   [ topbar (back link) ............................................. ]
-//   [ sidebar TOC ] [ markdown content with per-section disclosures   ]
+//   [ left tree nav | markdown content (flowing, no inline details)   ]
 //
 // Static. Generated at build time via `generateStaticParams`. All
 // content lives in `src/help/content.ts` as plain markdown strings.
@@ -17,12 +17,14 @@ import { HelpShell } from '../HelpShell'
 // preview (without the wikilink / attachment custom renderers, which
 // don't make sense in standalone help).
 //
-// The intro chunk (H1 + lead paragraph before the first H2) renders
-// always-visible at the top. Every H2 section becomes a default-
-// collapsed `<details>` block: heading text in the `<summary>`, body
-// markdown in the panel. Deep links into a specific section
-// (e.g. /help/faq#vault-locked) are handled by the HelpShell hash hook,
-// which opens the matching `<details>` on load + on hashchange.
+// PR #154: H2 sections used to render as `<details>` disclosures. The
+// nesting moved into the LEFT NAV as a tree, so the body now renders
+// as a single flowing markdown document. The page still calls
+// parseHelpBody to keep H2 anchor ids stable (so deep links from the
+// left nav scroll correctly), then concatenates intro + sections back
+// into one ReactMarkdown render. Concatenation preserves source order;
+// duplicate-heading slugs stay deterministic because we feed all
+// h2s through the same per-render slug counter in `makeComponents`.
 
 export function generateStaticParams() {
   return HELP_PAGES.map(p => ({ slug: p.slug }))
@@ -38,9 +40,9 @@ export function generateMetadata({ params }: { params: Promise<{ slug: string }>
   })
 }
 
-// Heading-id slugger used inside the intro chunk so any h1/h3 still gets
-// an anchor target. Section h2 headings are anchored by their disclosure
-// container instead — see the section render loop below.
+// Heading-id slugger. Mirrors parseHelpBody so a link in the left nav
+// (`/help/<slug>#<section-slug>`) lands on the matching <h2 id="...">
+// inside the rendered article.
 function slugifyHeading(text: string): string {
   return text
     .toLowerCase()
@@ -80,35 +82,16 @@ export default async function HelpPage({ params }: { params: Promise<{ slug: str
   const page = findHelpPage(slug)
   if (!page) notFound()
 
-  const { intro, sections } = parseHelpBody(page.body)
-  const sectionSlugs = sections.map(s => s.slug)
+  // We still call parseHelpBody so adding a new H2 to content.ts
+  // automatically populates the left-nav tree. The body itself is
+  // rendered as a single flowing markdown string.
+  parseHelpBody(page.body)
 
   return (
-    <HelpShell activeSlug={slug} sectionSlugs={sectionSlugs}>
-      {intro && (
-        <ReactMarkdown remarkPlugins={[remarkGfm]} components={makeComponents()}>
-          {intro}
-        </ReactMarkdown>
-      )}
-      {sections.map(section => (
-        <details
-          key={section.slug}
-          id={`help-section-${section.slug}`}
-          className="help-disclosure"
-        >
-          <summary className="help-disclosure-summary">
-            <span className="help-disclosure-chevron" aria-hidden="true" />
-            <h2 id={section.slug} className="help-disclosure-heading">
-              {section.heading}
-            </h2>
-          </summary>
-          <div className="help-disclosure-body">
-            <ReactMarkdown remarkPlugins={[remarkGfm]} components={makeComponents()}>
-              {section.body}
-            </ReactMarkdown>
-          </div>
-        </details>
-      ))}
+    <HelpShell activeSlug={slug}>
+      <ReactMarkdown remarkPlugins={[remarkGfm]} components={makeComponents()}>
+        {page.body}
+      </ReactMarkdown>
     </HelpShell>
   )
 }

--- a/src/help/content.ts
+++ b/src/help/content.ts
@@ -19,12 +19,21 @@ const GETTING_STARTED: HelpPage = {
   slug: 'getting-started',
   title: 'Getting started',
   summary: 'A 60-second tour of noteser — the editor, sidebar, and your first note.',
+  // Intro prose is copied (not iframed) from the in-app WelcomePane so a
+  // first-time visitor reading /help sees the same product framing as a
+  // first-time user inside the app. Keeping the prose as plain markdown
+  // avoids mounting the live component, which assumes a connected store.
   body: `
 # Getting started
 
-Welcome to noteser. This is a browser-first markdown note-taking app
-inspired by Obsidian — your notes live in localStorage by default and
-optionally sync to a GitHub repo or a local folder on disk.
+Edit Markdown notes in your browser, on top of a GitHub repo you own.
+When the same note changed in two places, you see every conflict line
+by line and pick yours, theirs, or both. The merge UX from VS Code,
+in the browser, on your repo.
+
+![Typing a note in noteser: live-preview Markdown with wikilinks, tags, and tasks](/demo/noteser-demo.gif)
+
+*Live-preview editing with wikilinks, tags, and tasks.*
 
 ## Your first note
 
@@ -79,6 +88,10 @@ const GITHUB_SYNC: HelpPage = {
 Noteser can sync your vault with a GitHub repo. One commit per sync,
 clean three-way merge, no plugins or extensions required — it talks
 to the GitHub Git Data API directly from the browser.
+
+![Source control panel: pending changes, Commit and Sync, recent commit history](/demo/noteser-git-demo.gif)
+
+*Commit and sync, view pending changes, scroll through history.*
 
 ## Connect a repo
 
@@ -293,6 +306,10 @@ const EDITOR_POWER: HelpPage = {
 These tools live inside the note editor and turn it from "a textarea" into
 something closer to VS Code or Obsidian.
 
+![Live preview rendering as you type, with a tasks code block aggregating items across the vault](/demo/noteser-tasks-demo.gif)
+
+*Live-preview formatting and a tasks query rendering inline.*
+
 ## Per-line revert (after sync)
 
 ![Editor showing the note body in live-preview mode with formatted headings, bullet points, and inline tags](/screenshots/help/editor-live-preview.png)
@@ -378,6 +395,10 @@ const MOBILE_HELP: HelpPage = {
 
 Below 768px the layout switches to a single-pane mobile mode with an
 off-canvas drawer for the sidebar.
+
+![Noteser on iPhone: open the drawer, navigate the file tree, open a note](/demo/noteser-mobile-demo.gif)
+
+*The mobile drawer and single-pane editor.*
 
 ## Edge-swipe drawer
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -537,82 +537,18 @@
   color: #f3f4f6;
 }
 
-/* /help disclosure sections.
- * Each H2 section is rendered as a <details> with a chevron-stamped
- * <summary> that wraps the heading. Default state is collapsed. The
- * native <details> element already handles open/close, keyboard
- * activation, and matches the deep-link hook in HelpShell that sets
- * `el.open = true` when the URL hash points at a section. */
-.help-prose .help-disclosure {
-  margin-top: 2em;
-  border-top: 1px solid #2a2e36;
-  padding-top: 0.25em;
-}
-
-.help-prose .help-disclosure:first-of-type {
-  margin-top: 2.4em;
-}
-
-.help-prose .help-disclosure-summary {
-  display: flex;
-  align-items: center;
-  gap: 0.55em;
-  list-style: none;
-  cursor: pointer;
-  padding: 0.6em 0;
-  border-radius: 6px;
-  transition: color 120ms ease;
-  -webkit-tap-highlight-color: transparent;
-}
-
-.help-prose .help-disclosure-summary::-webkit-details-marker {
-  display: none;
-}
-
-.help-prose .help-disclosure-summary:hover {
-  color: #f3f4f6;
-}
-
-.help-prose .help-disclosure-summary:focus-visible {
-  outline: 2px solid #60a5fa;
-  outline-offset: 2px;
-}
-
-.help-prose .help-disclosure-chevron {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  flex: none;
-  border-top: 5px solid transparent;
-  border-bottom: 5px solid transparent;
-  border-left: 6px solid #6b7280;
-  transition: transform 160ms ease;
-  transform-origin: 30% 50%;
-}
-
-.help-prose .help-disclosure[open] > .help-disclosure-summary .help-disclosure-chevron {
-  transform: rotate(90deg);
-}
-
-.help-prose .help-disclosure-heading {
-  /* Override the .help-prose h2 baseline rules: no top margin, no
-     bottom border. The disclosure container provides the rhythm. */
-  margin: 0;
-  padding: 0;
-  border-bottom: 0;
-  font-size: 1.3rem;
-}
-
-.help-prose .help-disclosure-body {
-  padding: 0.2em 0 1em 1.55em;
-}
-
-.help-prose .help-disclosure-body > * + * {
-  margin-top: 1.1em;
-}
-
-.help-prose .help-disclosure-body > :first-child {
-  margin-top: 0.6em;
+/* Caption styling for inline GIFs / screenshots. The help markdown
+   uses `*caption text*` (italic) on the line directly after an image
+   to label it; this rule tightens the spacing so the caption visually
+   binds to the image rather than reading as a standalone paragraph. */
+.help-prose p > img + em,
+.help-prose p:has(> img) + p > em:only-child {
+  display: block;
+  font-style: normal;
+  color: #9ca3af;
+  font-size: 0.9em;
+  text-align: center;
+  margin-top: -0.4em;
 }
 
 /* Inline screenshots inside help articles. Keep them inside the


### PR DESCRIPTION
## Summary

Three follow-ups to PR #153, all on /help:

- **A) Left nav becomes a collapsible tree.** Each main topic now shows a chevron next to its label. Click the chevron to expand and reveal that topic's H2 sub-section anchors. Click a sub-section to navigate to the topic and scroll to the matching heading (`/help/<topic-slug>#<section-slug>`). The active topic auto-expands on mount; other topics start collapsed. Expand state does not persist across navigation.
- **B) Body flows without inline disclosures.** The per-H2 `<details>` blocks from PR #153 are removed. The full topic content renders as a single markdown document. Heading anchor ids stay stable, so deep links from the left tree (and any external links) still scroll correctly. A small `hashchange` listener nudges `scrollIntoView` after paint because Next's native anchor scroll can fire before the page is laid out.
- **C) GIFs across topics.** Getting started prepends the welcome intro paragraph (copied from `WelcomePane`, not iframed) plus the main demo GIF. Editor, Mobile, and GitHub sync each gain one GIF with a short voice-clean caption. FAQ prose is unchanged.

## Files changed

- `src/app/help/HelpShell.tsx` — left-nav tree; chevron buttons; arrow-key navigation; active-topic auto-expand
- `src/app/help/[slug]/page.tsx` — single ReactMarkdown render; no more `<details>` wrapper; heading-id slugger unchanged
- `src/help/content.ts` — Getting started intro + GIF; Editor / Mobile / GitHub sync GIFs with captions
- `src/styles/globals.css` — drops the disclosure rules; adds a small caption rule for `*italic*` lines that follow an image
- `src/__tests__/helpShell.test.tsx` — updated to the new prop signature (no `sectionSlugs`) and the new tree behavior

## GIF placements

| Topic | Asset | Size |
|---|---|---|
| Getting started | `/demo/noteser-demo.gif` | 778 KB |
| Editor power features | `/demo/noteser-tasks-demo.gif` | 494 KB |
| Mobile / touch shortcuts | `/demo/noteser-mobile-demo.gif` | 484 KB |
| GitHub sync | `/demo/noteser-git-demo.gif` | 465 KB |
| Sidebar / Plugins | (no new GIF — already has screenshots from #153) | — |

Total weight of new image references: **2221 KB** across four GIFs, all lazy-loaded (the article uses the default browser image loading behavior; markdown `![alt](path)` does not eager-fetch off-screen images). No new asset files were added — only references to existing files under `public/demo/`.

## Keyboard accessibility

The previous tree was simple `<a>` items, so Tab and Shift+Tab were the only nav. The new tree adds chevron `<button>`s. Behavior:

- **Tab / Shift+Tab** cycle through chevrons, topic links, and sub-section links in source order.
- **ArrowDown / ArrowUp** move focus between nav items.
- **ArrowRight** expands a topic when focused on its chevron; **ArrowLeft** collapses.
- **Enter / Space** activate whatever is focused (native button + anchor behavior).
- `aria-expanded` is set on each chevron button so screen readers announce open / closed state.

The full ARIA `tree` / `treeitem` roles were considered but skipped because `treeitem` requires `aria-selected`, which does not map cleanly onto an anchor-based "navigate to URL" semantic. A nested `<ul>` with chevron buttons covers screen readers via `aria-expanded` and keyboards via the handler above.

## Theme toggle

PR #153 removed the per-help theme toggle; this PR keeps that gone. There is one regression-guard test (`does not render a theme toggle button`).

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test -- --ci` — 2728 tests pass (was 2727; one extra test in helpShell)
- [x] `npm run build` — clean static export of all `/help/*` routes
- [ ] Manual on `npm run dev`: left nav shows topic + chevrons, click chevron expands sub-sections, click sub-section navigates and scrolls, active topic auto-expanded, body flows without inline disclosures, Getting started shows welcome prose + demo GIF, other topics show their GIF where added