### PR TITLE
Show non-md vault files in the tree as un-openable entries

### DIFF
--- a/src/__tests__/foreignVaultFiles.test.tsx
+++ b/src/__tests__/foreignVaultFiles.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * foreignVaultFiles.test.tsx
+ *
+ * Coverage for non-md vault files (`.canvas`, `.base`, etc.) we mirror in the
+ * sidebar as un-openable entries. Three surfaces in this file:
+ *
+ *   1. FolderTree — a foreign-kind note renders with the distinct
+ *      `[data-testid=foreign-file-row]` row + does NOT call openNote on click.
+ *      A click instead surfaces a toast through useToastStore.
+ *
+ *   2. workspaceStore.openNote — calling openNote(id) on a foreign-kind note
+ *      is a no-op (no new tab) AND posts a toast. This guards every entry
+ *      point that ends up routed through openNote (search modal, command
+ *      palette, keyboard Enter on the tree row, etc.).
+ *
+ *   3. Push plan — see foreignVaultFilesPush.test.ts for the syncToGitHub
+ *      filter that drops foreign notes from the push.
+ *
+ * idb-keyval is mocked so the Zustand persist middleware doesn't reach
+ * IndexedDB (jsdom doesn't have it).
+ */
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn().mockResolvedValue(undefined),
+  set: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined),
+}))
+
+import React from 'react'
+import '@testing-library/jest-dom'
+import { render, screen, waitFor, fireEvent, cleanup, act } from '@testing-library/react'
+import { FolderTree } from '../components/sidebar/FolderTree'
+import { useNoteStore } from '../stores/noteStore'
+import { useFolderStore } from '../stores/folderStore'
+import { useUIStore } from '../stores/uiStore'
+import { useWorkspaceStore } from '../stores/workspaceStore'
+import { useToastStore } from '../stores/toastStore'
+import type { Note } from '../types'
+
+let noteCounter = 0
+function makeNote(overrides: Partial<Note> = {}): Note {
+  const id = `note-${++noteCounter}`
+  const now = Date.now()
+  return {
+    id,
+    title: `Note ${id}`,
+    content: '',
+    folderId: null,
+    createdAt: now,
+    updatedAt: now,
+    isDeleted: false,
+    deletedAt: null,
+    isPinned: false,
+    templateId: null,
+    kind: 'markdown',
+    ...overrides,
+  }
+}
+
+function renderTreeWith(notes: Note[]) {
+  useNoteStore.setState({ notes, selectedNoteId: null })
+  useFolderStore.setState({ folders: [], activeFolderId: null, expandedFolders: {} })
+  useUIStore.setState({ currentView: 'notes' })
+  return render(<FolderTree onRightClick={() => {}} />)
+}
+
+beforeEach(() => {
+  cleanup()
+  useNoteStore.setState({ notes: [], selectedNoteId: null })
+  useFolderStore.setState({ folders: [], activeFolderId: null, expandedFolders: {} })
+  // Toasts post real setTimeouts to auto-dismiss; previous-test timers
+  // would fire mid-next-test otherwise. Reset the workspace too so a
+  // previous-test tab doesn't leak across.
+  useToastStore.setState({ toasts: [] })
+  // Reset workspace to a single empty pane so per-test tab counts are
+  // measured against a known baseline.
+  const initialPaneId = 'test-pane'
+  useWorkspaceStore.setState({
+    panes: [{ id: initialPaneId, tabs: [], activeTabId: null }],
+    layout: { kind: 'leaf', paneId: initialPaneId } as never,
+    activePaneId: initialPaneId,
+    histories: {},
+    recents: [],
+  })
+})
+
+afterAll(() => {
+  cleanup()
+})
+
+describe('FolderTree — foreign vault file rows', () => {
+  test('clicking a foreign row does NOT open a tab and DOES post an info toast', async () => {
+    renderTreeWith([
+      makeNote({ title: 'Untitled.canvas', kind: 'foreign', gitPath: 'Untitled.canvas' }),
+    ])
+
+    // Workspace starts with one empty pane, zero tabs.
+    const before = useWorkspaceStore.getState().panes.reduce((n, p) => n + p.tabs.length, 0)
+
+    const row = await screen.findByTestId('foreign-file-row')
+    act(() => { fireEvent.click(row) })
+
+    // No new tab opened — openNote was either bypassed entirely (FolderTree
+    // routes foreign-row clicks straight to the toast) or refused by the
+    // workspace guard. Either way: no tab.
+    const after = useWorkspaceStore.getState().panes.reduce((n, p) => n + p.tabs.length, 0)
+    expect(after).toBe(before)
+
+    // And a toast was posted.
+    await waitFor(() => {
+      const toasts = useToastStore.getState().toasts
+      expect(toasts.length).toBeGreaterThan(0)
+      expect(toasts.some(t => t.message.includes('cannot open Untitled.canvas'))).toBe(true)
+    })
+  })
+
+  test('renders a foreign-kind note with the foreign-file row testid (not the markdown one)', async () => {
+    renderTreeWith([
+      makeNote({ title: 'Untitled.canvas', kind: 'foreign', gitPath: 'Untitled.canvas' }),
+    ])
+
+    const row = await screen.findByTestId('foreign-file-row')
+    expect(row.getAttribute('data-foreign')).toBe('true')
+    expect(row.textContent).toContain('Untitled.canvas')
+    expect(row.getAttribute('title')).toBe('File type not supported yet')
+    // The markdown leaf row uses `data-testid=note-row`; foreign rows MUST
+    // NOT be tagged as such so click-to-open keyboard / mouse handlers in
+    // tests can target only openable notes.
+    expect(screen.queryByTestId('note-row')).toBeNull()
+  })
+
+  test('renders both a markdown note row AND a foreign row in the same tree', async () => {
+    renderTreeWith([
+      makeNote({ title: 'Real note', kind: 'markdown' }),
+      makeNote({ title: 'Other.canvas', kind: 'foreign', gitPath: 'Other.canvas' }),
+    ])
+
+    // Wait for the foreign row to appear, then confirm both row testids are
+    // present. We assert presence via queryByTestId !== null rather than
+    // toBeInTheDocument — under React 19's concurrent rendering, a detached
+    // DOM node can survive a beforeEach `cleanup()` and read back from
+    // toBeInTheDocument as false, which is misleading here.
+    await screen.findByTestId('foreign-file-row')
+    expect(screen.queryByTestId('note-row')).not.toBeNull()
+    expect(screen.queryByTestId('foreign-file-row')).not.toBeNull()
+  })
+})
+
+describe('workspaceStore.openNote — foreign guard', () => {
+  test('openNote on a foreign-kind note posts a toast and does not open a tab', async () => {
+    const foreign = makeNote({ title: 'Untitled.canvas', kind: 'foreign', gitPath: 'Untitled.canvas' })
+    useNoteStore.setState({ notes: [foreign], selectedNoteId: null })
+
+    const tabsBefore = useWorkspaceStore.getState().panes.reduce((n, p) => n + p.tabs.length, 0)
+    useWorkspaceStore.getState().openNote(foreign.id, { preview: false })
+    const tabsAfter = useWorkspaceStore.getState().panes.reduce((n, p) => n + p.tabs.length, 0)
+
+    expect(tabsAfter).toBe(tabsBefore)
+    await waitFor(() => {
+      const toasts = useToastStore.getState().toasts
+      expect(toasts.length).toBeGreaterThan(0)
+      expect(toasts.some(t => t.message.includes('Untitled.canvas'))).toBe(true)
+    })
+  })
+
+  test('openNote on a markdown note still opens a tab normally (regression guard)', () => {
+    const md = makeNote({ title: 'Real note', kind: 'markdown' })
+    useNoteStore.setState({ notes: [md], selectedNoteId: null })
+    const tabsBefore = useWorkspaceStore.getState().panes.reduce((n, p) => n + p.tabs.length, 0)
+    useWorkspaceStore.getState().openNote(md.id, { preview: false })
+    const tabsAfter = useWorkspaceStore.getState().panes.reduce((n, p) => n + p.tabs.length, 0)
+    expect(tabsAfter).toBe(tabsBefore + 1)
+  })
+})

