### PR TITLE
feat(graph): local graph, color groups, filters, force tuning, tags-as-nodes (G1)

### DIFF
--- a/public/plugins/noteser-graph/README.md
+++ b/public/plugins/noteser-graph/README.md
@@ -23,14 +23,46 @@ Shown for the active note. Two sections plus an action button:
 
 ### Fullscreen view "Graph"
 
-Force-directed SVG of the whole vault.
+Force-directed SVG of the vault.
 
 - Nodes are notes; edges are wikilinks.
 - Click a node to "select" it. The header shows a `link` VNode pointing
   at that note (`{ kind: 'note', noteId }`); clicking the link goes
-  through the host's `wikilink://` intercept and opens the note.
+  through the host's `wikilink://` intercept and opens the note. Tag
+  nodes (see below) are not notes, so selecting one shows a plain label.
 - Header buttons: Recompute, Reset view, Zoom in / out, Pan in four
   directions.
+
+#### Graph richness controls (v0.2.0, "G1")
+
+A control panel above the canvas. Every choice persists via
+`setSetting` under the `g1.` namespace, so it survives a reload.
+
+- **View** - Global graph, or a Local graph: the neighbourhood of the
+  active note reached by BFS over the wikilink edges, at a depth of 1,
+  2, or 3 hops. The local graph re-derives when the active note
+  changes while the view is open.
+- **Color groups** - color every node by folder, by first tag, or by a
+  highlight query (notes whose title or body match the query turn
+  green). Folder and tag colors come from a fixed palette keyed by a
+  hash, so the same folder keeps the same color across reloads.
+- **Filters**
+  - A search box dims every node whose title or body does not match.
+  - "Hide orphans" drops degree-0 nodes before layout.
+  - "Show tags as nodes" adds one synthetic node per distinct tag with
+    an edge from each note to its tags. Off by default.
+- **Forces** - number inputs for center force, repel strength, link
+  force, link distance, and a node size multiplier, with a
+  "Reset forces" button. The four physics values feed the simulation;
+  the size multiplier scales the by-degree node radius. All values are
+  clamped to safe ranges so a stray entry cannot break the layout.
+
+Changing a color or filter setting repaints without re-running the
+simulation; changing the view mode, depth, force values, or a node
+toggle re-derives the graph and re-runs the layout.
+
+Setting keys: `g1.mode`, `g1.depth`, `g1.colorBy`, `g1.colorQuery`,
+`g1.search`, `g1.hideOrphans`, `g1.tagsAsNodes`, `g1.forces`.
 
 ## Install + dev workflow
 
@@ -152,7 +184,21 @@ Pure derivation logic lives in `main.js` as named exports:
 - `snapshotSha(notes)`
 - `runForceSimulation(nodes, edges, opts?)`
 
-Jest tests at `src/__tests__/noteserGraphPlugin.test.ts` import the
-plugin module directly and cover the unlinked-mention detector
-(code-block exclusion, wikilink exclusion, whole-word matching) plus
-graph derivation on a 5-note fixture.
+The G1 increment adds more pure helpers, all exported and unit-tested:
+
+- `extractTagsInline(body)`
+- `deriveTagGraph(base, notes)` / `tagNodeId(name)`
+- `bfsNeighbourhood(edges, rootId, depth)`
+- `subgraphForIds(graph, idSet)` / `localGraph(graph, rootId, depth)`
+- `dropOrphans(graph)` / `recomputeDegree(nodes, edges)`
+- `noteMatchesQuery(note, query)`
+- `computeNodeColors(nodes, notesById, opts)` / `colorForKey(key)`
+- `clampForces(forces)` / `DEFAULT_FORCES`
+
+Jest tests at `src/__tests__/noteserGraphPlugin.test.ts` and
+`src/__tests__/noteserGraphPluginG1.test.ts` import the plugin module
+directly. The first covers the unlinked-mention detector (code-block
+exclusion, wikilink exclusion, whole-word matching) plus graph
+derivation on a 5-note fixture; the second covers tag extraction, the
+tags-as-nodes synthesis, the local-graph BFS, orphan filtering, color
+assignment, and force clamping/tuning.

--- a/public/plugins/noteser-graph/main.js
+++ b/public/plugins/noteser-graph/main.js
@@ -1,34 +1,39 @@
-// noteser-graph v0.1.0
+// noteser-graph v0.2.0
 //
 // Closes issue #71. Built on Plugin API v1.2 (PRs A, B, C, F + the
 // VNode event delivery follow-up).
 //
 // Provides two surfaces:
 //
-//   1. A sidebar panel "Graph" for the ACTIVE note. Shows two
-//      sections:
-//        - Backlinks: notes whose body contains a wikilink that
-//          resolves to the active note's title (case-insensitive,
-//          aliases not handled here - the core BacklinksView still
-//          handles aliases until this plugin supersedes it).
-//        - Unlinked mentions: notes containing the active note's
-//          title as plain text, NOT inside an existing wikilink, NOT
-//          inside a fenced or inline code block. Whole-word match.
-//      A button at the bottom opens the global graph in a fullscreen
-//      view.
+//   1. A sidebar panel "Graph" for the ACTIVE note. Shows backlinks
+//      and unlinked mentions plus a button that opens the global
+//      graph in a fullscreen view.
 //
 //   2. A fullscreen view "Graph" containing a force-directed SVG of
-//      the entire vault. Nodes are notes, edges are wikilinks. Click
-//      a node to open the note (wikilink:// scheme; the host's
-//      wikilink-intercept handler dispatches openNote). A
-//      "Recompute" button at top-right re-runs the layout.
+//      the vault. v0.2.0 (the "G1: graph richness" increment) adds,
+//      all on the existing v1.2 VNode surface and with no platform
+//      change:
+//        - Local graph: a per-active-note neighbourhood at depth
+//          1 / 2 / 3 (BFS over the derived edge set).
+//        - Color groups: color every node by folder, by tag, or by a
+//          highlight query.
+//        - Filters: a search box that dims non-matching nodes, a
+//          "hide orphans" toggle, and a "tags as nodes" toggle.
+//        - Force tuning: center force, repel strength, link force,
+//          link distance, and a node size multiplier, each a number
+//          input with a reset-to-defaults button.
+//        - Node sizing by degree (size multiplier exposed above).
+//        - Tags as nodes (off by default, gated behind the filter
+//          toggle): one synthetic node per distinct tag with an edge
+//          from each note to its tags.
+//      Every user choice persists via setSetting under the "g1."
+//      namespace so it survives a reload.
 //
 // Permissions: vault.read.all, vault.events.
 //
 // Self-contained ES module. The worker dynamic-imports via Blob URL,
 // so the file cannot rely on sibling imports - every pure helper is
-// inline. A parallel `lib.mjs` mirrors the pure helpers so the Jest
-// suite can re-use the same logic without parsing this file.
+// inline and exported by name so the Jest suite can unit-test it.
 
 // ------------------------- Pure helpers (exported) -------------------------
 //
