### PR TITLE
feat(editor): extend hanging-indent to list continuation lines (Obsidian visual parity)

### DIFF
--- a/src/__tests__/hangingIndentPlugin.test.ts
+++ b/src/__tests__/hangingIndentPlugin.test.ts
@@ -15,14 +15,15 @@
 jest.mock('idb-keyval', () => ({
   get: jest.fn().mockResolvedValue(undefined),
   set: jest.fn().mockResolvedValue(undefined),
-  del: jest.fn().mockResolvedValue(undefined),
+  del: jest.fn().mockResolvedValue(undefined)
 }))
 
-import { EditorState } from '@codemirror/state'
+import { EditorState, Text } from '@codemirror/state'
 import { EditorView, ViewPlugin } from '@codemirror/view'
 import {
+  continuationIndentWidth,
   hangingIndentExtension,
-  listLinePrefixWidth,
+  listLinePrefixWidth
 } from '../components/editor/hangingIndentPlugin'
 
 describe('listLinePrefixWidth', () => {
@@ -61,6 +62,78 @@ describe('listLinePrefixWidth', () => {
   })
 })
 
+// Helper: build a Text doc from an array of lines (one per element) so the
+// continuation-walk tests read like the actual buffer they describe.
+function textOf(lines: string[]): Text {
+  return Text.of(lines)
+}
+
+describe('continuationIndentWidth (Shift+Enter list-paragraph chain)', () => {
+  test('bullet + 2-space continuation returns the bullet marker width (2)', () => {
+    const doc = textOf(['- bullet', '  cont line'])
+    expect(continuationIndentWidth(doc, 2)).toBe(2)
+  })
+
+  test('task + 6-space continuation returns the task marker width (6)', () => {
+    const doc = textOf(['- [ ] Check IIA references', '      this is a note'])
+    expect(continuationIndentWidth(doc, 2)).toBe(6)
+  })
+
+  test('two consecutive continuation lines share the same parent width', () => {
+    const doc = textOf([
+      '- [ ] task body',
+      '      first continuation',
+      '      second continuation'
+    ])
+    expect(continuationIndentWidth(doc, 2)).toBe(6)
+    expect(continuationIndentWidth(doc, 3)).toBe(6)
+  })
+
+  test('blank line between parent and would-be continuation breaks the chain', () => {
+    const doc = textOf(['- bullet', '', '  not a continuation'])
+    expect(continuationIndentWidth(doc, 3)).toBe(0)
+  })
+
+  test('plain top-level paragraph with no leading whitespace is not a continuation', () => {
+    const doc = textOf(['- bullet', 'plain paragraph below'])
+    expect(continuationIndentWidth(doc, 2)).toBe(0)
+  })
+
+  test('intermediate non-indented plain line breaks the chain (no chain to follow)', () => {
+    const doc = textOf([
+      '- bullet',
+      'unrelated paragraph',
+      '  looks like cont but parent is unreachable'
+    ])
+    expect(continuationIndentWidth(doc, 3)).toBe(0)
+  })
+
+  test('nested list: continuation matches the IMMEDIATE parent (deepest list line above)', () => {
+    // Outer bullet "- outer" (width 2), nested bullet "  - inner" (width 4),
+    // continuation under the inner item needs >=4 leading spaces.
+    const doc = textOf(['- outer', '  - inner', '    inner continuation'])
+    expect(continuationIndentWidth(doc, 3)).toBe(4)
+  })
+
+  test('leading whitespace shorter than parent marker width does not count', () => {
+    // "- [ ] body" needs >=6 spaces on the continuation; "    " is only 4.
+    const doc = textOf(['- [ ] body', '    too-shallow'])
+    expect(continuationIndentWidth(doc, 2)).toBe(0)
+  })
+
+  test('list-marker line itself returns 0 (handled by the marker pass, not the chain)', () => {
+    const doc = textOf(['- bullet', '- another bullet'])
+    expect(continuationIndentWidth(doc, 1)).toBe(0)
+    expect(continuationIndentWidth(doc, 2)).toBe(0)
+  })
+
+  test('plain line with only whitespace (no body) does not extend the chain', () => {
+    // A line of just spaces should behave like a blank line — terminator.
+    const doc = textOf(['- bullet', '   ', '  would-be cont'])
+    expect(continuationIndentWidth(doc, 3)).toBe(0)
+  })
+})
+
 // Read every line decoration the plugin produced for a given doc and return
 // a map of 1-based line number -> inline style string. Walking the
 // DecorationSet directly is the cleanest way to assert what the ViewPlugin