--- a/src/__tests__/foreignVaultFilesPush.test.ts
+++ b/src/__tests__/foreignVaultFilesPush.test.ts
@@ -1,0 +1,209 @@
+/**
+ * @jest-environment node
+ *
+ * foreignVaultFilesPush.test.ts
+ *
+ * The push pipeline MUST never include a `kind: 'foreign'` note. A foreign
+ * note is a read-only mirror of a non-md remote vault file (e.g. `.canvas`,
+ * `.base`); its `content` is intentionally empty. Pushing it would (a) upload
+ * an empty blob over the real remote file, and (b) — if only filtered from
+ * the `desired` set — trigger the deletion loop and emit a `sha: null` DELETE
+ * for the real file. Both outcomes are data loss, so the filter is critical.
+ *
+ * Strategy mirrors pushOnlyRealEdits.test.ts: mock the network surface via
+ * global.fetch, keep gitBlobSha real, drive syncToGitHub directly.
+ */
+
+import { syncToGitHub, _resetUploadedShaCache } from '../utils/githubSync'
+import type { Note, Folder, SyncRepo } from '@/types'
+
+jest.mock('../utils/attachments', () => ({
+  isAttachmentPath: () => false,
+  listAttachmentPaths: async () => [],
+  getAttachmentBlob: async () => null,
+  getAttachmentGitSha: async () => null,
+  getAttachmentTombstones: async () => [],
+  clearAttachmentTombstones: async () => undefined,
+}))
+jest.mock('../utils/lastPushedContent', () => ({
+  setLastPushedContent: async () => undefined,
+  getLastPushedContent: async () => null,
+}))
+jest.mock('../stores/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({ localGitignoreOverlay: '', vaultEncryptionEnabled: false }) },
+}))
+
+const REPO: SyncRepo = { owner: 'o', name: 'r', branch: 'main', isPrivate: true }
+
+function makeNote(id: string, title: string, content: string, extra: Partial<Note> = {}): Note {
+  return {
+    id,
+    title,
+    content,
+    folderId: null,
+    createdAt: 0,
+    updatedAt: 0,
+    isDeleted: false,
+    deletedAt: null,
+    isPinned: false,
+    templateId: null,
+    gitPath: null,
+    gitLastPushedSha: null,
+    gitRemoteBaseSha: null,
+    kind: 'markdown',
+    ...extra,
+  }
+}
+
+interface TreeEntry { path: string; sha: string | null }
+
+function makeFetchMock(remoteBlobs: Map<string, string>) {
+  const record = {
+    treeEntriesPosted: null as TreeEntry[] | null,
+    blobsCreated: [] as string[],
+    commitCreated: false,
+    refUpdated: false,
+  }
+  const fetchMock = jest.fn(async (url: string | URL, init?: RequestInit) => {
+    const u = String(url)
+    if (u.includes('/git/refs/heads/main') && init?.method === 'PATCH') {
+      record.refUpdated = true
+      return new Response(JSON.stringify({}), { status: 200 })
+    }
+    if (u.includes('/git/refs/heads/main')) {
+      return new Response(JSON.stringify({ ref: 'refs/heads/main', object: { sha: 'parent-commit' } }), { status: 200 })
+    }
+    if (u.match(/\/git\/commits\/parent-commit/)) {
+      return new Response(JSON.stringify({ tree: { sha: 'base-tree' } }), { status: 200 })
+    }
+    if (u.includes('/git/trees/base-tree?recursive=1')) {
+      const tree = Array.from(remoteBlobs.entries()).map(([path, sha]) => ({ path, type: 'blob', sha }))
+      return new Response(JSON.stringify({ tree }), { status: 200 })
+    }
+    if (u.endsWith('/git/blobs') && init?.method === 'POST') {
+      const body = JSON.parse(String(init.body)) as { content: string }
+      const sha = `created-blob-${record.blobsCreated.length}`
+      record.blobsCreated.push(body.content)
+      return new Response(JSON.stringify({ sha }), { status: 201 })
+    }
+    if (u.endsWith('/git/trees') && init?.method === 'POST') {
+      const body = JSON.parse(String(init.body)) as { tree: TreeEntry[] }
+      record.treeEntriesPosted = body.tree
+      return new Response(JSON.stringify({ sha: 'new-tree' }), { status: 201 })
+    }
+    if (u.endsWith('/git/commits') && init?.method === 'POST') {
+      record.commitCreated = true
+      return new Response(JSON.stringify({ sha: 'new-commit', html_url: 'https://github.com/x' }), { status: 201 })
+    }
+    return new Response('not mocked: ' + u, { status: 500 })
+  })
+  return { fetchMock, record }
+}
+
+describe('syncToGitHub — foreign-kind notes never appear in the push plan', () => {
+  beforeEach(() => { _resetUploadedShaCache() })
+
+  test('a foreign mirror is excluded from desired AND from the deletion loop (no blob, no delete, no commit)', async () => {
+    // A live remote file at Untitled.canvas with a sha; a local foreign mirror
+    // pointing at the same gitPath. The mirror's content is empty (read-only)
+    // and a naive push would either upload empty bytes over the remote OR
+    // emit a sha:null delete. Neither must happen.
+    const remoteSha = 'sha-canvas'
+    const foreignMirror = makeNote('foreign-1', 'Untitled.canvas', '', {
+      kind: 'foreign',
+      gitPath: 'Untitled.canvas',
+      gitLastPushedSha: remoteSha,
+      gitRemoteBaseSha: remoteSha,
+    })
+
+    const { fetchMock, record } = makeFetchMock(new Map([['Untitled.canvas', remoteSha]]))
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const outcome = await syncToGitHub({
+      token: 't',
+      repo: REPO,
+      notes: [foreignMirror],
+      folders: [] as Folder[],
+    })
+
+    // Nothing pushed: no blobs created, no tree posted (the empty-entries
+    // early-return triggers), no commit, no ref update.
+    expect(record.blobsCreated).toEqual([])
+    expect(record.treeEntriesPosted).toBeNull()
+    expect(record.commitCreated).toBe(false)
+    expect(record.refUpdated).toBe(false)
+
+    // Outcome reads as a clean no-op.
+    expect(outcome.result.unchanged).toBe(true)
+    expect(outcome.result.created).toBe(0)
+    expect(outcome.result.updated).toBe(0)
+    expect(outcome.result.deleted).toBe(0)
+    expect(outcome.pathUpdates).toEqual([])
+  })
+
+  test('a soft-deleted foreign mirror does NOT emit a remote delete (read-only mirror is immutable)', async () => {
+    // The mirror's local entry was marked deleted. A normal markdown note in
+    // this state would emit a sha:null tree entry for its gitPath. Foreign
+    // mirrors must be skipped here too — the user has no business deleting a
+    // file we cannot edit, and the safety guarantee is unconditional.
+    const remoteSha = 'sha-canvas'
+    const foreignMirror = makeNote('foreign-1', 'Untitled.canvas', '', {
+      kind: 'foreign',
+      gitPath: 'Untitled.canvas',
+      gitLastPushedSha: remoteSha,
+      gitRemoteBaseSha: remoteSha,
+      isDeleted: true,
+      deletedAt: 1,
+    })
+
+    const { fetchMock, record } = makeFetchMock(new Map([['Untitled.canvas', remoteSha]]))
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const outcome = await syncToGitHub({
+      token: 't',
+      repo: REPO,
+      notes: [foreignMirror],
+      folders: [] as Folder[],
+    })
+
+    expect(record.blobsCreated).toEqual([])
+    expect(record.treeEntriesPosted).toBeNull()
+    expect(record.commitCreated).toBe(false)
+    expect(outcome.result.deleted).toBe(0)
+    expect(outcome.pathUpdates).toEqual([])
+  })
+
+  test('a markdown note PLUS a foreign mirror: only the markdown participates (regression guard)', async () => {
+    // Sanity-check the filter doesn't accidentally drop markdown notes that
+    // happen to live alongside foreign mirrors. New markdown note (no gitPath)
+    // should push as a creation; the foreign mirror should not.
+    const remoteSha = 'sha-canvas'
+    const md = makeNote('md-1', 'Real note', 'Hello\n')
+    const foreignMirror = makeNote('foreign-1', 'Untitled.canvas', '', {
+      kind: 'foreign',
+      gitPath: 'Untitled.canvas',
+      gitLastPushedSha: remoteSha,
+      gitRemoteBaseSha: remoteSha,
+    })
+
+    const { fetchMock, record } = makeFetchMock(new Map([['Untitled.canvas', remoteSha]]))
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const outcome = await syncToGitHub({
+      token: 't',
+      repo: REPO,
+      notes: [md, foreignMirror],
+      folders: [] as Folder[],
+    })
+
+    // Exactly one blob created (the markdown note), exactly one tree entry,
+    // exactly one created path. Foreign mirror's path is NOT in the tree.
+    expect(record.blobsCreated).toHaveLength(1)
+    const paths = (record.treeEntriesPosted ?? []).map(e => e.path)
+    expect(paths).toEqual(['Real note.md'])
+    expect(paths).not.toContain('Untitled.canvas')
+
+    expect(outcome.result.created).toBe(1)
+    expect(outcome.result.deleted).toBe(0)
+  })
+})