@@ -85,28 +90,49 @@ export function escapeRegExp(s) {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
+// Tag pattern mirrors src/utils/tags.ts: starts with `#`, follows a
+// non-tag char or line start, body of [A-Za-z0-9_/-] (so nested tags
+// like #work/q1 survive), not followed by another tag char. Code
+// blocks and inline code are masked out first so a `#tag` inside code
+// is not counted.
+const TAG_RE = /(^|[^\w#/-])(#[A-Za-z0-9_/-]+)(?![\w/-])/g
+
+/**
+ * Extract every distinct tag (leading `#` stripped) from a body,
+ * lowercased. Code blocks and inline code are masked first so tags
+ * inside code do not count. Reimplemented inline because the worker
+ * has no access to `@/utils/tags`.
+ */
+export function extractTagsInline(body) {
+  if (!body || body.indexOf('#') === -1) return []
+  const masked = maskCodeAndWikilinks(body)
+  const out = []
+  const seen = new Set()
+  TAG_RE.lastIndex = 0
+  let m
+  while ((m = TAG_RE.exec(masked)) !== null) {
+    const name = m[2].slice(1).toLowerCase()
+    if (name && !seen.has(name)) {
+      seen.add(name)
+      out.push(name)
+    }
+  }
+  return out
+}
+
 /**
  * Find unlinked mentions of `title` in `body`.
  *
- *  - title is matched case-insensitively, as a whole word
- *    (alphanumeric / underscore word boundaries on each side).
+ *  - title is matched case-insensitively, as a whole word.
  *  - existing `[[wikilinks]]`, fenced code blocks, and inline code
- *    are masked out before matching, so a mention inside one of
- *    those is not counted.
- *  - returns the count of unlinked occurrences. The panel only
- *    needs a count + a single-snippet preview, so we return both.
- *
- * Returns null when `title` is empty/whitespace; callers should
- * skip rather than count "nothing" as zero mentions.
+ *    are masked out before matching.
+ *  - returns { count, snippet }, or null when `title` is empty.
  */
 export function findUnlinkedMentions(body, title) {
   const t = (title ?? '').trim()
   if (!t) return null
   const masked = maskCodeAndWikilinks(body ?? '')
   if (!masked) return { count: 0, snippet: null }
-  // \b only counts ascii word chars; for titles with spaces or
-  // punctuation we still want a whole-word match. Lookarounds on
-  // both sides accept either a non-word char or string boundary.
   const re = new RegExp(`(^|[^A-Za-z0-9_])(${escapeRegExp(t)})(?=$|[^A-Za-z0-9_])`, 'gi')
   let count = 0
   let snippet = null
@@ -131,13 +157,11 @@ export function findUnlinkedMentions(body, title) {
  *
  * Input:  notes - array of { id, title, body } (extra fields ok).
  * Output: { nodes, edges }
- *           nodes: [{ id, title, degree }]   (degree = in + out)
- *           edges: [{ source, target }]      (unique ordered pair)
+ *           nodes: [{ id, title, degree, kind: 'note' }]
+ *           edges: [{ source, target }]
  *
- *  - Edges are de-duplicated: two wikilinks from A -> B produce one
- *    edge. Self-links are dropped.
- *  - Unresolved targets (wikilinks whose query matches no note
- *    title) are dropped silently.
+ *  - Edges are de-duplicated; self-links dropped.
+ *  - Unresolved targets dropped silently.
  *  - Case-insensitive title resolution; duplicate titles map to the
  *    first note that owns them (stable by input order).
  */
@@ -169,19 +193,238 @@ export function deriveGraph(notes) {
     id: n.id,
     title: (n.title ?? '').trim() || '(untitled)',
     degree: degree.get(n.id) ?? 0,
+    kind: 'note',
   }))
   return { nodes, edges }
 }
 
+// Prefix that namespaces a synthetic tag node id away from real note
+// ids (which are UUIDs and never contain this sequence).
+export const TAG_NODE_PREFIX = 'graph-tag::'
+
+/** Build the id used for a tag node from a lowercased tag name. */
+export function tagNodeId(name) {
+  return TAG_NODE_PREFIX + name
+}
+
+/**
+ * Recompute the in+out degree for every node from an edge list and
+ * return a fresh node array with the updated `degree`. Pure: inputs
+ * are not mutated.
+ */
+export function recomputeDegree(nodes, edges) {
+  const degree = new Map()
+  for (const e of edges) {
+    degree.set(e.source, (degree.get(e.source) ?? 0) + 1)
+    degree.set(e.target, (degree.get(e.target) ?? 0) + 1)
+  }
+  return nodes.map((n) => ({ ...n, degree: degree.get(n.id) ?? 0 }))
+}
+
+/**
+ * Add one synthetic node per distinct tag and an edge from each note
+ * to every tag it carries, on top of an already-derived base graph.
+ *
+ *   base  - { nodes, edges } from deriveGraph
+ *   notes - the same vault snapshot (need bodies for tag extraction)
+ *
+ * Returns a new { nodes, edges } with tag nodes (`kind: 'tag'`)
+ * appended and every degree recomputed. Does not mutate `base`.
+ */
+export function deriveTagGraph(base, notes) {
+  const nodes = base.nodes.map((n) => ({ ...n }))
+  const edges = base.edges.map((e) => ({ ...e }))
+  const tagNodes = new Map() // tagNodeId -> node
+  const edgeKeys = new Set(edges.map((e) => e.source + ' ' + e.target))
+  for (const n of notes) {
+    const tags = extractTagsInline(n.body ?? '')
+    for (const name of tags) {
+      const id = tagNodeId(name)
+      if (!tagNodes.has(id)) {
+        tagNodes.set(id, { id, title: '#' + name, degree: 0, kind: 'tag' })
+      }
+      const key = n.id + ' ' + id
+      if (edgeKeys.has(key)) continue
+      edgeKeys.add(key)
+      edges.push({ source: n.id, target: id })
+    }
+  }
+  for (const node of tagNodes.values()) nodes.push(node)
+  return { nodes: recomputeDegree(nodes, edges), edges }
+}
+
+/**
+ * Breadth-first neighbourhood of `rootId` over an UNDIRECTED reading
+ * of the edge list, out to `depth` hops (inclusive of the root).
+ * Returns a Set of node ids. O(nodes + edges) - cheap for a
+ * 500-note vault even at depth 3.
+ */
+export function bfsNeighbourhood(edges, rootId, depth) {
+  const reached = new Set()
+  if (!rootId) return reached
+  reached.add(rootId)
+  if (depth <= 0) return reached
+  // Build an undirected adjacency list once.
+  const adj = new Map()
+  const push = (a, b) => {
+    let list = adj.get(a)
+    if (!list) {
+      list = []
+      adj.set(a, list)
+    }
+    list.push(b)
+  }
+  for (const e of edges) {
+    push(e.source, e.target)
+    push(e.target, e.source)
+  }
+  let frontier = [rootId]
+  for (let d = 0; d < depth && frontier.length; d++) {
+    const next = []
+    for (const id of frontier) {
+      const neighbours = adj.get(id)
+      if (!neighbours) continue
+      for (const nb of neighbours) {
+        if (reached.has(nb)) continue
+        reached.add(nb)
+        next.push(nb)
+      }
+    }
+    frontier = next
+  }
+  return reached
+}
+
+/**
+ * Restrict a graph to the nodes in `idSet`, dropping any edge with an
+ * endpoint outside the set, then recompute degree. Pure.
+ */
+export function subgraphForIds(graph, idSet) {
+  const nodes = graph.nodes.filter((n) => idSet.has(n.id))
+  const edges = graph.edges.filter(
+    (e) => idSet.has(e.source) && idSet.has(e.target),
+  )
+  return { nodes: recomputeDegree(nodes, edges), edges }
+}
+
+/**
+ * Local graph: the neighbourhood of `rootId` out to `depth` hops.
+ * When `rootId` is missing from the graph the result is just that
+ * single root node (if present) with no edges.
+ */
+export function localGraph(graph, rootId, depth) {
+  const idSet = bfsNeighbourhood(graph.edges, rootId, depth)
+  return subgraphForIds(graph, idSet)
+}
+
+/**
+ * Drop every degree-0 node (orphan) before layout. Degree is
+ * recomputed from the current edge list first so callers do not have
+ * to keep it in sync. Edges are unchanged (orphans own none). Pure.
+ */
+export function dropOrphans(graph) {
+  const withDegree = recomputeDegree(graph.nodes, graph.edges)
+  const nodes = withDegree.filter((n) => n.degree > 0)
+  return { nodes, edges: graph.edges }
+}
+
+/** Case-insensitive substring match across a note's title + body. */
+export function noteMatchesQuery(note, query) {
+  const q = (query ?? '').trim().toLowerCase()
+  if (!q) return false
+  const hay = ((note?.title ?? '') + ' ' + (note?.body ?? '')).toLowerCase()
+  return hay.includes(q)
+}
+
+// Color palette + group colors. Hex strings only so the host's
+// safeColor validator accepts them.
+const COLOR_PALETTE = [
+  '#8b5cf6',
+  '#ef4444',
+  '#f59e0b',
+  '#10b981',
+  '#3b82f6',
+  '#ec4899',
+  '#14b8a6',
+  '#f97316',
+  '#a855f7',
+  '#84cc16',
+  '#06b6d4',
+  '#eab308',
+]
+export const DEFAULT_NODE_COLOR = '#8b5cf6'
+export const TAG_NODE_COLOR = '#f59e0b'
+export const QUERY_HIT_COLOR = '#10b981'
+export const DIM_COLOR = '#3a4256'
+
+/** Deterministic palette pick for a grouping key (folder path, tag). */
+export function colorForKey(key) {
+  const s = String(key ?? '')
+  let h = 0x811c9dc5
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return COLOR_PALETTE[h % COLOR_PALETTE.length]
+}
+
+/**
+ * Compute a fill color per node.
+ *
+ *   nodes     - [{ id, title, kind }]
+ *   notesById - Map(id -> { title, body, folderPath })
+ *   opts      - { colorBy, colorQuery, search }
+ *
+ *  - When `search` is non-empty, any node whose title/body does not
+ *    match is dimmed to DIM_COLOR (this is the filter dim; matching
+ *    nodes still take their group color).
+ *  - Tag nodes always take TAG_NODE_COLOR (unless dimmed by search).
+ *  - colorBy 'folder' | 'tag' | 'query' assign group colors; 'none'
+ *    leaves the default node color.
+ *
+ * Returns a Map(id -> color hex). Pure relative to its inputs.
+ */
+export function computeNodeColors(nodes, notesById, opts) {
+  const colorBy = opts?.colorBy ?? 'none'
+  const colorQuery = (opts?.colorQuery ?? '').trim()
+  const search = (opts?.search ?? '').trim().toLowerCase()
+  const map = new Map()
+  for (const n of nodes) {
+    const isTag = n.kind === 'tag'
+    const note = isTag ? null : notesById.get(n.id)
+    if (search) {
+      const hay = isTag
+        ? (n.title ?? '').toLowerCase()
+        : ((note?.title ?? n.title ?? '') + ' ' + (note?.body ?? '')).toLowerCase()
+      if (!hay.includes(search)) {
+        map.set(n.id, DIM_COLOR)
+        continue
+      }
+    }
+    if (isTag) {
+      map.set(n.id, TAG_NODE_COLOR)
+      continue
+    }
+    let color = DEFAULT_NODE_COLOR
+    if (colorBy === 'folder') {
+      const f = (note?.folderPath ?? '').trim()
+      color = f ? colorForKey('folder:' + f) : DEFAULT_NODE_COLOR
+    } else if (colorBy === 'tag') {
+      const tags = note ? extractTagsInline(note.body ?? '') : []
+      color = tags.length ? colorForKey('tag:' + tags[0]) : DEFAULT_NODE_COLOR
+    } else if (colorBy === 'query') {
+      color = colorQuery && note && noteMatchesQuery(note, colorQuery)
+        ? QUERY_HIT_COLOR
+        : DEFAULT_NODE_COLOR
+    }
+    map.set(n.id, color)
+  }
+  return map
+}
+
 /**
  * Find every linker to a given note. Used for the sidebar
- * "Backlinks" section.
- *
- *   notes      - full vault array
- *   targetId   - note we want incoming links for
- *   targetTitle- resolved title (case-insensitive match)
- *
- * Returns [{ id, title }, ...] - one entry per distinct linker.
+ * "Backlinks" section. Returns [{ id, title }, ...].
  */
 export function findBacklinks(notes, targetId, targetTitle) {
   const t = (targetTitle ?? '').trim().toLowerCase()
@@ -227,9 +470,8 @@ export function findUnlinkedMentionsAcross(notes, targetId, targetTitle) {
 }
 
 /**
- * FNV-1a 32-bit rolling hash over (id, updatedAt) pairs. Used as a
- * cheap snapshot identity for the getAllNotes cache. Not
- * cryptographic - just an identity key.
+ * FNV-1a 32-bit rolling hash over (id, updatedAt) pairs. Cheap
+ * snapshot identity for the getAllNotes cache. Not cryptographic.
  */
 export function snapshotSha(notes) {
   let h = 0x811c9dc5
@@ -246,25 +488,43 @@ export function snapshotSha(notes) {
 // --------------------------- Force layout ------------------------------
 //
 // Hand-rolled O(n^2) force simulator. Good enough for 1k nodes in
-// well under the 500ms budget the brief calls out. No Barnes-Hut,
-// no quadtree - just paired repulsion + spring attraction + center
-// pull, with a step decay.
+// well under the 500ms budget. No Barnes-Hut, no quadtree - just
+// paired repulsion + spring attraction + center pull, with a step
+// decay. The four force constants are tunable per call via
+// `opts.forces`; defaults reproduce the original v0.1.0 layout.
 
 const LAYOUT_WIDTH = 1024
 const LAYOUT_HEIGHT = 768
-const LAYOUT_REPULSION = 600 // node-node repulsion strength
-const LAYOUT_SPRING_K = 0.04 // edge spring constant
-const LAYOUT_SPRING_REST = 60 // edge target length
-const LAYOUT_CENTER_K = 0.005 // pull toward (cx, cy)
 const LAYOUT_DAMPING = 0.85
 const LAYOUT_MAX_SPEED = 18
 
+/** Default force constants. These are the v0.1.0 hard-coded values. */
+export const DEFAULT_FORCES = {
+  center: 0.005, // pull toward (cx, cy)
+  repel: 600, // node-node repulsion strength
+  linkForce: 0.04, // edge spring constant
+  linkDistance: 60, // edge target length
+  sizeMultiplier: 1, // node radius scale (render-only)
+}
+
+/** Clamp user-entered force values to sane ranges so a stray 0 / NaN
+ *  / huge number cannot blow up the simulation or the SVG. */
+export function clampForces(forces) {
+  const f = { ...DEFAULT_FORCES, ...(forces || {}) }
+  const num = (v, def) => (Number.isFinite(v) ? v : def)
+  const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v))
+  return {
+    center: clamp(num(f.center, DEFAULT_FORCES.center), 0, 0.2),
+    repel: clamp(num(f.repel, DEFAULT_FORCES.repel), 0, 5000),
+    linkForce: clamp(num(f.linkForce, DEFAULT_FORCES.linkForce), 0, 1),
+    linkDistance: clamp(num(f.linkDistance, DEFAULT_FORCES.linkDistance), 1, 500),
+    sizeMultiplier: clamp(num(f.sizeMultiplier, DEFAULT_FORCES.sizeMultiplier), 0.25, 5),
+  }
+}
+
 /**
  * Scale iterations down for large graphs so the open-graph budget
- * (<500 ms for 1 k nodes per the brief) stays in reach. Smaller
- * graphs still get the high iteration count they need for a clean
- * layout; larger graphs settle in fewer iterations because the
- * repulsion field is denser anyway.
+ * (<500 ms for 1 k nodes) stays in reach.
  */
 function defaultIterations(n) {
   if (n <= 100) return 220
@@ -278,16 +538,18 @@ export function runForceSimulation(nodes, edges, opts) {
   const width = opts?.width ?? LAYOUT_WIDTH
   const height = opts?.height ?? LAYOUT_HEIGHT
   const iterations = opts?.iterations ?? defaultIterations(nodes.length)
+  const forces = clampForces(opts?.forces)
+  const repulsion = forces.repel
+  const springK = forces.linkForce
+  const springRest = forces.linkDistance
+  const centerK = forces.center
   const cx = width / 2
   const cy = height / 2
 
-  // Mulberry32: deterministic seeded PRNG so the layout is
-  // reproducible per call. Seeded by the node id list so the same
-  // vault returns the same layout each time.
+  // Mulberry32 seeded PRNG so the layout is reproducible per call.
   const seed = makeSeed(nodes)
   const rand = mulberry32(seed)
 
-  // Seed positions on a circle around the center, jittered.
   const N = nodes.length
   const radius = Math.min(width, height) * 0.4
   const sim = nodes.map((n, i) => {
@@ -303,7 +565,7 @@ export function runForceSimulation(nodes, edges, opts) {
   const indexById = new Map(sim.map((s, i) => [s.id, i]))
 
   for (let step = 0; step < iterations; step++) {
-    // Pair repulsion (O(n^2)). Acceptable up to ~1k nodes.
+    // Pair repulsion (O(n^2)).
     for (let i = 0; i < N; i++) {
       for (let j = i + 1; j < N; j++) {
         const a = sim[i]
@@ -312,14 +574,12 @@ export function runForceSimulation(nodes, edges, opts) {
         let dy = a.y - b.y
         let d2 = dx * dx + dy * dy
         if (d2 < 0.01) {
-          // Coincident nodes: nudge apart by a tiny random vector
-          // so the next iteration can separate them cleanly.
           dx = (rand() - 0.5) * 0.5
           dy = (rand() - 0.5) * 0.5
           d2 = dx * dx + dy * dy + 0.01
         }
         const d = Math.sqrt(d2)
-        const f = LAYOUT_REPULSION / d2
+        const f = repulsion / d2
         const fx = (dx / d) * f
         const fy = (dy / d) * f
         a.vx += fx
@@ -339,9 +599,9 @@ export function runForceSimulation(nodes, edges, opts) {
       const dx = b.x - a.x
       const dy = b.y - a.y
       const d = Math.sqrt(dx * dx + dy * dy) || 0.01
-      const delta = d - LAYOUT_SPRING_REST
-      const fx = (dx / d) * delta * LAYOUT_SPRING_K
-      const fy = (dy / d) * delta * LAYOUT_SPRING_K
+      const delta = d - springRest
+      const fx = (dx / d) * delta * springK
+      const fy = (dy / d) * delta * springK
       a.vx += fx
       a.vy += fy
       b.vx -= fx
@@ -351,12 +611,10 @@ export function runForceSimulation(nodes, edges, opts) {
     // Center pull + damping + integration.
     for (let i = 0; i < N; i++) {
       const p = sim[i]
-      p.vx += (cx - p.x) * LAYOUT_CENTER_K
-      p.vy += (cy - p.y) * LAYOUT_CENTER_K
+      p.vx += (cx - p.x) * centerK
+      p.vy += (cy - p.y) * centerK
       p.vx *= LAYOUT_DAMPING
       p.vy *= LAYOUT_DAMPING
-      // Cap speed so a high-degree node cannot fling itself off
-      // the canvas in one step.
       const sp = Math.sqrt(p.vx * p.vx + p.vy * p.vy)
       if (sp > LAYOUT_MAX_SPEED) {
         p.vx = (p.vx / sp) * LAYOUT_MAX_SPEED
@@ -406,40 +664,83 @@ function makeSeed(nodes) {
 const PANEL_ID = 'graph'
 const VIEW_ID = 'graph'
 
+// Setting keys, namespaced under "g1." so a future increment can pick
+// its own namespace without clashing.
+const SETTING_KEYS = {
+  mode: 'g1.mode',
+  depth: 'g1.depth',
+  colorBy: 'g1.colorBy',
+  colorQuery: 'g1.colorQuery',
+  search: 'g1.search',
+  hideOrphans: 'g1.hideOrphans',
+  tagsAsNodes: 'g1.tagsAsNodes',
+  forces: 'g1.forces',
+}
+
 // State the runtime keeps across handler firings.
 const state = {
   ctx: null,
-  // Cached snapshot: notes + sha. Re-derived lazily on save.
   notes: null,
   sha: null,
-  // Active note id from the most recent onActiveNoteChange or
-  // onPanelMount call.
   activeNoteId: null,
-  // Active note title looked up from the cached snapshot. We re-read
-  // on every panel render so a title rename surfaces immediately.
-  // Layout state for the fullscreen view.
-  layout: null, // { nodes: [{id,title,degree}], edges, positions: [{id,x,y}] }
+  layout: null, // { nodes, edges, positions, notesById }
   fullscreenMounted: false,
-  // Pan/zoom for the fullscreen viewport. v1.2 has no wheel or drag
-  // VNode events (the curated event set is onClick / onChange /
-  // onSubmit / onKeyDown only), so the fullscreen view ships zoom
-  // and pan via buttons in the header instead. See the plugin's
-  // README for the design notes + the v1.2 API gap call-out.
   viewport: { x: 0, y: 0, scale: 1 },
-  // The id of the node the user most recently clicked in the SVG.
-  // We render a clickable `link` VNode for that id in the header so
-  // the host's wikilink:// intercept opens the note on a single
-  // confirmation click. Two-click flow because the SVG circle's
-  // `onClick` produces a VNode event, not a navigation, and v1.2
-  // exposes no `ctx.openNote(id)` API.
   pickedNodeId: null,
+
+  // G1 graph-richness controls. Loaded from settings on activate.
+  mode: 'global', // 'global' | 'local'
+  depth: 1, // 1 | 2 | 3
+  colorBy: 'none', // 'none' | 'folder' | 'tag' | 'query'
+  colorQuery: '',
+  search: '',
+  hideOrphans: false,
+  tagsAsNodes: false,
+  forces: { ...DEFAULT_FORCES },
 }
 
-/** Lazily load + cache the vault snapshot. Re-uses the previous
- *  cached list when the snapshot SHA matches. */
+/** Read persisted G1 settings into `state`. getSetting is synchronous
+ *  (the host pre-populates the settings map before onActivate). */
+function loadSettings(ctx) {
+  try {
+    const mode = ctx.getSetting(SETTING_KEYS.mode)
+    if (mode === 'global' || mode === 'local') state.mode = mode
+
+    const depth = Number(ctx.getSetting(SETTING_KEYS.depth))
+    if (depth === 1 || depth === 2 || depth === 3) state.depth = depth
+
+    const colorBy = ctx.getSetting(SETTING_KEYS.colorBy)
+    if (['none', 'folder', 'tag', 'query'].includes(colorBy)) state.colorBy = colorBy
+
+    const colorQuery = ctx.getSetting(SETTING_KEYS.colorQuery)
+    if (typeof colorQuery === 'string') state.colorQuery = colorQuery
+
+    const search = ctx.getSetting(SETTING_KEYS.search)
+    if (typeof search === 'string') state.search = search
+
+    state.hideOrphans = ctx.getSetting(SETTING_KEYS.hideOrphans) === true
+    state.tagsAsNodes = ctx.getSetting(SETTING_KEYS.tagsAsNodes) === true
+
+    const forces = ctx.getSetting(SETTING_KEYS.forces)
+    if (forces && typeof forces === 'object') {
+      state.forces = clampForces(forces)
+    }
+  } catch {
+    // Settings unavailable - keep defaults.
+  }
+}
+
+function persist(ctx, key, value) {
+  try {
+    ctx.setSetting(key, value)
+  } catch {
+    // Persisting is best-effort; an unavailable store must not break
+    // the interaction.
+  }
+}
+
+/** Lazily load + cache the vault snapshot. */
 async function loadNotesSnapshot(ctx) {
-  // ctx.vault.read.getAllNotes() rejects when the vault exceeds 4 MiB;
-  // fall back to stream() in that case so a large vault still works.
   let notes
   try {
     notes = await ctx.vault.read.getAllNotes()
@@ -459,7 +760,6 @@ async function loadNotesSnapshot(ctx) {
   if (state.sha === sha && state.notes) return state.notes
   state.sha = sha
   state.notes = notes
-  // The cached graph layout is now stale.
   state.layout = null
   return notes
 }
@@ -470,9 +770,6 @@ function nowMs() {
     : Date.now()
 }
 
-/** Pull the active note id from the most recent event. Falls back
- *  to ctx.activeNote (set when the panel mounts during a hot
- *  reload). */
 function resolveActiveNoteId(ctx) {
   return state.activeNoteId ?? ctx.activeNote?.id ?? null
 }
@@ -535,8 +832,6 @@ async function renderPanel(ctx) {
   const mentions = findUnlinkedMentionsAcross(notes, activeId, activeTitle)
   const t1 = nowMs()
 
-  // Perf log: brief calls for verification that the derivation
-  // completes in under 50 ms on a switch.
   // eslint-disable-next-line no-console
   console.log(
     `[noteser-graph] panel derive: ${(t1 - t0).toFixed(1)} ms, ` +
@@ -561,9 +856,7 @@ async function renderPanel(ctx) {
             label: `${m.title} (${m.count})`,
             href: { kind: 'note', noteId: m.id },
           },
-          ...(m.snippet
-            ? [{ tag: 'text', value: m.snippet }]
-            : []),
+          ...(m.snippet ? [{ tag: 'text', value: m.snippet }] : []),
         ],
       }))
     : [{ tag: 'text', value: 'No unlinked mentions.' }]
@@ -587,6 +880,109 @@ async function renderPanel(ctx) {
   })
 }
 
+/** Build the control panel shown above the SVG in the fullscreen view. */
+function buildControls() {
+  const children = []
+
+  // View: global vs local neighbourhood of the active note.
+  children.push({ tag: 'text', value: 'View' })
+  children.push({
+    tag: 'radio',
+    group: 'graph-mode',
+    value: state.mode,
+    options: [
+      { value: 'global', label: 'Global graph' },
+      { value: 'local', label: 'Local graph (active note)' },
+    ],
+    onChange: { kind: 'emit', event: 'graph.setMode' },
+  })
+  if (state.mode === 'local') {
+    children.push({ tag: 'text', value: 'Depth' })
+    children.push({
+      tag: 'radio',
+      group: 'graph-depth',
+      value: String(state.depth),
+      options: [
+        { value: '1', label: '1 hop' },
+        { value: '2', label: '2 hops' },
+        { value: '3', label: '3 hops' },
+      ],
+      onChange: { kind: 'emit', event: 'graph.setDepth' },
+    })
+  }
+
+  // Color groups.
+  children.push({ tag: 'text', value: 'Color groups' })
+  children.push({
+    tag: 'radio',
+    group: 'graph-colorby',
+    value: state.colorBy,
+    options: [
+      { value: 'none', label: 'None' },
+      { value: 'folder', label: 'By folder' },
+      { value: 'tag', label: 'By tag' },
+      { value: 'query', label: 'By query' },
+    ],
+    onChange: { kind: 'emit', event: 'graph.setColorBy' },
+  })
+  if (state.colorBy === 'query') {
+    children.push({
+      tag: 'input',
+      type: 'search',
+      value: state.colorQuery,
+      placeholder: 'Highlight notes matching...',
+      onChange: { kind: 'emit', event: 'graph.setColorQuery' },
+    })
+  }
+
+  // Filters.
+  children.push({ tag: 'text', value: 'Filters' })
+  children.push({
+    tag: 'input',
+    type: 'search',
+    value: state.search,
+    placeholder: 'Dim notes that do not match...',
+    onChange: { kind: 'emit', event: 'graph.setSearch' },
+  })
+  children.push({
+    tag: 'button',
+    label: state.hideOrphans ? 'Show orphans' : 'Hide orphans',
+    variant: state.hideOrphans ? 'primary' : 'default',
+    onClick: { kind: 'emit', event: 'graph.toggleOrphans' },
+  })
+  children.push({
+    tag: 'button',
+    label: state.tagsAsNodes ? 'Hide tag nodes' : 'Show tags as nodes',
+    variant: state.tagsAsNodes ? 'primary' : 'default',
+    onClick: { kind: 'emit', event: 'graph.toggleTags' },
+  })
+
+  // Force tuning.
+  children.push({ tag: 'text', value: 'Forces' })
+  const forceRow = (label, key) => [
+    { tag: 'text', value: label },
+    {
+      tag: 'input',
+      type: 'number',
+      value: state.forces[key],
+      onChange: { kind: 'emit', event: 'graph.setForce', payload: { key } },
+    },
+  ]
+  children.push(...forceRow('Center force', 'center'))
+  children.push(...forceRow('Repel strength', 'repel'))
+  children.push(...forceRow('Link force', 'linkForce'))
+  children.push(...forceRow('Link distance', 'linkDistance'))
+  children.push(...forceRow('Node size', 'sizeMultiplier'))
+  children.push({
+    tag: 'button',
+    label: 'Reset forces',
+    variant: 'ghost',
+    onClick: { kind: 'emit', event: 'graph.resetForces' },
+  })
+
+  return { tag: 'box', gap: 2, children }
+}
+
 /** Build the fullscreen SVG VNode from the cached layout. */
 function renderFullscreen(ctx) {
   if (!state.layout) {
@@ -604,12 +1000,15 @@ function renderFullscreen(ctx) {
     })
     return
   }
-  const { nodes, edges, positions } = state.layout
+  const { nodes, edges, positions, notesById } = state.layout
   const posById = new Map(positions.map((p) => [p.id, p]))
+  const colors = computeNodeColors(nodes, notesById, {
+    colorBy: state.colorBy,
+    colorQuery: state.colorQuery,
+    search: state.search,
+  })
+  const sizeMult = clampForces(state.forces).sizeMultiplier
 
-  // Apply viewport transform via viewBox. Larger scale = zoomed
-  // out; scale < 1 = zoomed in. We bias the viewBox by viewport.x/y
-  // for pan.
   const vw = Math.max(64, Math.round(LAYOUT_WIDTH * state.viewport.scale))
   const vh = Math.max(64, Math.round(LAYOUT_HEIGHT * state.viewport.scale))
   const vx = Math.round(state.viewport.x)
@@ -634,22 +1033,24 @@ function renderFullscreen(ctx) {
   for (const n of nodes) {
     const p = posById.get(n.id)
     if (!p) continue
-    const r = 4 + Math.min(8, n.degree)
+    const r = Math.max(1, (4 + Math.min(8, n.degree)) * sizeMult)
     circleNodes.push({
       tag: 'circle',
       cx: p.x,
       cy: p.y,
       r,
-      fill: '#8b5cf6',
+      fill: colors.get(n.id) ?? DEFAULT_NODE_COLOR,
       stroke: '#0f172a',
       onClick: { kind: 'emit', event: 'graph.pickNode', payload: { id: n.id } },
     })
   }
 
+  const localSuffix =
+    state.mode === 'local' ? ` (local, depth ${state.depth})` : ''
   const headerChildren = [
     {
       tag: 'text',
-      value: `Note graph: ${nodes.length} notes, ${edges.length} links`,
+      value: `Note graph: ${nodes.length} nodes, ${edges.length} links${localSuffix}`,
     },
     {
       tag: 'button',
@@ -701,11 +1102,9 @@ function renderFullscreen(ctx) {
     },
   ]
 
-  // Persistent "Selected" row - when the user clicks a circle, this
-  // shows a `link` VNode whose href is `{ kind: 'note', noteId }`.
-  // Clicking the link goes through the host's wikilink:// intercept
-  // and opens the note. Two-click flow because v1.2 has no
-  // `ctx.openNote(id)` API and no link wrapper for SVG children.
+  // Persistent "Selected" row. Note nodes get a clickable link that
+  // opens the note through the wikilink:// intercept; tag nodes are
+  // not notes, so they show a plain label.
   const pickedRow = (() => {
     if (!state.pickedNodeId) {
       return { tag: 'text', value: 'Selected: (click a node)' }
@@ -713,6 +1112,12 @@ function renderFullscreen(ctx) {
     const picked = nodes.find((n) => n.id === state.pickedNodeId)
     if (!picked) {
       return { tag: 'text', value: 'Selected: (no longer in graph)' }
+    }
+    if (picked.kind === 'tag') {
+      return {
+        tag: 'text',
+        value: `Selected tag: ${picked.title} (${picked.degree} notes)`,
+      }
     }
     return {
       tag: 'box',
@@ -733,6 +1138,7 @@ function renderFullscreen(ctx) {
     gap: 3,
     children: [
       { tag: 'box', gap: 2, children: headerChildren },
+      buildControls(),
       pickedRow,
       {
         tag: 'svg',
@@ -756,30 +1162,61 @@ function renderFullscreen(ctx) {
   })
 }
 
+/**
+ * Build the graph model honouring every G1 setting, then run the
+ * force simulation. Sequence: derive base graph -> optionally add tag
+ * nodes -> optionally restrict to the local neighbourhood -> optionally
+ * drop orphans -> simulate.
+ */
 async function rebuildLayout(ctx) {
   const t0 = nowMs()
   const notes = await loadNotesSnapshot(ctx)
-  const { nodes, edges } = deriveGraph(notes)
+  const notesById = new Map(notes.map((n) => [n.id, n]))
+
+  let graph = deriveGraph(notes)
+  if (state.tagsAsNodes) {
+    graph = deriveTagGraph(graph, notes)
+  }
+  if (state.mode === 'local') {
+    const rootId = resolveActiveNoteId(ctx)
+    graph = localGraph(graph, rootId, state.depth)
+  }
+  if (state.hideOrphans) {
+    graph = dropOrphans(graph)
+  }
   const t1 = nowMs()
-  const positions = runForceSimulation(nodes, edges)
+  const positions = runForceSimulation(graph.nodes, graph.edges, {
+    forces: state.forces,
+  })
   const t2 = nowMs()
-  state.layout = { nodes, edges, positions }
-  state.viewport = { x: 0, y: 0, scale: 1 }
+  state.layout = {
+    nodes: graph.nodes,
+    edges: graph.edges,
+    positions,
+    notesById,
+  }
   // eslint-disable-next-line no-console
   console.log(
     `[noteser-graph] graph layout: derive=${(t1 - t0).toFixed(1)}ms ` +
       `simulate=${(t2 - t1).toFixed(1)}ms ` +
-      `nodes=${nodes.length} edges=${edges.length}`,
+      `nodes=${graph.nodes.length} edges=${graph.edges.length} ` +
+      `mode=${state.mode} tagsAsNodes=${state.tagsAsNodes} hideOrphans=${state.hideOrphans}`,
   )
+}
+
+/** Re-run the layout (node/edge set or positions changed) then paint. */
+async function rebuildAndRender(ctx) {
+  await rebuildLayout(ctx)
+  renderFullscreen(ctx)
 }
 
 export default {
   id: 'noteser-graph',
   name: 'Graph',
-  version: '0.1.0',
+  version: '0.2.0',
   author: 'Noteser',
   description:
-    'Backlinks and unlinked mentions for the active note in the sidebar, plus a force-directed graph of the entire vault in a fullscreen view. Closes issue #71.',
+    'Backlinks and unlinked mentions for the active note in the sidebar, plus a force-directed graph of the vault with local-graph, color groups, filters, force tuning, and tags-as-nodes. Closes issue #71.',
   permissions: ['vault.read.all', 'vault.events'],
   surfaces: {
     sidebarPanels: [{ id: PANEL_ID, title: 'Graph', icon: 'link' }],
@@ -792,104 +1229,149 @@ export default {
 
   onActivate(ctx) {
     state.ctx = ctx
+    loadSettings(ctx)
 
-    // Re-derive the panel + invalidate caches on every vault save.
-    // The host already debounces these at 250 ms, so a burst of
-    // keystrokes coalesces into one re-derive.
     ctx.vault.events.onNoteSaved(() => {
-      // Invalidate the cached snapshot so the next loadNotesSnapshot
-      // call refetches from the host.
       state.sha = null
       state.notes = null
       state.layout = null
-      // Re-render whichever surface is currently mounted.
       void renderPanel(ctx).catch(() => {})
       if (state.fullscreenMounted) {
-        void (async () => {
-          await rebuildLayout(ctx)
-          renderFullscreen(ctx)
-        })().catch(() => {})
+        void rebuildAndRender(ctx).catch(() => {})
       }
     })
 
-    // onActiveNoteChange also fires when the user opens a different
-    // note, even without a save. Update the panel.
     ctx.vault.events.onActiveNoteChange((noteId) => {
       state.activeNoteId = noteId
       void renderPanel(ctx).catch(() => {})
+      // A local graph is anchored on the active note, so follow it.
+      if (state.fullscreenMounted && state.mode === 'local') {
+        void rebuildAndRender(ctx).catch(() => {})
+      }
     })
 
-    // Wire VNode events: button clicks from the panel + fullscreen.
     ctx.onVNodeEvent(async ({ event, payload }) => {
       try {
-        if (event === 'graph.open') {
-          await ctx.openFullscreen(VIEW_ID)
-          return
-        }
-        if (event === 'graph.recompute') {
-          state.sha = null
-          state.notes = null
-          state.layout = null
-          await rebuildLayout(ctx)
-          renderFullscreen(ctx)
-          return
-        }
-        if (event === 'graph.resetView') {
-          state.viewport = { x: 0, y: 0, scale: 1 }
-          renderFullscreen(ctx)
-          return
-        }
-        if (event === 'graph.zoomIn') {
-          state.viewport.scale = Math.max(0.25, state.viewport.scale * 0.8)
-          renderFullscreen(ctx)
-          return
-        }
-        if (event === 'graph.zoomOut') {
-          state.viewport.scale = Math.min(4, state.viewport.scale * 1.25)
-          renderFullscreen(ctx)
-          return
-        }
-        if (event === 'graph.panLeft') {
-          state.viewport.x -= LAYOUT_WIDTH * state.viewport.scale * 0.15
-          renderFullscreen(ctx)
-          return
-        }
-        if (event === 'graph.panRight') {
-          state.viewport.x += LAYOUT_WIDTH * state.viewport.scale * 0.15
-          renderFullscreen(ctx)
-          return
-        }
-        if (event === 'graph.panUp') {
-          state.viewport.y -= LAYOUT_HEIGHT * state.viewport.scale * 0.15
-          renderFullscreen(ctx)
-          return
-        }
-        if (event === 'graph.panDown') {
-          state.viewport.y += LAYOUT_HEIGHT * state.viewport.scale * 0.15
-          renderFullscreen(ctx)
-          return
-        }
-        if (event === 'graph.pickNode' && payload && typeof payload === 'object') {
-          // Two-click open: the v1.2 VNode surface has no
-          // `ctx.openNote(id)` API and SVG children cannot be
-          // wrapped in a `link` VNode (the host's wikilink://
-          // intercept only fires on real `<a>` elements). So a
-          // click on a circle stores the picked id; the next
-          // render shows a `link` VNode pointing at that note in
-          // the header. The user clicks the link and the
-          // wikilink:// intercept dispatches openNote(noteId).
-          // The README documents this gap + the follow-up API
-          // addition that would close it.
-          const id = String(payload.id ?? '')
-          if (!id) return
-          state.pickedNodeId = id
-          renderFullscreen(ctx)
-          return
+        const value =
+          payload && typeof payload === 'object' ? payload.value : undefined
+        switch (event) {
+          case 'graph.open':
+            await ctx.openFullscreen(VIEW_ID)
+            return
+          case 'graph.recompute':
+            state.sha = null
+            state.notes = null
+            state.layout = null
+            state.viewport = { x: 0, y: 0, scale: 1 }
+            await rebuildAndRender(ctx)
+            return
+          case 'graph.resetView':
+            state.viewport = { x: 0, y: 0, scale: 1 }
+            renderFullscreen(ctx)
+            return
+          case 'graph.zoomIn':
+            state.viewport.scale = Math.max(0.25, state.viewport.scale * 0.8)
+            renderFullscreen(ctx)
+            return
+          case 'graph.zoomOut':
+            state.viewport.scale = Math.min(4, state.viewport.scale * 1.25)
+            renderFullscreen(ctx)
+            return
+          case 'graph.panLeft':
+            state.viewport.x -= LAYOUT_WIDTH * state.viewport.scale * 0.15
+            renderFullscreen(ctx)
+            return
+          case 'graph.panRight':
+            state.viewport.x += LAYOUT_WIDTH * state.viewport.scale * 0.15
+            renderFullscreen(ctx)
+            return
+          case 'graph.panUp':
+            state.viewport.y -= LAYOUT_HEIGHT * state.viewport.scale * 0.15
+            renderFullscreen(ctx)
+            return
+          case 'graph.panDown':
+            state.viewport.y += LAYOUT_HEIGHT * state.viewport.scale * 0.15
+            renderFullscreen(ctx)
+            return
+          case 'graph.setMode': {
+            const mode = value === 'local' ? 'local' : 'global'
+            state.mode = mode
+            persist(ctx, SETTING_KEYS.mode, mode)
+            await rebuildAndRender(ctx)
+            return
+          }
+          case 'graph.setDepth': {
+            const depth = Number(value)
+            state.depth = depth === 2 || depth === 3 ? depth : 1
+            persist(ctx, SETTING_KEYS.depth, state.depth)
+            await rebuildAndRender(ctx)
+            return
+          }
+          case 'graph.setColorBy': {
+            const colorBy = ['folder', 'tag', 'query'].includes(value)
+              ? value
+              : 'none'
+            state.colorBy = colorBy
+            persist(ctx, SETTING_KEYS.colorBy, colorBy)
+            // Color is a render-only concern; no re-simulation needed.
+            renderFullscreen(ctx)
+            return
+          }
+          case 'graph.setColorQuery':
+            state.colorQuery = typeof value === 'string' ? value : ''
+            persist(ctx, SETTING_KEYS.colorQuery, state.colorQuery)
+            renderFullscreen(ctx)
+            return
+          case 'graph.setSearch':
+            state.search = typeof value === 'string' ? value : ''
+            persist(ctx, SETTING_KEYS.search, state.search)
+            renderFullscreen(ctx)
+            return
+          case 'graph.toggleOrphans':
+            state.hideOrphans = !state.hideOrphans
+            persist(ctx, SETTING_KEYS.hideOrphans, state.hideOrphans)
+            await rebuildAndRender(ctx)
+            return
+          case 'graph.toggleTags':
+            state.tagsAsNodes = !state.tagsAsNodes
+            persist(ctx, SETTING_KEYS.tagsAsNodes, state.tagsAsNodes)
+            await rebuildAndRender(ctx)
+            return
+          case 'graph.setForce': {
+            const key =
+              payload && typeof payload === 'object' ? payload.key : null
+            if (key && key in DEFAULT_FORCES) {
+              const next = { ...state.forces, [key]: Number(value) }
+              state.forces = clampForces(next)
+              persist(ctx, SETTING_KEYS.forces, state.forces)
+              // Size multiplier is render-only; the four physics
+              // forces need a fresh simulation.
+              if (key === 'sizeMultiplier') {
+                renderFullscreen(ctx)
+              } else {
+                await rebuildAndRender(ctx)
+              }
+            }
+            return
+          }
+          case 'graph.resetForces':
+            state.forces = { ...DEFAULT_FORCES }
+            persist(ctx, SETTING_KEYS.forces, state.forces)
+            await rebuildAndRender(ctx)
+            return
+          case 'graph.pickNode': {
+            if (!payload || typeof payload !== 'object') return
+            const id = String(payload.id ?? '')
+            if (!id) return
+            state.pickedNodeId = id
+            renderFullscreen(ctx)
+            return
+          }
+          default:
+            return
         }
       } catch (err) {
-        ctx.notify(
-          err instanceof Error ? err.message : 'Graph action failed.',
-        )
+        ctx.notify(err instanceof Error ? err.message : 'Graph action failed.')
       }
     })
   },
@@ -903,6 +1385,9 @@ export default {
 
   onActiveNoteChange(note, ctx) {
     state.activeNoteId = note?.id ?? null
+    if (state.fullscreenMounted && state.mode === 'local') {
+      return rebuildAndRender(ctx)
+    }
     return renderPanel(ctx)
   },
 
@@ -922,8 +1407,7 @@ export default {
       state.notes = null
       state.layout = null
       if (state.fullscreenMounted) {
-        await rebuildLayout(ctx)
-        renderFullscreen(ctx)
+        await rebuildAndRender(ctx)
       } else {
         void renderPanel(ctx)
       }
@@ -935,10 +1419,9 @@ export default {
     if (viewId !== VIEW_ID) return
     state.fullscreenMounted = true
     state.ctx = ctx
-    // Push the "computing" placeholder right away.
+    state.viewport = { x: 0, y: 0, scale: 1 }
     renderFullscreen(ctx)
-    await rebuildLayout(ctx)
-    renderFullscreen(ctx)
+    await rebuildAndRender(ctx)
   },
 
   onFullscreenUnmount(viewId) {

--- a/public/plugins/noteser-graph/manifest.json
+++ b/public/plugins/noteser-graph/manifest.json
@@ -1,9 +1,9 @@
 {
   "id": "noteser-graph",
   "name": "Graph",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": "Noteser",
-  "description": "Backlinks and unlinked mentions for the active note in the sidebar, plus a force-directed graph of the entire vault in a fullscreen view.",
+  "description": "Backlinks and unlinked mentions for the active note in the sidebar, plus a force-directed graph of the vault with local-graph, color groups, filters, force tuning, and tags-as-nodes.",
   "main": "./main.js",
   "surfaces": {
     "sidebarPanels": [

--- a/src/__tests__/noteserGraphPluginG1.test.ts
+++ b/src/__tests__/noteserGraphPluginG1.test.ts
@@ -1,0 +1,418 @@
+/**
+ * noteserGraphPluginG1.test.ts
+ *
+ * Tests for the pure helpers added in the "G1: graph richness"
+ * increment of `public/plugins/noteser-graph/main.js`:
+ *   - inline tag extraction (code/wikilink masking, nested tags)
+ *   - tags-as-nodes graph synthesis
+ *   - BFS local-graph neighbourhood + subgraph restriction
+ *   - orphan filtering
+ *   - degree recomputation
+ *   - color group assignment (folder / tag / query) + search dim
+ *   - force clamping + tunable simulation
+ *
+ * The plugin module is plain JS so TS infers loose types; each export
+ * is re-cast to a test-facing signature for readability.
+ */
+
+import * as pluginModule from '../../public/plugins/noteser-graph/main.js'
+
+interface GNode {
+  id: string
+  title: string
+  degree: number
+  kind?: string
+}
+interface GEdge {
+  source: string
+  target: string
+}
+interface Graph {
+  nodes: GNode[]
+  edges: GEdge[]
+}
+
+const extractTagsInline = pluginModule.extractTagsInline as (
+  body: string,
+) => string[]
+const deriveGraph = pluginModule.deriveGraph as (
+  notes: ReadonlyArray<{ id: string; title: string; body: string }>,
+) => Graph
+const deriveTagGraph = pluginModule.deriveTagGraph as (
+  base: Graph,
+  notes: ReadonlyArray<{ id: string; title: string; body: string }>,
+) => Graph
+const tagNodeId = pluginModule.tagNodeId as (name: string) => string
+const bfsNeighbourhood = pluginModule.bfsNeighbourhood as (
+  edges: ReadonlyArray<GEdge>,
+  rootId: string | null,
+  depth: number,
+) => Set<string>
+const subgraphForIds = pluginModule.subgraphForIds as (
+  graph: Graph,
+  idSet: Set<string>,
+) => Graph
+const localGraph = pluginModule.localGraph as (
+  graph: Graph,
+  rootId: string | null,
+  depth: number,
+) => Graph
+const dropOrphans = pluginModule.dropOrphans as (graph: Graph) => Graph
+const recomputeDegree = pluginModule.recomputeDegree as (
+  nodes: ReadonlyArray<GNode>,
+  edges: ReadonlyArray<GEdge>,
+) => GNode[]
+const noteMatchesQuery = pluginModule.noteMatchesQuery as (
+  note: { title?: string; body?: string },
+  query: string,
+) => boolean
+const colorForKey = pluginModule.colorForKey as (key: string) => string
+const computeNodeColors = pluginModule.computeNodeColors as (
+  nodes: ReadonlyArray<GNode>,
+  notesById: Map<string, { title?: string; body?: string; folderPath?: string }>,
+  opts: { colorBy?: string; colorQuery?: string; search?: string },
+) => Map<string, string>
+const clampForces = pluginModule.clampForces as (
+  forces: Record<string, number> | null | undefined,
+) => {
+  center: number
+  repel: number
+  linkForce: number
+  linkDistance: number
+  sizeMultiplier: number
+}
+const runForceSimulation = pluginModule.runForceSimulation as (
+  nodes: ReadonlyArray<GNode>,
+  edges: ReadonlyArray<GEdge>,
+  opts?: {
+    width?: number
+    height?: number
+    iterations?: number
+    forces?: Record<string, number>
+  },
+) => Array<{ id: string; x: number; y: number }>
+const DEFAULT_NODE_COLOR = pluginModule.DEFAULT_NODE_COLOR as string
+const TAG_NODE_COLOR = pluginModule.TAG_NODE_COLOR as string
+const QUERY_HIT_COLOR = pluginModule.QUERY_HIT_COLOR as string
+const DIM_COLOR = pluginModule.DIM_COLOR as string
+const DEFAULT_FORCES = pluginModule.DEFAULT_FORCES as Record<string, number>
+
+function note(id: string, title: string, body: string, folderPath = '') {
+  return { id, title, body, folderPath }
+}
+
+describe('extractTagsInline', () => {
+  test('extracts distinct tags lowercased, hash stripped', () => {
+    expect(extractTagsInline('a #Work and #ideas plus #Work again')).toEqual([
+      'work',
+      'ideas',
+    ])
+  })
+
+  test('keeps nested tags with slashes', () => {
+    expect(extractTagsInline('see #work/projects/q1 here')).toEqual([
+      'work/projects/q1',
+    ])
+  })
+
+  test('ignores tags inside fenced code blocks', () => {
+    const body = 'real #tag here\n```\n#notatag in code\n```\n'
+    expect(extractTagsInline(body)).toEqual(['tag'])
+  })
+
+  test('ignores tags inside inline code', () => {
+    expect(extractTagsInline('a `#nope` but #yes counts')).toEqual(['yes'])
+  })
+
+  test('returns [] for empty / hash-free input', () => {
+    expect(extractTagsInline('')).toEqual([])
+    expect(extractTagsInline('no tags at all')).toEqual([])
+  })
+
+  test('does not treat a mid-word hash as a tag', () => {
+    expect(extractTagsInline('foo#bar baz')).toEqual([])
+  })
+})
+
+describe('deriveTagGraph', () => {
+  const notes = [
+    note('a', 'A', 'links [[B]] and #shared #alpha'),
+    note('b', 'B', 'has #shared too'),
+    note('c', 'C', 'no tags'),
+  ]
+
+  test('adds one node per distinct tag with kind tag', () => {
+    const base = deriveGraph(notes)
+    const g = deriveTagGraph(base, notes)
+    const tagNodes = g.nodes.filter((n) => n.kind === 'tag')
+    expect(tagNodes.map((n) => n.title).sort()).toEqual(['#alpha', '#shared'])
+  })
+
+  test('adds an edge from each note to each of its tags', () => {
+    const base = deriveGraph(notes)
+    const g = deriveTagGraph(base, notes)
+    const sharedId = tagNodeId('shared')
+    const edgesToShared = g.edges.filter((e) => e.target === sharedId)
+    expect(edgesToShared.map((e) => e.source).sort()).toEqual(['a', 'b'])
+  })
+
+  test('preserves the original wikilink edges', () => {
+    const base = deriveGraph(notes)
+    const g = deriveTagGraph(base, notes)
+    expect(g.edges).toContainEqual({ source: 'a', target: 'b' })
+  })
+
+  test('tag node degree counts linking notes', () => {
+    const base = deriveGraph(notes)
+    const g = deriveTagGraph(base, notes)
+    const shared = g.nodes.find((n) => n.id === tagNodeId('shared'))
+    expect(shared?.degree).toBe(2)
+  })
+
+  test('does not mutate the base graph', () => {
+    const base = deriveGraph(notes)
+    const baseNodeCount = base.nodes.length
+    const baseEdgeCount = base.edges.length
+    deriveTagGraph(base, notes)
+    expect(base.nodes).toHaveLength(baseNodeCount)
+    expect(base.edges).toHaveLength(baseEdgeCount)
+  })
+})
+
+describe('bfsNeighbourhood', () => {
+  // a - b - c - d ; e isolated. Plus a - f (so a has two neighbours).
+  const edges: GEdge[] = [
+    { source: 'a', target: 'b' },
+    { source: 'b', target: 'c' },
+    { source: 'c', target: 'd' },
+    { source: 'a', target: 'f' },
+  ]
+
+  test('depth 1 returns root + direct neighbours', () => {
+    const set = bfsNeighbourhood(edges, 'a', 1)
+    expect([...set].sort()).toEqual(['a', 'b', 'f'])
+  })
+
+  test('depth 2 reaches two hops', () => {
+    const set = bfsNeighbourhood(edges, 'a', 2)
+    expect([...set].sort()).toEqual(['a', 'b', 'c', 'f'])
+  })
+
+  test('depth 3 reaches the far end', () => {
+    const set = bfsNeighbourhood(edges, 'a', 3)
+    expect([...set].sort()).toEqual(['a', 'b', 'c', 'd', 'f'])
+  })
+
+  test('treats edges as undirected', () => {
+    const set = bfsNeighbourhood(edges, 'd', 1)
+    expect([...set].sort()).toEqual(['c', 'd'])
+  })
+
+  test('isolated root returns only itself', () => {
+    expect([...bfsNeighbourhood(edges, 'e', 3)]).toEqual(['e'])
+  })
+
+  test('null / empty root returns empty set', () => {
+    expect(bfsNeighbourhood(edges, null, 2).size).toBe(0)
+    expect(bfsNeighbourhood(edges, '', 2).size).toBe(0)
+  })
+})
+
+describe('subgraphForIds + localGraph', () => {
+  const graph: Graph = {
+    nodes: [
+      { id: 'a', title: 'A', degree: 2 },
+      { id: 'b', title: 'B', degree: 2 },
+      { id: 'c', title: 'C', degree: 2 },
+      { id: 'd', title: 'D', degree: 1 },
+    ],
+    edges: [
+      { source: 'a', target: 'b' },
+      { source: 'b', target: 'c' },
+      { source: 'c', target: 'd' },
+    ],
+  }
+
+  test('subgraphForIds drops nodes + dangling edges and recomputes degree', () => {
+    const sub = subgraphForIds(graph, new Set(['a', 'b']))
+    expect(sub.nodes.map((n) => n.id).sort()).toEqual(['a', 'b'])
+    expect(sub.edges).toEqual([{ source: 'a', target: 'b' }])
+    expect(sub.nodes.find((n) => n.id === 'a')?.degree).toBe(1)
+  })
+
+  test('localGraph depth 1 keeps the root and its neighbours', () => {
+    const local = localGraph(graph, 'b', 1)
+    expect(local.nodes.map((n) => n.id).sort()).toEqual(['a', 'b', 'c'])
+    expect(local.edges).toHaveLength(2)
+  })
+
+  test('localGraph depth 2 widens the neighbourhood', () => {
+    const local = localGraph(graph, 'a', 2)
+    expect(local.nodes.map((n) => n.id).sort()).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('dropOrphans + recomputeDegree', () => {
+  test('recomputeDegree counts in + out per node', () => {
+    const nodes: GNode[] = [
+      { id: 'a', title: 'A', degree: 0 },
+      { id: 'b', title: 'B', degree: 0 },
+      { id: 'c', title: 'C', degree: 0 },
+    ]
+    const edges: GEdge[] = [
+      { source: 'a', target: 'b' },
+      { source: 'b', target: 'c' },
+    ]
+    const out = recomputeDegree(nodes, edges)
+    const byId = new Map(out.map((n) => [n.id, n.degree]))
+    expect(byId.get('a')).toBe(1)
+    expect(byId.get('b')).toBe(2)
+    expect(byId.get('c')).toBe(1)
+  })
+
+  test('dropOrphans removes degree-0 nodes only', () => {
+    const graph: Graph = {
+      nodes: [
+        { id: 'a', title: 'A', degree: 0 },
+        { id: 'b', title: 'B', degree: 0 },
+        { id: 'orphan', title: 'O', degree: 99 }, // stale degree
+      ],
+      edges: [{ source: 'a', target: 'b' }],
+    }
+    const out = dropOrphans(graph)
+    expect(out.nodes.map((n) => n.id).sort()).toEqual(['a', 'b'])
+  })
+})
+
+describe('noteMatchesQuery', () => {
+  test('matches title or body case-insensitively', () => {
+    expect(noteMatchesQuery({ title: 'Roadmap', body: '' }, 'road')).toBe(true)
+    expect(noteMatchesQuery({ title: 'X', body: 'see the WIDGET' }, 'widget')).toBe(true)
+  })
+  test('returns false on miss or empty query', () => {
+    expect(noteMatchesQuery({ title: 'X', body: 'y' }, 'zzz')).toBe(false)
+    expect(noteMatchesQuery({ title: 'X', body: 'y' }, '')).toBe(false)
+  })
+})
+
+describe('colorForKey', () => {
+  test('is deterministic and returns a hex color', () => {
+    const c1 = colorForKey('folder:Work')
+    const c2 = colorForKey('folder:Work')
+    expect(c1).toBe(c2)
+    expect(c1).toMatch(/^#[0-9a-f]{6}$/i)
+  })
+})
+
+describe('computeNodeColors', () => {
+  const nodes: GNode[] = [
+    { id: 'a', title: 'A', degree: 1, kind: 'note' },
+    { id: 'b', title: 'B', degree: 1, kind: 'note' },
+    { id: 't', title: '#x', degree: 1, kind: 'tag' },
+  ]
+  const notesById = new Map<
+    string,
+    { title?: string; body?: string; folderPath?: string }
+  >([
+    ['a', { title: 'A', body: 'has #x tag', folderPath: 'Work' }],
+    ['b', { title: 'B', body: 'plain widget note', folderPath: 'Personal' }],
+  ])
+
+  test('colorBy none leaves note nodes at the default color', () => {
+    const m = computeNodeColors(nodes, notesById, { colorBy: 'none' })
+    expect(m.get('a')).toBe(DEFAULT_NODE_COLOR)
+    expect(m.get('b')).toBe(DEFAULT_NODE_COLOR)
+  })
+
+  test('tag nodes always take the tag color', () => {
+    const m = computeNodeColors(nodes, notesById, { colorBy: 'folder' })
+    expect(m.get('t')).toBe(TAG_NODE_COLOR)
+  })
+
+  test('colorBy folder gives different folders different colors', () => {
+    const m = computeNodeColors(nodes, notesById, { colorBy: 'folder' })
+    expect(m.get('a')).not.toBe(m.get('b'))
+    expect(m.get('a')).toBe(colorForKey('folder:Work'))
+  })
+
+  test('colorBy query highlights only matching notes', () => {
+    const m = computeNodeColors(nodes, notesById, {
+      colorBy: 'query',
+      colorQuery: 'widget',
+    })
+    expect(m.get('a')).toBe(DEFAULT_NODE_COLOR)
+    expect(m.get('b')).toBe(QUERY_HIT_COLOR)
+  })
+
+  test('search dims non-matching nodes regardless of group', () => {
+    const m = computeNodeColors(nodes, notesById, {
+      colorBy: 'folder',
+      search: 'widget',
+    })
+    expect(m.get('a')).toBe(DIM_COLOR) // A has no "widget"
+    expect(m.get('b')).not.toBe(DIM_COLOR) // B matches
+  })
+})
+
+describe('clampForces', () => {
+  test('fills defaults from undefined', () => {
+    expect(clampForces(undefined)).toEqual(DEFAULT_FORCES)
+  })
+
+  test('clamps out-of-range values into bounds', () => {
+    const out = clampForces({
+      center: 99,
+      repel: -10,
+      linkForce: 5,
+      linkDistance: 0,
+      sizeMultiplier: 100,
+    })
+    expect(out.center).toBeLessThanOrEqual(0.2)
+    expect(out.repel).toBe(0)
+    expect(out.linkForce).toBeLessThanOrEqual(1)
+    expect(out.linkDistance).toBeGreaterThanOrEqual(1)
+    expect(out.sizeMultiplier).toBeLessThanOrEqual(5)
+  })
+
+  test('replaces NaN with the default', () => {
+    expect(clampForces({ repel: NaN } as Record<string, number>).repel).toBe(
+      DEFAULT_FORCES.repel,
+    )
+  })
+})
+
+describe('runForceSimulation force tuning', () => {
+  const nodes: GNode[] = [
+    { id: 'a', title: 'A', degree: 1 },
+    { id: 'b', title: 'B', degree: 1 },
+  ]
+  const edges: GEdge[] = [{ source: 'a', target: 'b' }]
+
+  test('default forces reproduce the legacy layout', () => {
+    const a = runForceSimulation(nodes, edges, { iterations: 20 })
+    const b = runForceSimulation(nodes, edges, {
+      iterations: 20,
+      forces: { ...DEFAULT_FORCES },
+    })
+    expect(a).toEqual(b)
+  })
+
+  test('a stronger repel pushes the two nodes farther apart', () => {
+    const dist = (
+      ps: Array<{ id: string; x: number; y: number }>,
+    ): number => {
+      const pa = ps.find((p) => p.id === 'a')!
+      const pb = ps.find((p) => p.id === 'b')!
+      return Math.hypot(pa.x - pb.x, pa.y - pb.y)
+    }
+    const low = runForceSimulation(nodes, edges, {
+      iterations: 60,
+      forces: { ...DEFAULT_FORCES, repel: 100, linkForce: 0 },
+    })
+    const high = runForceSimulation(nodes, edges, {
+      iterations: 60,
+      forces: { ...DEFAULT_FORCES, repel: 4000, linkForce: 0 },
+    })
+    expect(dist(high)).toBeGreaterThan(dist(low))
+  })
+})


### PR DESCRIPTION
Graph-richness increment for the `noteser-graph` plugin (the "G1" item in `docs/plugins-v1.3-plan.md`, Layer 2 roadmap features 4-8 + 10). Six features, all on the existing v1.2 VNode surface.

## Features
1. **Local graph** - per-active-note neighbourhood via BFS over the derived wikilink edge set at depth 1/2/3. Mode toggle (Global / Local) and a depth radio inside the fullscreen view.
2. **Color groups** - color nodes by folder, by first tag, or by a highlight query. Tag extraction is reimplemented inline in the worker (no `@/utils` access).
3. **Filters** - search box that dims non-matching nodes, a hide-orphans toggle (drops degree-0 nodes before layout), and a tags-as-nodes toggle.
4. **Force tuning** - the simulation constants (center, repel, link force, link distance) lifted into a tunable, clamped `state.forces`, driven by number inputs, with a reset-to-defaults button.
5. **Node sizing by degree** - existing degree sizing now scaled by a size multiplier exposed in the force settings.
6. **Tags as nodes** (default OFF, gated behind the filter toggle) - one synthetic node per distinct tag with an edge from each note to its tags.

## Persistence
Every user choice (mode, depth, color-by, color query, search, hide-orphans, tags-as-nodes, forces, size multiplier) persists via `setSetting`/`getSetting` under the `g1.*` namespace, so it survives a reload.

## Scope
- Plugin-only. Touches `public/plugins/noteser-graph/` only (`main.js`, `manifest.json`, `README.md`) plus a new test file. No `src/plugins/` change, no platform dependency. Ships today on v1.2.
- The backlinks / unlinked-mentions sidebar panel is unchanged.

## Tests
- New pure helpers are exported and unit-tested in `src/__tests__/noteserGraphPluginG1.test.ts` (tag extraction, tags-as-nodes synthesis, local-graph BFS, orphan filtering, degree recompute, color assignment, force clamping/tuning). Existing `noteserGraphPlugin.test.ts` still passes unchanged.
- `npm run lint` clean, `tsc --noEmit` zero errors, full `npm test -- --ci` green (2821 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)