@@ -69,19 +142,31 @@ describe('listLinePrefixWidth', () => {
 function collectLineDecorations(doc: string): Map<number, string> {
   const state = EditorState.create({
     doc,
-    extensions: [EditorView.lineWrapping, hangingIndentExtension],
+    extensions: [EditorView.lineWrapping, hangingIndentExtension]
   })
   const view = new EditorView({ state })
   try {
     const out = new Map<number, string>()
     // Locate our plugin via the public field accessor.
-    const plugins = (view as unknown as {
-      plugins: { value: { decorations?: unknown } }[]
-    }).plugins
+    const plugins = (
+      view as unknown as {
+        plugins: { value: { decorations?: unknown } }[]
+      }
+    ).plugins
     const found = plugins
       .map(p => p.value)
-      .find((v): v is { decorations: { iter(): { value: { spec: { attributes?: { style?: string } } } | null; from: number; next(): void } } } =>
-        !!v && typeof v === 'object' && 'decorations' in v
+      .find(
+        (
+          v
+        ): v is {
+          decorations: {
+            iter(): {
+              value: { spec: { attributes?: { style?: string } } } | null
+              from: number
+              next(): void
+            }
+          }
+        } => !!v && typeof v === 'object' && 'decorations' in v
       )
     if (!found) return out
     const iter = found.decorations.iter()
@@ -110,7 +195,7 @@ describe('hangingIndentExtension decorations', () => {
       '- [ ] task line',
       '- [x] done task',
       '  - [ ] nested task',
-      'another plain line',
+      'another plain line'
     ].join('\n')
 
     const decos = collectLineDecorations(doc)
@@ -133,6 +218,46 @@ describe('hangingIndentExtension decorations', () => {
   test('document with no list lines emits no decorations', () => {
     const decos = collectLineDecorations('just\nsome\nprose\n')
     expect(decos.size).toBe(0)
+  })
+
+  test('bullet + 2-space continuation: continuation matches the bullet width', () => {
+    const decos = collectLineDecorations(['- bullet', '  cont'].join('\n'))
+    expect(decos.get(1)).toBe('padding-left:2ch;text-indent:-2ch;')
+    expect(decos.get(2)).toBe('padding-left:2ch;text-indent:-2ch;')
+  })
+
+  test('task + 6-space continuation: continuation matches the task width (6)', () => {
+    const decos = collectLineDecorations(
+      ['- [ ] Check IIA references', '      this is a note'].join('\n')
+    )
+    expect(decos.get(1)).toBe('padding-left:6ch;text-indent:-6ch;')
+    expect(decos.get(2)).toBe('padding-left:6ch;text-indent:-6ch;')
+  })
+
+  test('two consecutive continuation lines both get the parent decoration', () => {
+    const decos = collectLineDecorations(
+      ['- [ ] body', '      cont 1', '      cont 2'].join('\n')
+    )
+    expect(decos.get(2)).toBe('padding-left:6ch;text-indent:-6ch;')
+    expect(decos.get(3)).toBe('padding-left:6ch;text-indent:-6ch;')
+  })
+
+  test('blank line between parent and would-be continuation: continuation gets NO decoration', () => {
+    const decos = collectLineDecorations(
+      ['- bullet', '', '  not a continuation'].join('\n')
+    )
+    expect(decos.get(1)).toBe('padding-left:2ch;text-indent:-2ch;')
+    expect(decos.has(2)).toBe(false)
+    expect(decos.has(3)).toBe(false)
+  })
+
+  test('nested list continuation aligns to the immediate parent (inner bullet, width 4)', () => {
+    const decos = collectLineDecorations(
+      ['- outer', '  - inner', '    inner cont'].join('\n')
+    )
+    expect(decos.get(1)).toBe('padding-left:2ch;text-indent:-2ch;')
+    expect(decos.get(2)).toBe('padding-left:4ch;text-indent:-4ch;')
+    expect(decos.get(3)).toBe('padding-left:4ch;text-indent:-4ch;')
   })
 })
 

--- a/src/components/editor/hangingIndentPlugin.ts
+++ b/src/components/editor/hangingIndentPlugin.ts
@@ -19,6 +19,21 @@
 // affected by `text-indent` and therefore appear indented by `N`. Net result:
 // hanging indent, identical source.
 //
+// CONTINUATION LINES (PR #166 / Shift+Enter)
+// `continueListItemParagraph` inserts a soft newline + N raw spaces so the
+// next line attaches to the same list item as a CommonMark "list paragraph".
+// That continuation line has NO marker — it's just whitespace + body — so the
+// list-marker pass above ignores it. Without help, the raw N spaces in the
+// source render at N monospace ch, but the parent's body (which lives behind
+// `padding-left:Nch; text-indent:-Nch;`) is positioned at exactly Nch from
+// the left padding edge. With proportional/bold rendering of the marker (e.g.
+// the "[ ]" checkbox glyph) those two anchors can drift by a fraction of a
+// character, leaving the continuation visually 1 char to the right of the
+// parent's body start. To fix that we apply the SAME hanging-indent CSS to
+// every continuation line, with width = the parent list item's marker width.
+// The `text-indent:-Nch` swallows the N leading spaces in the source and the
+// `padding-left:Nch` plants the body exactly where the parent's body sits.
+//
 // Performance: a StateField over the WHOLE document would re-scan every doc.
 // Instead we run as a ViewPlugin that only iterates the VISIBLE viewport
 // lines on each update, mirroring the strategy CM6 recommends for syntax-
@@ -31,9 +46,9 @@ import {
   ViewPlugin,
   type DecorationSet,
   type PluginValue,
-  type ViewUpdate,
+  type ViewUpdate
 } from '@codemirror/view'
-import { RangeSetBuilder, type Extension } from '@codemirror/state'
+import { RangeSetBuilder, type Extension, type Text } from '@codemirror/state'
 import { splitListLine } from '@/utils/listTransforms'
 
 // Compute the marker prefix length (in characters) for a given line of text.
@@ -54,31 +69,91 @@ export function listLinePrefixWidth(line: string): number {
   return p.kind === 'task' ? base + 4 : base
 }
 
+// If `lineNumber` (1-based) is a continuation line of an earlier list item,
+// return the parent list item's marker width. Otherwise return 0.
+//
+// A line is a continuation when:
+//   1. It parses as `kind: 'plain'` (no list marker of its own).
+//   2. It starts with at least one whitespace character (CommonMark requires
+//      the paragraph continuation to be indented to attach to the item).
+//   3. Walking up via consecutive non-blank lines reaches a list-marker line
+//      AND the current line's leading-whitespace char count is >= that
+//      parent's marker width. Intermediate continuation lines (also plain,
+//      also whitespace-led) are transparently walked through, so two
+//      consecutive Shift+Enters share the same parent.
+//   4. The chain is BROKEN by any blank line (CommonMark: blank line can end
+//      a list item) or by a plain line with no leading whitespace.
+//
+// Exported for unit tests so callers can assert the chain logic without
+// instantiating an EditorView.
+export function continuationIndentWidth(doc: Text, lineNumber: number): number {
+  const line = doc.line(lineNumber)
+  const parts = splitListLine(line.text)
+  // (1) must itself be plain — list-marker lines are handled by the marker
+  // pass via `listLinePrefixWidth`.
+  if (parts.kind !== 'plain') return 0
+  // (2) the leading indent is the only place a continuation can attach. If
+  // the rest of the line is empty (line.text === indent), treat it the same
+  // as a blank line — it terminates the chain rather than extending it.
+  const leadCount = parts.indent.length
+  if (leadCount === 0) return 0
+  if (parts.body.length === 0) return 0
+
+  // (3) + (4) walk upward.
+  for (let n = lineNumber - 1; n >= 1; n--) {
+    const prev = doc.line(n)
+    if (prev.text.length === 0) return 0
+    const prevParts = splitListLine(prev.text)
+    if (prevParts.kind !== 'plain') {
+      // Hit a real list-marker line. This is the parent.
+      const parentWidth = listLinePrefixWidth(prev.text)
+      return leadCount >= parentWidth ? parentWidth : 0
+    }
+    // prev is plain. Is it itself a continuation candidate (whitespace +
+    // body)? If yes, walk further up. Otherwise it's an unrelated paragraph
+    // and the chain is broken.
+    if (prevParts.indent.length === 0) return 0
+    if (prevParts.body.length === 0) return 0
+  }
+  return 0
+}
+
 // Build a DecorationSet covering only the visible viewport. CodeMirror feeds
 // the visible ranges via `view.visibleRanges`; we walk lines inside each one
-// and emit at most one line decoration per list line.
+// and emit at most one line decoration per list / continuation line.
 function buildDecorations(view: EditorView): DecorationSet {
   const builder = new RangeSetBuilder<Decoration>()
   const { doc } = view.state
+
+  // The visible viewport can start partway through a list-item's continuation
+  // chain (the user scrolled past the parent marker). `continuationIndentWidth`
+  // walks upward in the document, not just within the viewport, so this still
+  // produces the correct parent width for off-screen parents.
+  const emit = (lineFrom: number, width: number): void => {
+    builder.add(
+      lineFrom,
+      lineFrom,
+      Decoration.line({
+        attributes: {
+          style: `padding-left:${width}ch;text-indent:-${width}ch;`
+        }
+      })
+    )
+  }
 
   for (const { from, to } of view.visibleRanges) {
     let pos = from
     while (pos <= to) {
       const line = doc.lineAt(pos)
-      const width = listLinePrefixWidth(line.text)
-      if (width > 0) {
+      const markerWidth = listLinePrefixWidth(line.text)
+      if (markerWidth > 0) {
         // `text-indent` only affects the FIRST visual line — that's exactly
         // the behaviour we want: cancel the padding for row 1 (so the marker
         // stays at the left margin), let rows 2+ keep the padding.
-        builder.add(
-          line.from,
-          line.from,
-          Decoration.line({
-            attributes: {
-              style: `padding-left:${width}ch;text-indent:-${width}ch;`,
-            },
-          }),
-        )
+        emit(line.from, markerWidth)
+      } else {
+        const contWidth = continuationIndentWidth(doc, line.number)
+        if (contWidth > 0) emit(line.from, contWidth)
       }
       if (line.to + 1 > to) break
       pos = line.to + 1
@@ -108,6 +183,6 @@ class HangingIndentPlugin implements PluginValue {
 export const hangingIndentExtension: Extension = ViewPlugin.fromClass(
   HangingIndentPlugin,
   {
-    decorations: v => v.decorations,
-  },
+    decorations: v => v.decorations
+  }
 )


### PR DESCRIPTION
## Summary

PR #160 added the hanging-indent ViewPlugin that emits `padding-left:Nch;text-indent:-Nch;` per list-marker line, so wrapped/long bullets stay visually under the body column. PR #166 added Shift+Enter "continue list paragraph" — insert N raw spaces so the next line attaches to the same list item as a CommonMark list paragraph.

The mismatch user-visible: inside `- [ ] Check IIA...`, pressing Shift+Enter and typing `this is a note` rendered with 6 raw spaces. The parent's body (positioned via `padding-left:6ch;text-indent:-6ch;`) sits at exactly 6ch from the line edge, but the bold checkbox glyph `[ ]` renders at slightly under 6 monospace ch in CodeMirror. The continuation's 6 raw spaces hit exactly 6ch, so it landed about one char to the right of the parent body (the "C" of "Check").

This PR extends the same plugin to detect continuation lines and apply the parent's marker-width decoration to them. `text-indent` swallows the source whitespace, `padding-left` plants the body at the same ch column as the parent body — both share the same anchor, so the gap disappears regardless of the bracket glyph's exact rendered width. Source markdown stays untouched (the N raw spaces still ship to disk so CommonMark/Obsidian parses the paragraph as part of the list item).

Detection rule: plain line + leading whitespace + body, whose first non-plain ancestor walking up (never across a blank line, never across a non-indented plain line) is a list-marker line whose marker width is `<=` the continuation's leading-space count. Nested lists pick up the IMMEDIATE list-marker line above, so `- outer / 2-space - inner / 4-space cont` aligns to the inner item (width 4), not the outer (width 2).

## What changed

- `src/components/editor/hangingIndentPlugin.ts`: new `continuationIndentWidth(doc, lineNumber)` helper; `buildDecorations` now falls through to it on lines that aren't themselves list-marker lines. Viewport-only iteration unchanged.
- `src/__tests__/hangingIndentPlugin.test.ts`: 11 new unit cases for `continuationIndentWidth` + 5 new integration cases covering the bullet/task/nested-list/blank-break/two-consecutive scenarios from the spec.

## CSS produced for the Jon screenshot case

`- [ ] Check IIA references` + `      this is a note` ->

```
line 1: padding-left:6ch;text-indent:-6ch;   (already there in PR #160)
line 2: padding-left:6ch;text-indent:-6ch;   (NEW in this PR)
```

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` zero errors
- [x] `npm test -- --ci` green (217 suites, 2786 tests)
- [ ] Manual smoke: open task, Shift+Enter, type continuation — body of continuation lines aligns with body of parent (the "C" of "Check")