### PR TITLE
fix(plugins): clean noteser-graph description, add missing descriptions, normalize fs capability casing

### DIFF
--- a/public/plugins/noteser-callout/manifest.json
+++ b/public/plugins/noteser-callout/manifest.json
@@ -3,6 +3,7 @@
   "name": "Callouts",
   "version": "0.1.0",
   "author": "Noteser",
+  "description": "Colored callout boxes inside notes, rendered from fenced code blocks (note / info / tip / warn / danger).",
   "main": "./main.js",
   "surfaces": {
     "codeBlockRenderers": [

--- a/public/plugins/noteser-graph/manifest.json
+++ b/public/plugins/noteser-graph/manifest.json
@@ -3,7 +3,7 @@
   "name": "Graph",
   "version": "0.1.0",
   "author": "Noteser",
-  "description": "Backlinks and unlinked mentions for the active note in the sidebar, plus a force-directed graph of the entire vault in a fullscreen view. Closes issue #71.",
+  "description": "Backlinks and unlinked mentions for the active note in the sidebar, plus a force-directed graph of the entire vault in a fullscreen view.",
   "main": "./main.js",
   "surfaces": {
     "sidebarPanels": [

--- a/public/plugins/noteser-pdf-export/manifest.json
+++ b/public/plugins/noteser-pdf-export/manifest.json
@@ -3,6 +3,7 @@
   "name": "PDF export",
   "version": "0.1.0",
   "author": "Noteser",
+  "description": "Adds an Export note as PDF command to the palette.",
   "main": "./main.js",
   "permissions": ["file-save"],
   "surfaces": {

--- a/public/plugins/noteser-word-count/manifest.json
+++ b/public/plugins/noteser-word-count/manifest.json
@@ -3,6 +3,7 @@
   "name": "Word count",
   "version": "0.1.0",
   "author": "Noteser",
+  "description": "Live word and character count for the active note, with reading-time estimate.",
   "main": "./main.js",
   "surfaces": {
     "sidebarPanels": [{ "id": "panel", "title": "Word count" }]


### PR DESCRIPTION
## Summary

Three small manifest fixes under `public/plugins/`.

### Fix 1: noteser-graph description leak
Dropped the literal `Closes issue #71.` sentence from the end of the public `description`. That was an internal PR artifact and the install-preview modal renders the description verbatim to end users.

### Fix 2: add missing description fields
Three plugins had no `description` key. awesome-noteser pulls descriptions from the manifest, and the install-preview modal renders the field verbatim, so every bundled plugin should ship one. Added a one-line factual description to each:

- **noteser-word-count**: "Live word and character count for the active note, with reading-time estimate."
- **noteser-callout**: "Colored callout boxes inside notes, rendered from fenced code blocks (note / info / tip / warn / danger)."
- **noteser-pdf-export**: "Adds an Export note as PDF command to the palette."

### Fix 3: fs capability casing -> no manifest change required

**Source of truth: kebab-case `fs.open-directory`.**

Evidence:
- `src/plugins/manifest.ts` PERMISSIONS const lists `'fs.open-directory'`.
- `src/plugins/PluginHost.ts:839` gates the capability with `permissions?.includes('fs.open-directory')`.
- `src/__tests__/plugins/fsOpenDirectory.test.ts` has an explicit test that **rejects** `fs.openDirectory` as a typo.

The only manifest declaring the permission (`noteser-importer/manifest.json`) already uses `fs.open-directory`. The camelCase form `fs.openDirectory` only appears as the SDK method name `ctx.fs.openDirectory(...)`, which is a distinct concept and follows JS naming convention. Docs already disambiguate the two correctly, so no doc edits either.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` zero errors
- [x] `npm test -- --ci` green (2757 passed, 17 skipped)
- [x] Each touched manifest is valid JSON (`python3 -m json.tool` exits 0)

Generated with Claude Code.