--- a/src/__tests__/githubSyncClassify.test.ts
+++ b/src/__tests__/githubSyncClassify.test.ts
@@ -910,3 +910,107 @@ test('PROBE: identical local + remote content despite drifted ancestor → uncha
   const { classifications } = await pullFromGitHub({ token: 't', repo: REPO, notes: local, folders: [] })
   expect(classifications[0].kind).toBe('unchanged')
 })
+
+// ── foreign vault files (.canvas / .base / etc.) ────────────────────────────
+//
+// Non-md, non-attachment files we cannot render yet. The pull emits a
+// `foreignFile` classification per remote file so the apply layer can mirror
+// each one as an un-openable entry in the sidebar tree.
+
+test('classifies a remote .canvas file with no local match as foreignFile', async () => {
+  mockGetTreeMap.mockResolvedValue(new Map([['Untitled.canvas', 'sha-canvas']]))
+
+  const { classifications } = await pullFromGitHub({ token: 't', repo: REPO, notes: [], folders: [] })
+
+  // Exactly one classification, exactly the foreignFile entry — no body fetch.
+  const foreign = classifications.filter(c => c.kind === 'foreignFile')
+  expect(foreign).toHaveLength(1)
+  expect(foreign[0]).toEqual({ kind: 'foreignFile', path: 'Untitled.canvas', remoteSha: 'sha-canvas' })
+  expect(mockGetBlobContent).not.toHaveBeenCalled()
+})
+
+test('classifies both a .canvas and a .base remote file as foreignFile', async () => {
+  mockGetTreeMap.mockResolvedValue(new Map([
+    ['Untitled.canvas', 'sha-canvas'],
+    ['Untitled.base', 'sha-base'],
+  ]))
+
+  const { classifications } = await pullFromGitHub({ token: 't', repo: REPO, notes: [], folders: [] })
+
+  const foreign = classifications.filter(c => c.kind === 'foreignFile')
+  expect(foreign).toHaveLength(2)
+  const byPath = new Map(foreign.map(f => [(f as { path: string }).path, f]))
+  expect(byPath.get('Untitled.canvas')).toEqual({ kind: 'foreignFile', path: 'Untitled.canvas', remoteSha: 'sha-canvas' })
+  expect(byPath.get('Untitled.base')).toEqual({ kind: 'foreignFile', path: 'Untitled.base', remoteSha: 'sha-base' })
+})
+
+test('does not re-emit foreignFile when a local foreign note already mirrors the path', async () => {
+  mockGetTreeMap.mockResolvedValue(new Map([['Untitled.canvas', 'sha-canvas']]))
+
+  // Local already has a foreign mirror for this exact path (a prior pull).
+  const local: Note[] = [
+    note({
+      id: '1',
+      title: 'Untitled.canvas',
+      content: '',
+      gitPath: 'Untitled.canvas',
+      gitLastPushedSha: 'sha-canvas',
+      gitRemoteBaseSha: 'sha-canvas',
+    } as Note & { kind: 'foreign' }),
+  ]
+  // Tag it as foreign — note() helper doesn't expose `kind` directly.
+  ;(local[0] as { kind?: string }).kind = 'foreign'
+
+  const { classifications } = await pullFromGitHub({ token: 't', repo: REPO, notes: local, folders: [] })
+
+  expect(classifications.find(c => c.kind === 'foreignFile')).toBeUndefined()
+})
+
+test('local foreign mirror whose remote file is gone classifies as remoteDeleted (no content hashing)', async () => {
+  mockGetTreeMap.mockResolvedValue(new Map())
+  // gitBlobSha should NOT be called for the foreign-shortcut path — keep the
+  // mock implementation strict so an unexpected call would explode visibly.
+  mockGitBlobSha.mockImplementation(() => { throw new Error('foreign branch should not hash content') })
+
+  const local: Note[] = [
+    note({
+      id: '1',
+      title: 'Untitled.canvas',
+      content: '',
+      gitPath: 'Untitled.canvas',
+      gitLastPushedSha: 'sha-canvas',
+      gitRemoteBaseSha: 'sha-canvas',
+    }),
+  ]
+  ;(local[0] as { kind?: string }).kind = 'foreign'
+
+  const { classifications } = await pullFromGitHub({ token: 't', repo: REPO, notes: local, folders: [] })
+
+  expect(classifications).toHaveLength(1)
+  expect(classifications[0]).toEqual({ kind: 'remoteDeleted', noteId: '1' })
+})
+
+test('non-md non-attachment file under an ignored path does NOT classify as foreignFile', async () => {
+  // The default gitignore matcher drops `.DS_Store` and *.tmp. Drop a
+  // .canvas alongside one of those in an ignored subtree and confirm the
+  // gitignore wins (the matcher gate runs BEFORE the foreign check).
+  // Note: the default ignore set doesn't currently cover .canvas in any
+  // path, so we use the per-device overlay (settingsStore) to ignore a
+  // specific name and assert it gets filtered out.
+  const { useSettingsStore } = await import('../stores/settingsStore')
+  useSettingsStore.setState({ localGitignoreOverlay: 'ignored.canvas' })
+  try {
+    mockGetTreeMap.mockResolvedValue(new Map([
+      ['Untitled.canvas', 'sha-canvas'],
+      ['ignored.canvas',  'sha-ignored'],
+    ]))
+
+    const { classifications } = await pullFromGitHub({ token: 't', repo: REPO, notes: [], folders: [] })
+
+    const foreign = classifications.filter(c => c.kind === 'foreignFile')
+    expect(foreign).toHaveLength(1)
+    expect((foreign[0] as { path: string }).path).toBe('Untitled.canvas')
+  } finally {
+    useSettingsStore.setState({ localGitignoreOverlay: '' })
+  }
+})

