### PR TITLE
Skip dotfiles from foreign-vault-files tree

### DIFF
--- a/src/utils/githubSync/internal.ts
+++ b/src/utils/githubSync/internal.ts
@@ -151,6 +151,12 @@ export function isForeignVaultFile(path: string): boolean {
   if (!path) return false
   if (path.endsWith('.md')) return false
   if (isAttachmentPath(path)) return false
+  // Dotfiles + files inside any dot-folder (.gitignore, .obsidian/*,
+  // .noteser/*, etc.) are repo/app infrastructure, not user-facing vault
+  // content. The .trash folder is a noteser-internal soft-delete area that
+  // the existing tree renders specially, so it stays out of the foreign
+  // pipeline too.
+  if (path.split('/').some(seg => seg.startsWith('.'))) return false
   return true
 }
 


### PR DESCRIPTION
Jon (Telegram 2026-06-09): .gitignore was showing in the noteser tree because PR #157's isForeignVaultFile is intentionally narrow. Extends the filter so any path with a dot-prefixed segment is excluded — covers .gitignore at root, .obsidian/, .noteser/, .github/, and so on. Visible foreign content stays limited to actual user files like .canvas or .base.