### PR TITLE
chore(tests): silence persist warnings + fix act() in useCollaboration test

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -15,3 +15,17 @@ if (typeof global.Response === 'undefined' && typeof globalThis.Response !== 'un
   global.Headers = globalThis.Headers
   global.Request = globalThis.Request
 }
+
+// Zustand's persist middleware logs a `console.warn` every time a
+// hydrated store writes back to a missing storage. jsdom doesn't expose
+// localStorage to Zustand's createJSONStorage (it returns undefined when
+// the storage probe runs before the test environment is ready), so each
+// store fires the warning on every `set()` — ~70 lines per test run.
+// Filter only that exact category; every other warning passes through.
+const PERSIST_WARNING_RE = /\[zustand persist middleware\] Unable to update item .*storage is currently unavailable/
+const originalConsoleWarn = console.warn
+console.warn = (...args) => {
+  const first = args[0]
+  if (typeof first === 'string' && PERSIST_WARNING_RE.test(first)) return
+  originalConsoleWarn(...args)
+}

--- a/src/__tests__/useCollaboration.test.ts
+++ b/src/__tests__/useCollaboration.test.ts
@@ -29,7 +29,13 @@ class MockWebSocket {
   }
   close() {
     this.readyState = 3
-    queueMicrotask(() => { this.onclose?.() })
+    // Real browsers fire `onclose` asynchronously after close(). In
+    // tests that branch only matters when we're explicitly asserting on
+    // disconnect/reconnect behavior — those tests drive it via
+    // fireClose(). Auto-firing here would dispatch onclose during the
+    // hook's useEffect cleanup at test teardown, which calls setStatus
+    // outside any act() boundary and trips a React warning. Tests that
+    // care call fireClose() directly inside act().
   }
   fireOpen() { this.readyState = 1; this.onopen?.() }
   fireClose() { this.readyState = 3; this.onclose?.() }


### PR DESCRIPTION
## Summary

Two narrow Jest-output cleanups so real warnings stand out in `npm test` output again.

- `jest.setup.js`: filter the exact `[zustand persist middleware] Unable to update item ... storage is currently unavailable` line. Zustand's persist middleware logs once per `set()` when storage is missing, and jsdom doesn't expose `localStorage` to `createJSONStorage` at hydration time — so every persisted store fires the warning on every state update. About 70 lines per run. Every other `console.warn` still passes through.
- `useCollaboration.test.ts`: stop `MockWebSocket.close()` from auto-firing `onclose` via a microtask. That microtask dispatched during the hook's `useEffect` cleanup at test teardown, calling `setStatus('disconnected')` outside any `act(...)` boundary. Tests that actually need a close event still drive it via `fireClose()`.

Before: 70 persist warnings + 1 act() warning per full `npm test` run.
After: 0 persist warnings, 0 act() warnings; one legitimate `[attachments]` IndexedDB warning still surfaces (as it should).

Closes #130
Closes #131

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npx jest src/__tests__/useCollaboration.test.ts --ci` — 5/5 pass, no act() warning
- [x] Full `npm test` — 2757 pass, 17 skipped, 216 suites, 0 fail
- [x] `npm test -- --ci 2>&1 | grep -ciE "zustand persist|storage is currently unavailable"` — 0 (was 70)