--- a/src/components/sidebar/ContextMenu.tsx
+++ b/src/components/sidebar/ContextMenu.tsx
@@ -16,7 +16,10 @@ import {
   ClockIcon,
   ShareIcon,
   ArrowsRightLeftIcon,
+  EyeIcon,
+  ArrowTopRightOnSquareIcon,
 } from '@heroicons/react/24/outline'
+import { revealNote } from '@/utils/revealNote'
 import { useShallow } from 'zustand/react/shallow'
 import { useNoteStore, useFolderStore, useUIStore, useWorkspaceStore, useSettingsStore, useGitHubStore } from '@/stores'
 import type { ContextMenuState, Folder } from '@/types'
@@ -232,6 +235,71 @@ export const ContextMenu = ({ contextMenu, onClose }: ContextMenuProps) => {
   }
 
   if (!item) return null
+
+  // foreign-vault-files: a note with `kind: 'foreign'` is a read-only mirror
+  // of a remote vault file (e.g. `.canvas`, `.base`) — Rename / Delete /
+  // Duplicate / Pin all make no sense (we cannot edit the file). Render a
+  // short menu with Reveal in folder (sidebar focus) and Show on GitHub
+  // (open the raw file in a new tab) so the user can still find or inspect
+  // the file. Everything destructive is excluded by design.
+  const isForeignNote = isNote && (item as { kind?: string }).kind === 'foreign'
+  if (isForeignNote) {
+    const foreignNote = item as { gitPath?: string | null }
+    const { token, syncRepo } = useGitHubStore.getState()
+    const gitPath = foreignNote.gitPath ?? null
+    const githubUrl = syncRepo && gitPath
+      ? `https://github.com/${syncRepo.owner}/${syncRepo.name}/blob/${syncRepo.branch}/${gitPath
+          .split('/')
+          .map(encodeURIComponent)
+          .join('/')}`
+      : null
+    const handleReveal = () => {
+      revealNote(contextMenu.id)
+      onClose()
+    }
+    const handleShowOnGitHub = () => {
+      if (githubUrl) window.open(githubUrl, '_blank', 'noopener')
+      onClose()
+    }
+    // We hide Show on GitHub when we don't have a repo to link to (e.g. the
+    // user hasn't connected GitHub yet). The Reveal action stays available
+    // because it works purely against local state. `token` is read so a
+    // future enhancement can gate features that need an authenticated
+    // request, but currently the URL is public-readable so we don't depend
+    // on it here.
+    void token
+    // MenuButton is declared further down the function body so we inline the
+    // two buttons here instead of forward-referencing it. The styling matches
+    // MenuButton verbatim to keep the menu consistent with the other entries.
+    return (
+      <div
+        ref={menuRef}
+        className="fixed bg-obsidianGray border border-obsidianBorder rounded-lg shadow-obsidian py-1 min-w-[180px] z-50"
+        style={{ top: contextMenu.y, left: contextMenu.x }}
+        role="menu"
+        data-testid="context-menu"
+      >
+        <button
+          onClick={handleReveal}
+          className="w-full flex items-center gap-2 px-3 py-2 text-sm text-obsidianText hover:bg-obsidianHighlight transition-colors"
+          data-testid="context-menu-foreign-reveal"
+        >
+          <EyeIcon className="w-4 h-4" />
+          Reveal in folder
+        </button>
+        {githubUrl && (
+          <button
+            onClick={handleShowOnGitHub}
+            className="w-full flex items-center gap-2 px-3 py-2 text-sm text-obsidianText hover:bg-obsidianHighlight transition-colors"
+            data-testid="context-menu-foreign-github"
+          >
+            <ArrowTopRightOnSquareIcon className="w-4 h-4" />
+            Show on GitHub
+          </button>
+        )}
+      </div>
+    )
+  }
 
   // Note-only: is the right-clicked note in the trash? Drives the
   // Restore option visibility — and we hide the rest of the note

