### PR TITLE
Autocomplete: dismiss on space and on note switch

### DIFF
--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -450,6 +450,12 @@ export function CodeMirrorEditor({
   useEffect(() => { activeNotesRef.current = activeNotes }, [activeNotes])
   useEffect(() => { navigateRef.current = onWikilinkNavigate }, [onWikilinkNavigate])
   useEffect(() => { noteIdRef.current = noteId }, [noteId])
+  // Switching active note dismisses any open autocomplete dropdowns. Without
+  // this, the popup floats over the new note's editor (visible bug 2026-06-08).
+  useEffect(() => {
+    setTagState(null)
+    setWikilinkState(null)
+  }, [noteId])
 
   // Diff-gutter baseline (109): when the note changes — or after a
   // successful sync writes a fresh snapshot — fetch the last-pushed

--- a/src/components/editor/TagAutocomplete.tsx
+++ b/src/components/editor/TagAutocomplete.tsx
@@ -52,6 +52,11 @@ export function TagAutocomplete({ query, tags, position, onSelect, onClose }: Ta
       } else if (e.key === 'Escape') {
         e.preventDefault()
         onClose()
+      } else if (e.key === ' ') {
+        // Space dismisses the dropdown but lets the space character land in
+        // the editor — close without preventDefault so CodeMirror still gets
+        // the input.
+        onClose()
       }
     }
     window.addEventListener('keydown', onKey, true)


### PR DESCRIPTION
Jon (Telegram 2026-06-08): the tag autocomplete dropdown stays floating over the editor after switching to a different note, and pressing space does not dismiss it. Fix: TagAutocomplete catches space (closes without preventDefault so the space still lands in the editor) and CodeMirrorEditor clears both tag + wikilink dropdown state whenever the active noteId changes.