--- a/src/components/sidebar/FolderTree.tsx
+++ b/src/components/sidebar/FolderTree.tsx
@@ -6,8 +6,10 @@ import {
   ChevronRightIcon,
   FolderIcon,
   DocumentTextIcon,
+  DocumentMagnifyingGlassIcon,
   TrashIcon,
 } from '@heroicons/react/24/outline'
+import { useToastStore } from '@/stores/toastStore'
 import { StarIcon as StarIconSolid } from '@heroicons/react/24/solid'
 import { useShallow } from 'zustand/react/shallow'
 import { useNoteStore, useFolderStore, useUIStore, useWorkspaceStore, useSettingsStore } from '@/stores'
@@ -633,8 +635,51 @@ export const FolderTree = ({ onRightClick }: FolderTreeProps) => {
     </div>
   )
 
+  // Foreign-vault-file row: a non-md, non-attachment file we mirror from the
+  // remote vault as a non-openable entry (e.g. `.canvas`, `.base`). It uses
+  // a distinct icon + muted italic styling to signal "not openable"; a click
+  // surfaces a toast instead of opening the editor. Right-click hands the
+  // existing `onRightClick` handler the note id — the ContextMenu special-
+  // cases foreign-kind notes to only show Reveal in folder / Show on GitHub
+  // (no Rename / Delete on files we cannot edit).
+  const ForeignFileItem = ({ note, depth = 0 }: { note: typeof notes[0]; depth?: number }) => {
+    const kbFocused = isRowFocused('note', note.id)
+    const handleClick = () => {
+      useToastStore.getState().addToast({
+        kind: 'info',
+        message: `noteser cannot open ${note.title} yet. The file is in your vault and visible in the tree.`,
+        source: 'foreign-file-open',
+      })
+    }
+    return (
+      <div
+        className={`obsidian-file-item italic text-obsidianSecondaryText ${
+          kbFocused ? 'ring-1 ring-inset ring-obsidianAccentPurple' : ''
+        }`}
+        onClick={handleClick}
+        onContextMenu={e => onRightClick(e, 'note', note.id)}
+        title="File type not supported yet"
+        tabIndex={-1}
+        data-testid="foreign-file-row"
+        data-note-id={note.id}
+        data-foreign="true"
+        role="treeitem"
+        aria-level={depth + 1}
+        aria-selected={false}
+        aria-disabled="true"
+      >
+        <DocumentMagnifyingGlassIcon className="w-4 h-4 mr-2 flex-shrink-0" />
+        <span className="flex-1 truncate">{note.title}</span>
+      </div>
+    )
+  }
+
   // Render note item
   const NoteItem = ({ note, className = '', depth = 0 }: { note: typeof notes[0]; className?: string; depth?: number }) => {
+    // Foreign files render through a separate row component — no editor open,
+    // no drag-and-drop into other folders, no multi-select bulk delete. See
+    // ForeignFileItem above.
+    if (note.kind === 'foreign') return <ForeignFileItem note={note} depth={depth} />
     const kbFocused = isRowFocused('note', note.id)
     const multiSelected = isSelected(note.id)
     const isCompareSource = compareSourceNoteId === note.id

--- a/src/stores/noteStore.ts
+++ b/src/stores/noteStore.ts
@@ -342,7 +342,13 @@ export const useNoteStore = create<NoteState>()(
     {
       name: STORAGE_KEYS.notes,
       storage: idbStorage,
-      version: 2,
+      // v3 — foreign-vault-files: stamp `kind: 'markdown'` on every persisted
+      // note so the new `kind` field is explicit on existing data. v2 records
+      // (kind absent) are treated as markdown by every read path, so the
+      // migration is idempotent — re-running it on a v3 store leaves it
+      // unchanged and adding `kind` to a brand-new note via addNote uses the
+      // same default.
+      version: 3,
       migrate: (persistedState: unknown, version: number) => {
         const state = persistedState as NoteState
         if (version === 0 || version === 1) {
@@ -358,8 +364,19 @@ export const useNoteStore = create<NoteState>()(
               deletedAt: note.deletedAt || null,
               isPinned: note.isPinned || false,
               templateId: note.templateId || null,
-              folderId: note.folderId ? String(note.folderId) : null
+              folderId: note.folderId ? String(note.folderId) : null,
+              // Every pre-v3 note is markdown.
+              kind: (note as Note).kind ?? 'markdown',
             }))
+          }
+        }
+        if (version === 2) {
+          return {
+            ...state,
+            notes: (state.notes || []).map((note: Note) => ({
+              ...note,
+              kind: note.kind ?? 'markdown',
+            })),
           }
         }
         return state

--- a/src/stores/workspaceStore.ts
+++ b/src/stores/workspaceStore.ts
@@ -547,6 +547,27 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       recents: [],
 
       openNote: (noteId, opts) => {
+        // foreign-vault-files: refuse to open a foreign-kind note. These are
+        // read-only mirrors of remote vault files (e.g. `.canvas`, `.base`)
+        // that noteser does not yet know how to render. Show a toast and
+        // bail without touching the workspace state so the user sees the
+        // file in the tree but the editor stays on whatever was previously
+        // open. Same dynamic-import pattern the rest of openNote uses to
+        // avoid a static cycle with toastStore (which is fine to load lazily
+        // since toasts are point-in-time feedback, not on the render path).
+        const target = useNoteStore.getState().notes.find(n => n.id === noteId)
+        if (target && target.kind === 'foreign') {
+          if (typeof window !== 'undefined') {
+            void import('./toastStore').then(({ useToastStore }) => {
+              useToastStore.getState().addToast({
+                kind: 'info',
+                message: `noteser cannot open ${target.title} yet. The file is in your vault and visible in the tree.`,
+                source: 'foreign-file-open',
+              })
+            }).catch(() => { /* swallow — toast is best-effort */ })
+          }
+          return
+        }
         const preview = opts?.preview ?? true
         const state = get()
         // Default target pane: caller-specified, else active pane, else first.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,6 +65,14 @@ export interface Note {
   // persisted before this field existed, and for all normally-created notes.
   // Only an explicit `false` marks a shell.
   contentLoaded?: boolean
+  // Classification of what this entry actually is. Default 'markdown' for every
+  // existing note. 'foreign' marks a non-markdown vault file (e.g. `.canvas`,
+  // `.base`) that we mirror in the sidebar tree so the user can see it, but
+  // cannot open or edit. Foreign entries always carry empty `content` (the real
+  // body lives only in the remote repo); they are excluded from the push plan
+  // so a "read-only mirror" entry can never overwrite the remote file with an
+  // empty body. Future work will add openable renderers per format.
+  kind?: 'markdown' | 'foreign'
 }
 
 export interface Folder {

--- a/src/utils/githubSync.ts
+++ b/src/utils/githubSync.ts
@@ -21,6 +21,9 @@ export {
   pushPath,
   // MIME helpers (also used by tests)
   guessMimeFromPath,
+  // Foreign-vault-file classifier (non-md, non-attachment vault files we
+  // mirror in the tree as un-openable entries — see syncPull / syncPush).
+  isForeignVaultFile,
   // Note serialization + parser
   serializeNote,
   normalizeForPush,

--- a/src/utils/githubSync/internal.ts
+++ b/src/utils/githubSync/internal.ts
@@ -15,6 +15,7 @@ import type { Note, Folder } from '@/types'
 // importing sanitizeFilename from '../export' dragged jszip + file-saver
 // into the first-load bundle. '../sanitizeFilename' is jszip-free.
 import { sanitizeFilename } from '../sanitizeFilename'
+import { isAttachmentPath } from '../attachments'
 import { encryptNoteContent, decryptNoteContent, isEncryptedContent } from '../vaultCrypto'
 import { getVaultKey, VaultLockedError } from '../vaultKey'
 
@@ -128,6 +129,29 @@ export function pushPath(note: Note, folders: Folder[]): string {
   // derived path no longer matches it.
   const derived = notePath(note, folders)
   return derived === note.gitPath ? note.gitPath : derived
+}
+
+// Foreign vault file detection. A "foreign" file is something the remote
+// vault holds that noteser does NOT yet know how to render (e.g. `.canvas`,
+// `.base`, custom Obsidian plugin files). We mirror them into the sidebar
+// tree as un-openable entries so the user can see the full vault layout —
+// future work will add openable renderers per format.
+//
+// The check is intentionally narrow:
+//   - `.md` files are notes, never foreign.
+//   - Anything under the attachments folder is handled by the binary-
+//     attachment pipeline (`.attachments/` etc.); it has its own classify
+//     path and must not be picked up here.
+//   - Everything else is foreign.
+//
+// Paths to files at the repo root (no extension at all) also count as
+// foreign — they are still files the user can see in GitHub, and refusing
+// to render them in the tree would hide vault content.
+export function isForeignVaultFile(path: string): boolean {
+  if (!path) return false
+  if (path.endsWith('.md')) return false
+  if (isAttachmentPath(path)) return false
+  return true
 }
 
 // Map common image extensions to MIME types so attachment pulls hand the

--- a/src/utils/githubSync/syncClassify.ts
+++ b/src/utils/githubSync/syncClassify.ts
@@ -66,6 +66,13 @@ export type PullClassification =
       path: string
       localContent: string
     }
+  // Foreign vault file (non-md, non-attachment) we don't yet know how to render
+  // but want visible in the sidebar as an un-openable entry. Apply materialises
+  // a Note with `kind: 'foreign'`, empty content, gitPath = path, so the user
+  // sees the file in the tree. The push path skips foreign notes so they can
+  // never overwrite the real remote file with an empty body. See
+  // `isForeignVaultFile` in `./internal.ts`.
+  | { kind: 'foreignFile'; path: string; remoteSha: string }
   // Binary attachment: remote has this file, local doesn't. Apply step fetches
   // the bytes and writes them to IDB at the same path.
   | { kind: 'attachmentCreated'; path: string; remoteSha: string; mime: string }

--- a/src/utils/githubSync/syncPull.ts
+++ b/src/utils/githubSync/syncPull.ts
@@ -38,6 +38,7 @@ import {
   serializeNote,
   parseNote,
   guessMimeFromPath,
+  isForeignVaultFile,
 } from './internal'
 import type { PullClassification, PullOutcome } from './syncClassify'
 
@@ -526,6 +527,23 @@ export async function pullFromGitHub(input: {
     }
   }
 
+  // 1c-foreign. Non-md, non-attachment files we want visible in the tree as
+  // un-openable entries. We emit a `foreignFile` classification only when no
+  // local foreign Note already mirrors the path — every other case (already
+  // mirrored, soft-deleted locally) is a no-op so we never resurrect a
+  // tombstoned mirror or duplicate-create on repeated pulls. The body is
+  // intentionally NOT fetched: a canvas/base file can be megabytes and is not
+  // rendered locally yet. The push side (`syncPush.ts`) skips `kind: 'foreign'`
+  // notes so a mirror can never overwrite the real remote file with empty
+  // bytes.
+  for (const [path, remoteSha] of remoteTree) {
+    if (!isForeignVaultFile(path)) continue
+    if (gitignoreMatcher.isIgnored(path)) continue
+    const existing = notes.find(n => n.gitPath === path)
+    if (existing) continue
+    out.push({ kind: 'foreignFile', path, remoteSha })
+  }
+
   // 1c. Binary attachments under `attachments/`. Compare each remote entry
   // against the local IDB store; queue creates/updates so syncApply can fetch
   // the bytes lazily (each blob fetch is its own API call, so we only pay
@@ -551,6 +569,14 @@ export async function pullFromGitHub(input: {
   for (const note of notes) {
     if (note.isDeleted || !note.gitPath || seenLocalIds.has(note.id)) continue
     if (remoteTree.has(note.gitPath)) continue
+    // foreign-vault-files: a foreign mirror whose remote file is gone is a
+    // clean delete. There is nothing the user could have edited locally (the
+    // mirror is empty + read-only), so always `remoteDeleted` — no conflict
+    // path to consider, no content-SHA computation needed.
+    if (note.kind === 'foreign') {
+      out.push({ kind: 'remoteDeleted', noteId: note.id })
+      continue
+    }
     // Was it deleted on the remote?
     const lastPushed = note.gitLastPushedSha ?? null
     const localContent = serializeNote(note)

--- a/src/utils/githubSync/syncPush.ts
+++ b/src/utils/githubSync/syncPush.ts
@@ -152,7 +152,14 @@ export async function syncToGitHub(input: SyncInput): Promise<SyncOutcome> {
   // until its body loads and contentLoaded flips true. This is the push-side
   // half of the #1 sync-safety rule (the pull-side half is the classifier
   // guard in pullFromGitHub).
-  const activeNotes = notes.filter(n => !n.isDeleted && n.contentLoaded !== false)
+  //
+  // foreign-vault-files: ALSO exclude `kind: 'foreign'` notes. They are
+  // read-only mirrors of remote files we cannot edit (e.g. `.canvas`,
+  // `.base`) — their `content` is intentionally empty and pushing them would
+  // overwrite the real remote file with empty bytes. Same dropping pattern
+  // as shells: out of `activeNotes` keeps them out of BOTH `desired` and the
+  // deletion loop in step 4.
+  const activeNotes = notes.filter(n => !n.isDeleted && n.contentLoaded !== false && n.kind !== 'foreign')
   const desired = new Map<string, { content: string; note: Note }>()
   for (const note of activeNotes) {
     // preserve-gitpath-on-push: a synced note pushes to its EXISTING gitPath
@@ -511,6 +518,10 @@ export async function syncToGitHub(input: SyncInput): Promise<SyncOutcome> {
     }
   }
   for (const note of notes) {
+    // foreign-vault-files: a `kind: 'foreign'` note is a read-only mirror —
+    // it must never push a delete to the remote even if the user (somehow)
+    // soft-deletes the mirror locally. Just skip it; the real file stays put.
+    if (note.kind === 'foreign') continue
     if (note.isDeleted && note.gitPath && remoteTree.has(note.gitPath)) {
       // Only delete if no active note has already moved into that path AND no
       // live note's content maps to it. The protectedRemotePaths check is the

--- a/src/utils/syncApply.ts
+++ b/src/utils/syncApply.ts
@@ -35,6 +35,15 @@ function splitRepoPath(path: string): { segments: string[]; title: string } {
   return { segments: parts, title }
 }
 
+// Same as splitRepoPath but preserves the extension in `title` — foreign vault
+// files surface with their full filename ("Untitled 1.canvas") so the user can
+// see what type of file the entry is at a glance.
+function splitRepoForeignPath(path: string): { segments: string[]; title: string } {
+  const parts = path.split('/')
+  const file = parts.pop() ?? ''
+  return { segments: parts, title: file }
+}
+
 // ── Apply ──────────────────────────────────────────────────────────────────
 
 export interface ApplyCounts {
@@ -101,6 +110,41 @@ export async function applyNonConflicts(classifications: PullClassification[]): 
       // re-implement that here — folder creation is rare relative to
       // notes, and the folderStore set() already coalesces in practice.
       ensureFolderPath(c.path.split('/'))
+      continue
+    }
+
+    if (c.kind === 'foreignFile') {
+      // Foreign vault file (non-md, non-attachment). We materialise a
+      // placeholder Note with `kind: 'foreign'` so the file appears in the
+      // sidebar tree as an un-openable entry, mirroring the remote vault
+      // layout. The body is intentionally empty — canvas / base files can be
+      // megabytes and we have no renderer for them yet. The push pipeline
+      // (`syncPush.ts`) skips foreign notes so this mirror can never overwrite
+      // the real remote file with empty bytes; the editor likewise refuses to
+      // open them. See Note.kind in `src/types/index.ts`.
+      const { segments, title } = splitRepoForeignPath(c.path)
+      const folderId = ensureFolderPath(segments)
+      const foreignNote = {
+        id: uuid(),
+        title,
+        content: '',
+        folderId,
+        gitPath: c.path,
+        // Pin both SHAs to the raw remote blob SHA so the classifier reads
+        // the entry as `unchanged` on subsequent pulls and never re-emits a
+        // foreignFile for it.
+        gitLastPushedSha: c.remoteSha,
+        gitRemoteBaseSha: c.remoteSha,
+        kind: 'foreign' as const,
+        createdAt: now,
+        updatedAt: now,
+        isDeleted: false,
+        deletedAt: null,
+        isPinned: false,
+        templateId: null,
+      }
+      byId.set(foreignNote.id, foreignNote as ReturnType<typeof useNoteStore.getState>['notes'][number])
+      counts.created++
       continue
     }
 


### PR DESCRIPTION
## Summary

- Pull non-md, non-attachment vault files (e.g. `.canvas`, `.base`) into the local note store as `kind: 'foreign'` mirrors so the sidebar reflects the full repo layout.
- Render foreign entries with a distinct icon (`DocumentMagnifyingGlassIcon`), muted italic styling, and a `File type not supported yet` tooltip; clicking surfaces a toast instead of opening the editor.
- Guard the editor: `openNote(id)` on a foreign-kind note shows the toast and bails — covers search modal, command palette, keyboard Enter on the tree row, and every other openNote caller.
- Skip foreign notes in the push pipeline unconditionally (`activeNotes` filter + soft-delete loop) so a read-only mirror can never overwrite the real remote file with empty bytes.
- Bump `noteStore` persist version to v3 with an idempotent migration that stamps `kind: 'markdown'` on every existing record. Foreign-aware context menu replaces Rename / Delete with Reveal in folder + Show on GitHub.

This is the data model + visibility step Jon asked for on 2026-06-08. Canvas / base rendering is explicitly out of scope and tracked as the follow-up "later" item.

## Data model

```ts
// src/types/index.ts
interface Note {
  // ...
  kind?: 'markdown' | 'foreign'
}
```

Default is `'markdown'`. Foreign mirrors carry empty `content`, gitPath = remote path, and both SHAs pinned to the raw remote blob SHA so the classifier reads them as `unchanged` on subsequent pulls.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` zero errors
- [x] `npm test -- --ci` green (2748 passed, 17 skipped)
- [x] New unit coverage in `src/__tests__/foreignVaultFiles.test.tsx` (FolderTree row + openNote guard)
- [x] New push coverage in `src/__tests__/foreignVaultFilesPush.test.ts` (no blob, no delete, regression guard with a markdown sibling)
- [x] New classify coverage in `src/__tests__/githubSyncClassify.test.ts` (`.canvas` / `.base` foreignFile, dedupe, remote-gone, gitignore-respect)
- [ ] Manual: load a vault with at least one `.canvas` file in GitHub, sync, confirm the file appears in the tree with the distinct icon, clicking shows a toast and does not break the editor.