### PR TITLE
feat(graph): interactive drag, wheel zoom, pan, hover highlight (G2-G5)

### DIFF
--- a/public/plugins/noteser-graph/README.md
+++ b/public/plugins/noteser-graph/README.md
@@ -2,7 +2,10 @@
 
 Reference plugin that delivers the graph view + backlinks panel called for
 in issue #71. Built on the Plugin API v1.2 (PRs A, B, C, F + the post-v1.2
-VNode event delivery / wikilink intercept follow-up). Self-contained ES
+VNode event delivery / wikilink intercept follow-up) and the v1.3
+interaction surface (L1-L4: pointer / wheel / hover events, host-owned
+pan/zoom with the `surface.transform` settle event, and the
+`worker:patchSvgPositions` position-patch fast path). Self-contained ES
 module - the worker dynamic-imports `main.js` via a Blob URL.
 
 ## What it provides
@@ -26,12 +29,40 @@ Shown for the active note. Two sections plus an action button:
 Force-directed SVG of the vault.
 
 - Nodes are notes; edges are wikilinks.
-- Click a node to "select" it. The header shows a `link` VNode pointing
-  at that note (`{ kind: 'note', noteId }`); clicking the link goes
-  through the host's `wikilink://` intercept and opens the note. Tag
-  nodes (see below) are not notes, so selecting one shows a plain label.
-- Header buttons: Recompute, Reset view, Zoom in / out, Pan in four
-  directions.
+- Header buttons: Recompute, Reset view, and (when any node is pinned)
+  Release pinned.
+
+#### Interactive (v0.3.0, "G2-G5")
+
+The graph uses the v1.3 interaction surface to feel like Obsidian:
+
+- **Wheel zoom + drag pan (G2).** The svg declares `panZoom: 'host'`, so
+  the host owns the viewBox: wheel-zoom and dragging the background pan
+  instantly with no worker round-trip. On gesture settle the host emits
+  one `surface.transform` event `{ x, y, scale }`; the plugin
+  reconstructs the viewport box from it and persists it under
+  `g2.viewport`, so the viewport survives a reload. The old nine
+  zoom/pan buttons are gone.
+- **Node drag, pin/unpin (G3).** Pressing a node circle pins it (the
+  host auto-captures the pointer because the circle declares both
+  `onPointerDown` and `onPointerMove`); moving the pointer drags the
+  pinned node to `payload.{x,y}` (already svg user-space). The
+  simulation reheats around pinned nodes (`simulationStep` skips
+  integration for `fixed` nodes) and streams ONLY the moved coordinates
+  through `ctx.patchSvgPositions({ viewId, patches })` each frame, so a
+  500-node drag never re-emits the whole SVG tree. A pinned node keeps a
+  distinct ring; click a pinned node to unpin it, or use "Release
+  pinned".
+- **Hover highlight (G4).** Hovering a node (`onPointerEnter`) dims every
+  non-neighbour circle to a muted fill and brightens/thickens the hovered
+  node's edges; `onPointerLeave` clears it. The highlight is recolor-only
+  (no re-layout, no patch channel).
+- **Click vs drag to open (G5).** A press that releases within ~4px and
+  ~250ms counts as a click, not a drag: a click on a free note node
+  selects it and surfaces the open link; a click on a pinned node unpins
+  it. A real drag never opens the note. Opening still flows through the
+  host's `wikilink://` intercept on the selected-row `link` (see the API
+  note below).
 
 #### Graph richness controls (v0.2.0, "G1")
 
@@ -62,7 +93,8 @@ simulation; changing the view mode, depth, force values, or a node
 toggle re-derives the graph and re-runs the layout.
 
 Setting keys: `g1.mode`, `g1.depth`, `g1.colorBy`, `g1.colorQuery`,
-`g1.search`, `g1.hideOrphans`, `g1.tagsAsNodes`, `g1.forces`.
+`g1.search`, `g1.hideOrphans`, `g1.tagsAsNodes`, `g1.forces`, and the
+G2 viewport box `g2.viewport`.
 
 ## Install + dev workflow
 
@@ -139,37 +171,30 @@ The plugin's panel id (`graph`) intentionally does not collide with the
 core's `backlinks` id, so a user can have both panels installed without
 the registry rejecting either.
 
-## v1.2 API gaps surfaced while building
+## What v1.3 closed, and the one gap that remains
 
-The brief asked for:
+The v1.2 surface could not express wheel-zoom, drag-pan, node drag, or
+hover, so v0.1.0 / v0.2.0 shipped zoom/pan as header buttons and a
+two-click "select then open" flow. The v1.3 interaction surface closes
+the interaction gaps:
 
-- **Wheel = zoom** on the graph view, and
-- **Drag = pan** on the graph view, and
-- **Click a circle = open the note in one click**.
+- `onWheel` + `panZoom: 'host'` -> wheel zoom + drag pan (the buttons
+  are gone).
+- `onPointerDown / Move / Up` on circles + automatic pointer capture ->
+  node drag.
+- `worker:patchSvgPositions` (`ctx.patchSvgPositions`) -> 60fps drag
+  without re-emitting the SVG tree.
+- `onPointerEnter / Leave` -> hover highlight.
 
-The v1.2 VNode event set is restricted to `onClick`, `onChange`,
-`onSubmit`, and `onKeyDown` (the last only for Esc / Enter). There is
-no `onWheel`, no `onPointerDown / move / up`. SVG children
-(`circle` / `rect`) accept `onClick` only, so dragging the canvas to
-pan and wheel-to-zoom are not expressible at the VNode layer.
-
-Likewise, the host's `wikilink://` intercept fires on real `<a>`
-elements rendered from a `link` VNode. SVG children cannot be wrapped
-in a `link` VNode (the SvgChild union does not allow it), and the
-`PluginCtx` exposes no `ctx.openNote(id)` method. Clicking a circle
-therefore lands as a regular VNode event, and the plugin has to
-re-render with a `link` VNode the user clicks to actually navigate.
-
-To preserve the brief's spirit, this plugin ships:
-
-- **Zoom in / out + Pan four-direction buttons** in the header instead
-  of wheel + drag.
-- **Two-click open** for circle clicks (click circle -> persistent
-  "Selected" `link` row appears in the header -> click link to open).
-
-A v1.3 API increment that lands `onWheel` / pointer events on the SVG
-shape and an `ctx.openNote(id)` method would close both gaps without
-breaking this plugin's UI.
+One gap remains: `PluginCtx` still exposes **no `ctx.openNote(id)`**
+method, and SVG children cannot be wrapped in a `link` VNode. The only
+way to open a note from a plugin is a real `<a>` click on a `link`
+VNode with `href: { kind: 'note', noteId }`, which the host's
+`wikilink://` intercept turns into `useWorkspaceStore.openNote`. So G5
+here is the click-vs-drag DISAMBIGUATION plus surfacing that open link
+on a genuine click; a true single-click programmatic open would need a
+future `ctx.openNote(id)` host method. This plugin does not (and may
+not) reach into `src/plugins` to add one.
 
 ## Tests
 
@@ -195,10 +220,24 @@ The G1 increment adds more pure helpers, all exported and unit-tested:
 - `computeNodeColors(nodes, notesById, opts)` / `colorForKey(key)`
 - `clampForces(forces)` / `DEFAULT_FORCES`
 
-Jest tests at `src/__tests__/noteserGraphPlugin.test.ts` and
-`src/__tests__/noteserGraphPluginG1.test.ts` import the plugin module
-directly. The first covers the unlinked-mention detector (code-block
-exclusion, wikilink exclusion, whole-word matching) plus graph
-derivation on a 5-note fixture; the second covers tag extraction, the
-tags-as-nodes synthesis, the local-graph BFS, orphan filtering, color
-assignment, and force clamping/tuning.
+The G2-G5 interactive increment adds more pure helpers, all exported and
+unit-tested:
+
+- `isTapGesture(start, end, opts?)` / `TAP_MOVE_THRESHOLD` /
+  `TAP_TIME_THRESHOLD` - click-vs-drag classification.
+- `simulationStep(sim, edges, opts?)` / `simIsSettled(sim, threshold?)` -
+  one live integration step honouring the per-node `fixed` flag.
+- `hoverNeighbours(edges, hoveredId)` / `edgeKey(source, target)` - the
+  hover highlight node + incident-edge sets.
+- `viewportFromTransform(base, transform)` / `clampViewport(vp)` /
+  `DEFAULT_VIEWPORT` - the `surface.transform` viewport round-trip.
+
+Jest tests at `src/__tests__/noteserGraphPlugin.test.ts`,
+`src/__tests__/noteserGraphPluginG1.test.ts`, and
+`src/__tests__/noteserGraphPluginG2G5.test.ts` import the plugin module
+directly. The first covers the unlinked-mention detector plus graph
+derivation; the second covers tag extraction, the tags-as-nodes
+synthesis, the local-graph BFS, orphan filtering, color assignment, and
+force clamping/tuning; the third covers the click-vs-drag threshold,
+pinned-node handling in the simulation step, the hover neighbour set,
+and the viewport persistence round-trip.

--- a/public/plugins/noteser-graph/main.js
+++ b/public/plugins/noteser-graph/main.js
@@ -1,7 +1,10 @@
-// noteser-graph v0.2.0
+// noteser-graph v0.3.0
 //
 // Closes issue #71. Built on Plugin API v1.2 (PRs A, B, C, F + the
-// VNode event delivery follow-up).
+// VNode event delivery follow-up) and Plugin API v1.3 (L1-L4: pointer
+// + wheel + hover events, host-owned pan/zoom with the
+// `surface.transform` settle event, and the `worker:patchSvgPositions`
+// position-patch fast path).
 //
 // Provides two surfaces:
 //
@@ -10,9 +13,20 @@
 //      graph in a fullscreen view.
 //
 //   2. A fullscreen view "Graph" containing a force-directed SVG of
-//      the vault. v0.2.0 (the "G1: graph richness" increment) adds,
-//      all on the existing v1.2 VNode surface and with no platform
-//      change:
+//      the vault. v0.3.0 (the "G2-G5: interactive" increment) makes
+//      the graph feel like Obsidian, on the v1.3 interaction surface:
+//        - Wheel zoom + drag pan, owned by the host (instant, no
+//          worker round-trip); the viewport persists across reload.
+//        - Node drag: press a node to pin it under the pointer; the
+//          simulation reheats around pinned nodes; per-frame position
+//          patches keep a 500-node drag at 60fps. Click a pinned node
+//          to unpin it, or use "Release pinned".
+//        - Hover highlight: hovering a node dims every non-neighbour
+//          and brightens the hovered node's edges.
+//        - Click vs drag: a short, still press opens the note (via the
+//          existing wikilink open affordance); a real drag never does.
+//      v0.2.0 (the "G1: graph richness" increment) added, all on the
+//      existing v1.2 VNode surface and with no platform change:
 //        - Local graph: a per-active-note neighbourhood at depth
 //          1 / 2 / 3 (BFS over the derived edge set).
 //        - Color groups: color every node by folder, by tag, or by a
@@ -659,6 +673,238 @@ function makeSeed(nodes) {
   return h >>> 0
 }
 
+// --------------------- Interaction helpers (exported) ------------------
+//
+// Pure helpers for the v0.3.0 interactive layer (drag, wheel zoom, pan,
+// hover highlight, click-vs-drag). Exported by name so the Jest suite
+// can verify them without a live host. Runtime callers reach them
+// through the closure.
+
+/** The svg's full extent. The host-owned viewBox starts here, and a
+ *  "reset view" returns to it. */
+export const DEFAULT_VIEWPORT = { x: 0, y: 0, w: LAYOUT_WIDTH, h: LAYOUT_HEIGHT }
+
+/**
+ * Clamp a viewport box to finite numbers + a sane width/height so a
+ * corrupt persisted setting or a degenerate transform cannot blow up
+ * the rendered svg. The width/height bounds mirror the host's zoom
+ * clamp (roughly 50x in or out of the base extent). Pure.
+ */
+export function clampViewport(vp) {
+  const num = (v, def) => (Number.isFinite(v) ? v : def)
+  const x = num(vp?.x, DEFAULT_VIEWPORT.x)
+  const y = num(vp?.y, DEFAULT_VIEWPORT.y)
+  const w = Math.min(
+    LAYOUT_WIDTH * 50,
+    Math.max(LAYOUT_WIDTH / 50, num(vp?.w, DEFAULT_VIEWPORT.w)),
+  )
+  const h = Math.min(
+    LAYOUT_HEIGHT * 50,
+    Math.max(LAYOUT_HEIGHT / 50, num(vp?.h, DEFAULT_VIEWPORT.h)),
+  )
+  return { x, y, w, h }
+}
+
+/**
+ * Reconstruct the viewport box from a `surface.transform` settle event.
+ *
+ *   base      - { w, h } the viewBox dimensions the svg mounted with.
+ *               The host fixes its `baseW`/`baseH` at mount and reports
+ *               `scale = baseW / liveW`, so reconstructing the live
+ *               width as `base.w / scale` round-trips exactly.
+ *   transform - { x, y, scale } from the settle event.
+ *
+ * Returns the full box { x, y, w, h } in svg user space, clamped. Pure.
+ * A no-op settle (scale 1, unchanged x/y) returns the base box, so the
+ * persisted viewport survives a reload without drifting.
+ */
+export function viewportFromTransform(base, transform) {
+  const scale =
+    Number.isFinite(transform?.scale) && transform.scale > 0
+      ? transform.scale
+      : 1
+  const bw = Number.isFinite(base?.w) && base.w > 0 ? base.w : LAYOUT_WIDTH
+  const bh = Number.isFinite(base?.h) && base.h > 0 ? base.h : LAYOUT_HEIGHT
+  return clampViewport({
+    x: Number.isFinite(transform?.x) ? transform.x : 0,
+    y: Number.isFinite(transform?.y) ? transform.y : 0,
+    w: bw / scale,
+    h: bh / scale,
+  })
+}
+
+/** Movement (px, svg user space) below which a press counts as a click. */
+export const TAP_MOVE_THRESHOLD = 4
+/** Duration (ms) below which a press counts as a click, not a drag. */
+export const TAP_TIME_THRESHOLD = 250
+
+/**
+ * Classify a pointerdown -> pointerup pair as a click (tap) or a drag.
+ *
+ *   start - { x, y, t }   pointerdown position (svg user space) + time
+ *   end   - { x, y, t }   pointerup position + time
+ *
+ * Returns true only when BOTH the travel distance is at/under
+ * TAP_MOVE_THRESHOLD and the elapsed time is at/under
+ * TAP_TIME_THRESHOLD. A real drag (either threshold exceeded) returns
+ * false, so it never opens the note. Pure.
+ */
+export function isTapGesture(start, end, opts) {
+  if (!start || !end) return false
+  const moveMax = opts?.moveThreshold ?? TAP_MOVE_THRESHOLD
+  const timeMax = opts?.timeThreshold ?? TAP_TIME_THRESHOLD
+  const dx = (end.x ?? 0) - (start.x ?? 0)
+  const dy = (end.y ?? 0) - (start.y ?? 0)
+  const dist = Math.sqrt(dx * dx + dy * dy)
+  const dt = (end.t ?? 0) - (start.t ?? 0)
+  return dist <= moveMax && dt <= timeMax
+}
+
+// Separator that cannot occur in a node id, used to key an edge as
+// "source -> target" for the hover-incidence set.
+const EDGE_KEY_SEP = ' '
+
+/** Stable key for an edge in the hover-incidence set. */
+export function edgeKey(source, target) {
+  return String(source) + EDGE_KEY_SEP + String(target)
+}
+
+/**
+ * Hover highlight set for `hoveredId`: the hovered node plus its direct
+ * (1-hop, undirected) neighbours, and the set of edges incident to the
+ * hovered node.
+ *
+ * Returns { nodes: Set<id>, edges: Set<edgeKey> }. Edge keys use the
+ * SAME orientation as the input edge list (`edgeKey(e.source,
+ * e.target)`) so a renderer iterating the same edges can test
+ * incidence directly. O(edges). Pure.
+ */
+export function hoverNeighbours(edges, hoveredId) {
+  const nodes = new Set()
+  const incident = new Set()
+  if (!hoveredId) return { nodes, edges: incident }
+  nodes.add(hoveredId)
+  for (const e of edges) {
+    if (e.source === hoveredId) {
+      nodes.add(e.target)
+      incident.add(edgeKey(e.source, e.target))
+    } else if (e.target === hoveredId) {
+      nodes.add(e.source)
+      incident.add(edgeKey(e.source, e.target))
+    }
+  }
+  return { nodes, edges: incident }
+}
+
+/** Max per-axis speed below which the live reheat loop is "settled". */
+export const SIM_SETTLE_SPEED = 0.4
+
+/**
+ * Run ONE force-simulation integration step over a live sim array,
+ * honouring a per-node `fixed` flag.
+ *
+ *   sim   - [{ id, x, y, vx, vy, fixed }]   (MUTATED in place)
+ *   edges - [{ source, target }]
+ *   opts  - { forces, width, height }
+ *
+ * Pinned / dragged nodes (`fixed === true`) keep their position: their
+ * velocity is zeroed and integration is skipped, but they STILL exert
+ * repulsion + spring forces on the rest, so the layout resumes and
+ * reheats AROUND them. Returns the same `sim` array (the live loop
+ * reuses one array per drag; tests pass a fresh one). Mirrors the
+ * physics of `runForceSimulation`, one iteration.
+ */
+export function simulationStep(sim, edges, opts) {
+  const forces = clampForces(opts?.forces)
+  const width = opts?.width ?? LAYOUT_WIDTH
+  const height = opts?.height ?? LAYOUT_HEIGHT
+  const cx = width / 2
+  const cy = height / 2
+  const N = sim.length
+  const indexById = new Map()
+  for (let i = 0; i < N; i++) indexById.set(sim[i].id, i)
+
+  // Pair repulsion (O(n^2)).
+  for (let i = 0; i < N; i++) {
+    for (let j = i + 1; j < N; j++) {
+      const a = sim[i]
+      const b = sim[j]
+      let dx = a.x - b.x
+      let dy = a.y - b.y
+      let d2 = dx * dx + dy * dy
+      if (d2 < 0.01) {
+        // Coincident nodes: nudge apart deterministically.
+        dx = 0.1
+        dy = 0.1
+        d2 = 0.02
+      }
+      const d = Math.sqrt(d2)
+      const f = forces.repel / d2
+      const fx = (dx / d) * f
+      const fy = (dy / d) * f
+      a.vx += fx
+      a.vy += fy
+      b.vx -= fx
+      b.vy -= fy
+    }
+  }
+
+  // Spring attraction along edges.
+  for (const e of edges) {
+    const ai = indexById.get(e.source)
+    const bi = indexById.get(e.target)
+    if (ai === undefined || bi === undefined) continue
+    const a = sim[ai]
+    const b = sim[bi]
+    const dx = b.x - a.x
+    const dy = b.y - a.y
+    const d = Math.sqrt(dx * dx + dy * dy) || 0.01
+    const delta = d - forces.linkDistance
+    const fx = (dx / d) * delta * forces.linkForce
+    const fy = (dy / d) * delta * forces.linkForce
+    a.vx += fx
+    a.vy += fy
+    b.vx -= fx
+    b.vy -= fy
+  }
+
+  // Center pull + damping + integration. Fixed nodes never move.
+  for (let i = 0; i < N; i++) {
+    const p = sim[i]
+    if (p.fixed) {
+      p.vx = 0
+      p.vy = 0
+      continue
+    }
+    p.vx += (cx - p.x) * forces.center
+    p.vy += (cy - p.y) * forces.center
+    p.vx *= LAYOUT_DAMPING
+    p.vy *= LAYOUT_DAMPING
+    const sp = Math.sqrt(p.vx * p.vx + p.vy * p.vy)
+    if (sp > LAYOUT_MAX_SPEED) {
+      p.vx = (p.vx / sp) * LAYOUT_MAX_SPEED
+      p.vy = (p.vy / sp) * LAYOUT_MAX_SPEED
+    }
+    p.x += p.vx
+    p.y += p.vy
+  }
+  return sim
+}
+
+/**
+ * True when no UNPINNED node is still moving faster than `threshold`
+ * (per axis), so the live reheat loop can stop. Pinned nodes are
+ * ignored (they are held still on purpose). Pure.
+ */
+export function simIsSettled(sim, threshold) {
+  const t = threshold ?? SIM_SETTLE_SPEED
+  for (const p of sim) {
+    if (p.fixed) continue
+    if (Math.abs(p.vx) > t || Math.abs(p.vy) > t) return false
+  }
+  return true
+}
+
 // ------------------------ Plugin runtime --------------------------------
 
 const PANEL_ID = 'graph'
@@ -675,6 +921,8 @@ const SETTING_KEYS = {
   hideOrphans: 'g1.hideOrphans',
   tagsAsNodes: 'g1.tagsAsNodes',
   forces: 'g1.forces',
+  // G2: the host-owned viewport box, persisted from `surface.transform`.
+  viewport: 'g2.viewport',
 }
 
 // State the runtime keeps across handler firings.
@@ -685,8 +933,29 @@ const state = {
   activeNoteId: null,
   layout: null, // { nodes, edges, positions, notesById }
   fullscreenMounted: false,
-  viewport: { x: 0, y: 0, scale: 1 },
   pickedNodeId: null,
+
+  // G2: host-owned pan/zoom viewport. `viewport` is the full viewBox
+  // box `{ x, y, w, h }`; `viewportBase` is the box the svg mounted
+  // with (the host's fixed baseW/baseH for the scale it reports in the
+  // `surface.transform` settle event); `viewportEpoch` is folded into
+  // the svg id so bumping it forces the host svg to remount and
+  // re-init its pan/zoom state (used by "reset view" / recompute).
+  viewport: { ...DEFAULT_VIEWPORT },
+  viewportBase: { w: DEFAULT_VIEWPORT.w, h: DEFAULT_VIEWPORT.h },
+  viewportEpoch: 0,
+
+  // G3: live node-drag state.
+  pinned: new Set(), // ids of pinned (fixed) nodes
+  sim: null, // live [{ id, x, y, vx, vy, fixed }] during/after a drag
+  simIndex: null, // Map(id -> sim node) for O(1) lookup
+  dragId: null, // node currently under the pointer, or null
+  dragStart: null, // { id, x, y, t, moved, wasPinned } for click-vs-drag
+  simTimer: null, // reheat-loop setTimeout handle
+  simFrames: 0, // frames run in the current loop (hard-stop guard)
+
+  // G4: id of the node currently hovered, or null.
+  hoveredId: null,
 
   // G1 graph-richness controls. Loaded from settings on activate.
   mode: 'global', // 'global' | 'local'
@@ -724,6 +993,12 @@ function loadSettings(ctx) {
     const forces = ctx.getSetting(SETTING_KEYS.forces)
     if (forces && typeof forces === 'object') {
       state.forces = clampForces(forces)
+    }
+
+    const viewport = ctx.getSetting(SETTING_KEYS.viewport)
+    if (viewport && typeof viewport === 'object') {
+      state.viewport = clampViewport(viewport)
+      state.viewportBase = { w: state.viewport.w, h: state.viewport.h }
     }
   } catch {
     // Settings unavailable - keep defaults.
@@ -983,6 +1258,15 @@ function buildControls() {
   return { tag: 'box', gap: 2, children }
 }
 
+// Edge + node colors. The hover highlight only recolors (no re-layout):
+// non-neighbours mute to DIM_COLOR, the hovered node's edges brighten.
+const EDGE_COLOR = '#475569'
+const EDGE_MUTED = '#2a3142'
+const EDGE_HILITE = '#94a3b8'
+const NODE_STROKE = '#0f172a'
+const HOVER_RING = '#e2e8f0' // ring on the hovered node
+const PIN_RING = '#f59e0b' // ring on a pinned node (Obsidian-ish accent)
+
 /** Build the fullscreen SVG VNode from the cached layout. */
 function renderFullscreen(ctx) {
   if (!state.layout) {
@@ -1008,25 +1292,42 @@ function renderFullscreen(ctx) {
     search: state.search,
   })
   const sizeMult = clampForces(state.forces).sizeMultiplier
+  const hover = state.hoveredId ? hoverNeighbours(edges, state.hoveredId) : null
 
-  const vw = Math.max(64, Math.round(LAYOUT_WIDTH * state.viewport.scale))
-  const vh = Math.max(64, Math.round(LAYOUT_HEIGHT * state.viewport.scale))
-  const vx = Math.round(state.viewport.x)
-  const vy = Math.round(state.viewport.y)
+  // The host owns the viewBox once `panZoom: 'host'` is set, so we
+  // render from the persisted viewport box and let the host mutate it
+  // live during pan/zoom. A control-driven re-render keeps the viewport
+  // because the prop equals the last settled box (React no-ops on it).
+  const vp = state.viewport
+  const viewBox = [vp.x, vp.y, vp.w, vp.h]
 
   const lineNodes = []
   for (const e of edges) {
     const a = posById.get(e.source)
     const b = posById.get(e.target)
     if (!a || !b) continue
+    let stroke = EDGE_COLOR
+    let strokeWidth = 1
+    if (hover) {
+      if (hover.edges.has(edgeKey(e.source, e.target))) {
+        stroke = EDGE_HILITE
+        strokeWidth = 2
+      } else {
+        stroke = EDGE_MUTED
+      }
+    }
     lineNodes.push({
       tag: 'line',
       x1: a.x,
       y1: a.y,
       x2: b.x,
       y2: b.y,
-      stroke: '#475569',
-      strokeWidth: 1,
+      stroke,
+      strokeWidth,
+      // L4 patch channel: tag each endpoint with the node id it follows
+      // so a drag's per-frame position patch moves the edge with it.
+      sourceId: e.source,
+      targetId: e.target,
     })
   }
   const circleNodes = []
@@ -1034,14 +1335,31 @@ function renderFullscreen(ctx) {
     const p = posById.get(n.id)
     if (!p) continue
     const r = Math.max(1, (4 + Math.min(8, n.degree)) * sizeMult)
+    let fill = colors.get(n.id) ?? DEFAULT_NODE_COLOR
+    let stroke = NODE_STROKE
+    if (hover && !hover.nodes.has(n.id)) {
+      // Dim every node that is neither the hovered node nor a neighbour.
+      fill = DIM_COLOR
+    }
+    if (state.hoveredId === n.id) stroke = HOVER_RING
+    if (state.pinned.has(n.id)) stroke = PIN_RING
     circleNodes.push({
       tag: 'circle',
       cx: p.x,
       cy: p.y,
       r,
-      fill: colors.get(n.id) ?? DEFAULT_NODE_COLOR,
-      stroke: '#0f172a',
-      onClick: { kind: 'emit', event: 'graph.pickNode', payload: { id: n.id } },
+      fill,
+      stroke,
+      // L1: echoed back as `payload.target`; also the L4 patch-channel id.
+      id: n.id,
+      // G3 drag + G5 click-vs-drag. The host auto-captures the pointer
+      // because the circle declares both down + move.
+      onPointerDown: { kind: 'emit', event: 'graph.nodeDown' },
+      onPointerMove: { kind: 'emit', event: 'graph.nodeMove' },
+      onPointerUp: { kind: 'emit', event: 'graph.nodeUp' },
+      // G4 hover highlight.
+      onPointerEnter: { kind: 'emit', event: 'graph.nodeEnter' },
+      onPointerLeave: { kind: 'emit', event: 'graph.nodeLeave' },
     })
   }
 
@@ -1064,50 +1382,23 @@ function renderFullscreen(ctx) {
       variant: 'ghost',
       onClick: { kind: 'emit', event: 'graph.resetView' },
     },
-    {
-      tag: 'button',
-      label: 'Zoom in',
-      variant: 'ghost',
-      onClick: { kind: 'emit', event: 'graph.zoomIn' },
-    },
-    {
-      tag: 'button',
-      label: 'Zoom out',
-      variant: 'ghost',
-      onClick: { kind: 'emit', event: 'graph.zoomOut' },
-    },
-    {
-      tag: 'button',
-      label: 'Pan left',
-      variant: 'ghost',
-      onClick: { kind: 'emit', event: 'graph.panLeft' },
-    },
-    {
-      tag: 'button',
-      label: 'Pan right',
-      variant: 'ghost',
-      onClick: { kind: 'emit', event: 'graph.panRight' },
-    },
-    {
-      tag: 'button',
-      label: 'Pan up',
-      variant: 'ghost',
-      onClick: { kind: 'emit', event: 'graph.panUp' },
-    },
-    {
-      tag: 'button',
-      label: 'Pan down',
-      variant: 'ghost',
-      onClick: { kind: 'emit', event: 'graph.panDown' },
-    },
   ]
+  if (state.pinned.size > 0) {
+    headerChildren.push({
+      tag: 'button',
+      label: `Release pinned (${state.pinned.size})`,
+      variant: 'ghost',
+      onClick: { kind: 'emit', event: 'graph.releasePinned' },
+    })
+  }
 
-  // Persistent "Selected" row. Note nodes get a clickable link that
-  // opens the note through the wikilink:// intercept; tag nodes are
-  // not notes, so they show a plain label.
+  // Persistent "Selected" row. A click (not a drag) on a note node sets
+  // the picked id; the row then shows a wikilink link that opens the
+  // note through the host's wikilink:// intercept. Tag nodes are not
+  // notes, so they show a plain label.
   const pickedRow = (() => {
     if (!state.pickedNodeId) {
-      return { tag: 'text', value: 'Selected: (click a node)' }
+      return { tag: 'text', value: 'Selected: (click a node to open it)' }
     }
     const picked = nodes.find((n) => n.id === state.pickedNodeId)
     if (!picked) {
@@ -1142,16 +1433,24 @@ function renderFullscreen(ctx) {
       pickedRow,
       {
         tag: 'svg',
+        // Folding the epoch into the id makes the host remount the svg
+        // (and re-init its pan/zoom baseW) on a hard viewport reset.
+        id: 'graph-canvas-' + state.viewportEpoch,
         width: LAYOUT_WIDTH,
         height: LAYOUT_HEIGHT,
-        viewBox: [vx, vy, vw, vh],
+        viewBox,
+        // Host owns pan (drag the background) + wheel zoom; it emits one
+        // `surface.transform` settle event we persist.
+        panZoom: 'host',
         children: [
           {
+            // Generous background so panning/zooming still shows a
+            // backdrop; it does not track the live viewBox.
             tag: 'rect',
-            x: vx,
-            y: vy,
-            width: vw,
-            height: vh,
+            x: -LAYOUT_WIDTH,
+            y: -LAYOUT_HEIGHT,
+            width: LAYOUT_WIDTH * 3,
+            height: LAYOUT_HEIGHT * 3,
             fill: '#0f172a',
           },
           ...lineNodes,
@@ -1169,6 +1468,16 @@ function renderFullscreen(ctx) {
  * drop orphans -> simulate.
  */
 async function rebuildLayout(ctx) {
+  // A fresh layout invalidates the live drag state: positions, pins,
+  // and hover all key off the previous node set.
+  stopSimLoop()
+  state.sim = null
+  state.simIndex = null
+  state.pinned.clear()
+  state.dragId = null
+  state.dragStart = null
+  state.hoveredId = null
+
   const t0 = nowMs()
   const notes = await loadNotesSnapshot(ctx)
   const notesById = new Map(notes.map((n) => [n.id, n]))
@@ -1210,17 +1519,244 @@ async function rebuildAndRender(ctx) {
   renderFullscreen(ctx)
 }
 
+// ----------------------- Host-owned viewport (G2) ----------------------
+
+/** Reset the viewport to fit + force the host svg to remount so its
+ *  internal pan/zoom state (baseW) re-inits from the fresh viewBox. */
+function resetViewport(ctx) {
+  state.viewport = { ...DEFAULT_VIEWPORT }
+  state.viewportBase = { w: DEFAULT_VIEWPORT.w, h: DEFAULT_VIEWPORT.h }
+  state.viewportEpoch++
+  persist(ctx, SETTING_KEYS.viewport, state.viewport)
+}
+
+// --------------------------- Node drag (G3) ----------------------------
+//
+// A press on a node pins it under the pointer. A background reheat loop
+// runs one or two `simulationStep`s per frame keeping pinned nodes
+// fixed, and streams ONLY the moved coordinates through the L4 patch
+// channel (`ctx.patchSvgPositions`) so a 500-node drag never re-emits
+// the whole SVG tree. The worker has no requestAnimationFrame, so the
+// loop is driven by setTimeout at ~60fps.
+
+const SIM_FRAME_MS = 16
+const SIM_STEPS_PER_FRAME = 2
+const SIM_MAX_FRAMES = 600 // hard stop (~10s) so a loop can never run away
+const PATCH_EPSILON = 0.05 // px move below which a node is not re-patched
+
+/** Build the live sim array from the cached layout positions, marking
+ *  currently-pinned nodes fixed. Idempotent: keeps an existing sim. */
+function ensureSim() {
+  if (!state.layout) return
+  if (state.sim) return
+  state.sim = state.layout.positions.map((p) => ({
+    id: p.id,
+    x: p.x,
+    y: p.y,
+    vx: 0,
+    vy: 0,
+    fixed: state.pinned.has(p.id),
+  }))
+  state.simIndex = new Map(state.sim.map((p) => [p.id, p]))
+}
+
+function stopSimLoop() {
+  if (state.simTimer !== null) {
+    clearTimeout(state.simTimer)
+    state.simTimer = null
+  }
+  state.simFrames = 0
+}
+
+/** Start (or keep) the reheat loop. No-op if already running. */
+function startSimLoop() {
+  if (state.simTimer !== null) return
+  state.simFrames = 0
+  const tick = () => {
+    state.simTimer = null
+    const ctx = state.ctx
+    if (!state.fullscreenMounted || !state.sim || !state.layout || !ctx) return
+
+    for (let i = 0; i < SIM_STEPS_PER_FRAME; i++) {
+      simulationStep(state.sim, state.layout.edges, { forces: state.forces })
+    }
+
+    // Sync sim -> cached positions (so a later re-render stays put) and
+    // collect a patch for every node that actually moved.
+    const posById = new Map(state.layout.positions.map((p) => [p.id, p]))
+    const patches = []
+    for (const p of state.sim) {
+      const lp = posById.get(p.id)
+      if (!lp) continue
+      const moved =
+        Math.abs(lp.x - p.x) > PATCH_EPSILON ||
+        Math.abs(lp.y - p.y) > PATCH_EPSILON ||
+        state.dragId === p.id
+      lp.x = p.x
+      lp.y = p.y
+      if (moved) patches.push({ id: p.id, x: p.x, y: p.y })
+    }
+    if (patches.length && typeof ctx.patchSvgPositions === 'function') {
+      try {
+        ctx.patchSvgPositions({ viewId: VIEW_ID, patches })
+      } catch {
+        // Patch channel best-effort; a dropped frame is harmless.
+      }
+    }
+
+    state.simFrames++
+    const keepGoing =
+      state.dragId !== null ||
+      (!simIsSettled(state.sim) && state.simFrames < SIM_MAX_FRAMES)
+    if (keepGoing) {
+      state.simTimer = setTimeout(tick, SIM_FRAME_MS)
+    }
+  }
+  state.simTimer = setTimeout(tick, SIM_FRAME_MS)
+}
+
+/** Stop the loop if nothing is being dragged and the layout has come to
+ *  rest, leaving the cached positions final. */
+function maybeStopSimLoop() {
+  if (
+    state.simTimer !== null &&
+    state.dragId === null &&
+    (!state.sim || simIsSettled(state.sim))
+  ) {
+    stopSimLoop()
+  }
+}
+
+/** Unpin a node and reheat so it can settle back into the layout. */
+function unpin(id) {
+  state.pinned.delete(id)
+  const node = state.simIndex?.get(id)
+  if (node) node.fixed = false
+  if (state.sim) startSimLoop()
+}
+
+/** Read a finite coordinate off a pointer payload, or null. */
+function payloadCoord(payload, key) {
+  const v = Number(payload?.[key])
+  return Number.isFinite(v) ? v : null
+}
+
+/** Pointerdown on a node: tentatively pin it under the pointer and
+ *  record the gesture start so pointerup can tell a click from a drag. */
+function handleNodeDown(payload) {
+  if (!state.layout) return
+  const id = String(payload?.target ?? '')
+  if (!id) return
+  ensureSim()
+  const node = state.simIndex?.get(id)
+  const px = payloadCoord(payload, 'x')
+  const py = payloadCoord(payload, 'y')
+  state.dragId = id
+  state.dragStart = {
+    id,
+    x: px ?? node?.x ?? 0,
+    y: py ?? node?.y ?? 0,
+    t: nowMs(),
+    moved: false,
+    wasPinned: state.pinned.has(id),
+  }
+  // Pin it so the reheat loop holds it still under the pointer.
+  state.pinned.add(id)
+  if (node) {
+    node.fixed = true
+    node.vx = 0
+    node.vy = 0
+    if (px !== null) node.x = px
+    if (py !== null) node.y = py
+  }
+  startSimLoop()
+}
+
+/** Pointermove while dragging: move the pinned node to the pointer. The
+ *  reheat loop streams the position patch + reheats neighbours. */
+function handleNodeMove(payload) {
+  const id = state.dragId
+  if (!id || !state.sim) return
+  const node = state.simIndex?.get(id)
+  if (!node) return
+  const px = payloadCoord(payload, 'x')
+  const py = payloadCoord(payload, 'y')
+  if (px !== null) node.x = px
+  if (py !== null) node.y = py
+  node.fixed = true
+  node.vx = 0
+  node.vy = 0
+  if (state.dragStart && !state.dragStart.moved && px !== null && py !== null) {
+    const dx = px - state.dragStart.x
+    const dy = py - state.dragStart.y
+    if (Math.sqrt(dx * dx + dy * dy) > TAP_MOVE_THRESHOLD) {
+      state.dragStart.moved = true
+    }
+  }
+  startSimLoop()
+}
+
+/**
+ * Pointerup on a node. Distinguishes a click from a drag:
+ *  - Click (small move, short time): if the node was already pinned,
+ *    UNPIN it (Obsidian-style toggle). Otherwise release the tentative
+ *    pin and select it, surfacing the wikilink open affordance.
+ *  - Drag: keep it pinned (Obsidian behaviour); the loop settles the
+ *    neighbours and stops.
+ */
+function handleNodeUp(ctx, payload) {
+  const ds = state.dragStart
+  const id = state.dragId
+  state.dragId = null
+  state.dragStart = null
+  if (!ds || !id) {
+    maybeStopSimLoop()
+    return
+  }
+  const node = state.simIndex?.get(id)
+  const px = payloadCoord(payload, 'x')
+  const py = payloadCoord(payload, 'y')
+  const end = {
+    x: px ?? node?.x ?? ds.x,
+    y: py ?? node?.y ?? ds.y,
+    t: nowMs(),
+  }
+  const tap = isTapGesture({ x: ds.x, y: ds.y, t: ds.t }, end) && !ds.moved
+  if (tap) {
+    if (ds.wasPinned) {
+      // A click on an already-pinned node unpins it.
+      unpin(id)
+    } else {
+      // A click on a free node is an OPEN intent, not a drag: drop the
+      // tentative pin and select it so the open link appears.
+      unpin(id)
+      state.pickedNodeId = id
+    }
+  }
+  // Re-render once so the pin ring + "Release pinned" button (drag) or
+  // the selection/open link (click) reflect the new state. The reheat
+  // loop keeps streaming position patches on top of this.
+  renderFullscreen(ctx)
+  maybeStopSimLoop()
+}
+
 export default {
   id: 'noteser-graph',
   name: 'Graph',
-  version: '0.2.0',
+  version: '0.3.0',
   author: 'Noteser',
   description:
-    'Backlinks and unlinked mentions for the active note in the sidebar, plus a force-directed graph of the vault with local-graph, color groups, filters, force tuning, and tags-as-nodes. Closes issue #71.',
+    'Backlinks and unlinked mentions for the active note in the sidebar, plus an interactive force-directed graph of the vault: drag to pin nodes, wheel to zoom, drag the background to pan, hover to highlight neighbours, with local-graph, color groups, filters, force tuning, and tags-as-nodes. Closes issue #71.',
   permissions: ['vault.read.all', 'vault.events'],
   surfaces: {
     sidebarPanels: [{ id: PANEL_ID, title: 'Graph', icon: 'link' }],
-    fullscreenViews: [{ id: VIEW_ID, title: 'Note graph' }],
+    fullscreenViews: [
+      {
+        id: VIEW_ID,
+        title: 'Note graph',
+        interaction: { pointer: true, wheel: true, hover: true },
+      },
+    ],
     commands: [
       { id: 'open-graph', title: 'Graph: open global graph' },
       { id: 'recompute', title: 'Graph: recompute layout' },
@@ -1262,35 +1798,59 @@ export default {
             state.sha = null
             state.notes = null
             state.layout = null
-            state.viewport = { x: 0, y: 0, scale: 1 }
+            resetViewport(ctx)
             await rebuildAndRender(ctx)
             return
           case 'graph.resetView':
-            state.viewport = { x: 0, y: 0, scale: 1 }
+            resetViewport(ctx)
             renderFullscreen(ctx)
             return
-          case 'graph.zoomIn':
-            state.viewport.scale = Math.max(0.25, state.viewport.scale * 0.8)
+          case 'surface.transform':
+            // Host-owned pan/zoom settle. The host already applied the
+            // viewBox to the DOM, so we only record + persist the new
+            // viewport; re-rendering here would be redundant (and could
+            // fight the live DOM).
+            if (payload && typeof payload === 'object') {
+              state.viewport = viewportFromTransform(
+                state.viewportBase,
+                payload,
+              )
+              persist(ctx, SETTING_KEYS.viewport, state.viewport)
+            }
+            return
+          case 'graph.nodeDown':
+            handleNodeDown(payload)
+            return
+          case 'graph.nodeMove':
+            handleNodeMove(payload)
+            return
+          case 'graph.nodeUp':
+            handleNodeUp(ctx, payload)
+            return
+          case 'graph.nodeEnter': {
+            // Ignore hover while dragging (the pointer is captured by
+            // the dragged node, so enter/leave on others are noise).
+            if (state.dragId !== null) return
+            const id = String(payload?.target ?? '')
+            if (!id || state.hoveredId === id) return
+            state.hoveredId = id
             renderFullscreen(ctx)
             return
-          case 'graph.zoomOut':
-            state.viewport.scale = Math.min(4, state.viewport.scale * 1.25)
-            renderFullscreen(ctx)
+          }
+          case 'graph.nodeLeave': {
+            if (state.dragId !== null) return
+            const id = String(payload?.target ?? '')
+            // Only clear when leaving the node we believe is hovered, so
+            // a stale enter/leave pair cannot wipe a fresh hover.
+            if (state.hoveredId && (!id || id === state.hoveredId)) {
+              state.hoveredId = null
+              renderFullscreen(ctx)
+            }
             return
-          case 'graph.panLeft':
-            state.viewport.x -= LAYOUT_WIDTH * state.viewport.scale * 0.15
-            renderFullscreen(ctx)
-            return
-          case 'graph.panRight':
-            state.viewport.x += LAYOUT_WIDTH * state.viewport.scale * 0.15
-            renderFullscreen(ctx)
-            return
-          case 'graph.panUp':
-            state.viewport.y -= LAYOUT_HEIGHT * state.viewport.scale * 0.15
-            renderFullscreen(ctx)
-            return
-          case 'graph.panDown':
-            state.viewport.y += LAYOUT_HEIGHT * state.viewport.scale * 0.15
+          }
+          case 'graph.releasePinned':
+            if (state.pinned.size === 0) return
+            for (const id of Array.from(state.pinned)) unpin(id)
             renderFullscreen(ctx)
             return
           case 'graph.setMode': {
@@ -1359,14 +1919,6 @@ export default {
             persist(ctx, SETTING_KEYS.forces, state.forces)
             await rebuildAndRender(ctx)
             return
-          case 'graph.pickNode': {
-            if (!payload || typeof payload !== 'object') return
-            const id = String(payload.id ?? '')
-            if (!id) return
-            state.pickedNodeId = id
-            renderFullscreen(ctx)
-            return
-          }
           default:
             return
         }
@@ -1419,14 +1971,26 @@ export default {
     if (viewId !== VIEW_ID) return
     state.fullscreenMounted = true
     state.ctx = ctx
-    state.viewport = { x: 0, y: 0, scale: 1 }
+    // Restore the persisted viewport (loaded in onActivate). The svg
+    // mounts with this box, so the host's baseW equals viewportBase.w —
+    // keep them in sync so the first `surface.transform` round-trips.
+    state.viewport = clampViewport(state.viewport)
+    state.viewportBase = { w: state.viewport.w, h: state.viewport.h }
+    state.viewportEpoch++
     renderFullscreen(ctx)
     await rebuildAndRender(ctx)
   },
 
   onFullscreenUnmount(viewId) {
     if (viewId !== VIEW_ID) return
+    stopSimLoop()
     state.fullscreenMounted = false
     state.pickedNodeId = null
+    state.sim = null
+    state.simIndex = null
+    state.pinned.clear()
+    state.dragId = null
+    state.dragStart = null
+    state.hoveredId = null
   },
 }

--- a/public/plugins/noteser-graph/manifest.json
+++ b/public/plugins/noteser-graph/manifest.json
@@ -1,16 +1,20 @@
 {
   "id": "noteser-graph",
   "name": "Graph",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Noteser",
-  "description": "Backlinks and unlinked mentions for the active note in the sidebar, plus a force-directed graph of the vault with local-graph, color groups, filters, force tuning, and tags-as-nodes.",
+  "description": "Backlinks and unlinked mentions for the active note in the sidebar, plus an interactive force-directed graph of the vault: drag to pin nodes, wheel to zoom, drag the background to pan, hover to highlight neighbours, with local-graph, color groups, filters, force tuning, and tags-as-nodes.",
   "main": "./main.js",
   "surfaces": {
     "sidebarPanels": [
       { "id": "graph", "title": "Graph", "icon": "link" }
     ],
     "fullscreenViews": [
-      { "id": "graph", "title": "Note graph" }
+      {
+        "id": "graph",
+        "title": "Note graph",
+        "interaction": { "pointer": true, "wheel": true, "hover": true }
+      }
     ],
     "commands": [
       { "id": "open-graph", "title": "Graph: open global graph" },

--- a/src/__tests__/noteserGraphPluginG2G5.test.ts
+++ b/src/__tests__/noteserGraphPluginG2G5.test.ts
@@ -1,0 +1,278 @@
+/**
+ * noteserGraphPluginG2G5.test.ts
+ *
+ * Tests for the pure helpers added in the "G2-G5: interactive"
+ * increment (v0.3.0) of `public/plugins/noteser-graph/main.js`:
+ *   - click-vs-drag threshold logic (G5)
+ *   - pinned-node `fixed`-flag handling in the live simulation step (G3)
+ *   - hover neighbour-set computation (G4)
+ *   - viewport persistence round-trip from `surface.transform` (G2)
+ *
+ * The plugin module is plain JS so TS infers loose types; each export
+ * is re-cast to a test-facing signature for readability.
+ */
+
+import * as pluginModule from '../../public/plugins/noteser-graph/main.js'
+
+interface SimNode {
+  id: string
+  x: number
+  y: number
+  vx: number
+  vy: number
+  fixed?: boolean
+}
+interface Edge {
+  source: string
+  target: string
+}
+interface Pt {
+  x: number
+  y: number
+  t: number
+}
+interface Box {
+  x: number
+  y: number
+  w: number
+  h: number
+}
+
+const isTapGesture = pluginModule.isTapGesture as (
+  start: Pt | null,
+  end: Pt | null,
+  opts?: { moveThreshold?: number; timeThreshold?: number },
+) => boolean
+const TAP_MOVE_THRESHOLD = pluginModule.TAP_MOVE_THRESHOLD as number
+const TAP_TIME_THRESHOLD = pluginModule.TAP_TIME_THRESHOLD as number
+
+const simulationStep = pluginModule.simulationStep as (
+  sim: SimNode[],
+  edges: ReadonlyArray<Edge>,
+  opts?: { forces?: Record<string, number>; width?: number; height?: number },
+) => SimNode[]
+const simIsSettled = pluginModule.simIsSettled as (
+  sim: ReadonlyArray<SimNode>,
+  threshold?: number,
+) => boolean
+
+const hoverNeighbours = pluginModule.hoverNeighbours as (
+  edges: ReadonlyArray<Edge>,
+  hoveredId: string | null,
+) => { nodes: Set<string>; edges: Set<string> }
+const edgeKey = pluginModule.edgeKey as (source: string, target: string) => string
+
+const viewportFromTransform = pluginModule.viewportFromTransform as (
+  base: { w: number; h: number },
+  transform: { x: number; y: number; scale: number },
+) => Box
+const clampViewport = pluginModule.clampViewport as (
+  vp: Partial<Box> | null | undefined,
+) => Box
+const DEFAULT_VIEWPORT = pluginModule.DEFAULT_VIEWPORT as Box
+
+// ─────────────────────────── click vs drag (G5) ────────────────────────────
+
+describe('isTapGesture (G5 click-vs-drag)', () => {
+  it('treats a still, quick press as a click', () => {
+    expect(
+      isTapGesture({ x: 10, y: 10, t: 0 }, { x: 12, y: 11, t: 120 }),
+    ).toBe(true)
+  })
+
+  it('rejects a press that moves beyond the distance threshold', () => {
+    expect(
+      isTapGesture({ x: 10, y: 10, t: 0 }, { x: 40, y: 10, t: 100 }),
+    ).toBe(false)
+  })
+
+  it('rejects a press that is held longer than the time threshold', () => {
+    expect(
+      isTapGesture({ x: 10, y: 10, t: 0 }, { x: 10, y: 10, t: 500 }),
+    ).toBe(false)
+  })
+
+  it('accepts movement exactly at the distance threshold', () => {
+    expect(
+      isTapGesture(
+        { x: 0, y: 0, t: 0 },
+        { x: TAP_MOVE_THRESHOLD, y: 0, t: 10 },
+      ),
+    ).toBe(true)
+  })
+
+  it('accepts a hold exactly at the time threshold', () => {
+    expect(
+      isTapGesture({ x: 0, y: 0, t: 0 }, { x: 0, y: 0, t: TAP_TIME_THRESHOLD }),
+    ).toBe(true)
+  })
+
+  it('honours custom thresholds', () => {
+    expect(
+      isTapGesture({ x: 0, y: 0, t: 0 }, { x: 6, y: 0, t: 10 }, {
+        moveThreshold: 10,
+      }),
+    ).toBe(true)
+    expect(
+      isTapGesture({ x: 0, y: 0, t: 0 }, { x: 6, y: 0, t: 10 }, {
+        moveThreshold: 2,
+      }),
+    ).toBe(false)
+  })
+
+  it('returns false when either endpoint is missing', () => {
+    expect(isTapGesture(null, { x: 0, y: 0, t: 0 })).toBe(false)
+    expect(isTapGesture({ x: 0, y: 0, t: 0 }, null)).toBe(false)
+  })
+})
+
+// ───────────────────── pinned-node simulation step (G3) ─────────────────────
+
+describe('simulationStep (G3 pinned-node handling)', () => {
+  it('never moves a fixed node', () => {
+    const sim: SimNode[] = [
+      { id: 'a', x: 100, y: 100, vx: 0, vy: 0, fixed: true },
+      { id: 'b', x: 110, y: 100, vx: 0, vy: 0 },
+    ]
+    simulationStep(sim, [], { forces: { repel: 1000 } })
+    const a = sim.find((n) => n.id === 'a')!
+    expect(a.x).toBe(100)
+    expect(a.y).toBe(100)
+    expect(a.vx).toBe(0)
+    expect(a.vy).toBe(0)
+  })
+
+  it('moves an unpinned node and lets the fixed node still repel it', () => {
+    const sim: SimNode[] = [
+      { id: 'a', x: 100, y: 100, vx: 0, vy: 0, fixed: true },
+      { id: 'b', x: 110, y: 100, vx: 0, vy: 0 },
+    ]
+    simulationStep(sim, [], { forces: { repel: 1000, center: 0 } })
+    const b = sim.find((n) => n.id === 'b')!
+    // The pinned node a repels b to the right (away from a at x=100).
+    expect(b.x).toBeGreaterThan(110)
+    expect(b.y).toBeCloseTo(100, 5)
+  })
+
+  it('reports settled only when every unpinned node is near rest', () => {
+    const moving: SimNode[] = [{ id: 'a', x: 0, y: 0, vx: 5, vy: 0 }]
+    expect(simIsSettled(moving)).toBe(false)
+    const resting: SimNode[] = [{ id: 'a', x: 0, y: 0, vx: 0.01, vy: 0.01 }]
+    expect(simIsSettled(resting)).toBe(true)
+  })
+
+  it('ignores fast-moving fixed nodes when deciding settledness', () => {
+    // A fixed node carrying stale velocity must not keep the loop alive.
+    const sim: SimNode[] = [
+      { id: 'a', x: 0, y: 0, vx: 99, vy: 99, fixed: true },
+      { id: 'b', x: 0, y: 0, vx: 0, vy: 0 },
+    ]
+    expect(simIsSettled(sim)).toBe(true)
+  })
+})
+
+// ───────────────────────── hover neighbour set (G4) ─────────────────────────
+
+describe('hoverNeighbours (G4 hover highlight)', () => {
+  const edges: Edge[] = [
+    { source: 'a', target: 'b' },
+    { source: 'c', target: 'a' },
+    { source: 'b', target: 'd' },
+  ]
+
+  it('includes the hovered node and its 1-hop neighbours (undirected)', () => {
+    const { nodes } = hoverNeighbours(edges, 'a')
+    expect([...nodes].sort()).toEqual(['a', 'b', 'c'])
+    // d is two hops away, so it is NOT a neighbour of a.
+    expect(nodes.has('d')).toBe(false)
+  })
+
+  it('marks exactly the edges incident to the hovered node', () => {
+    const { edges: incident } = hoverNeighbours(edges, 'a')
+    expect(incident.has(edgeKey('a', 'b'))).toBe(true)
+    expect(incident.has(edgeKey('c', 'a'))).toBe(true)
+    // b->d does not touch a.
+    expect(incident.has(edgeKey('b', 'd'))).toBe(false)
+    expect(incident.size).toBe(2)
+  })
+
+  it('returns empty sets when nothing is hovered', () => {
+    const { nodes, edges: incident } = hoverNeighbours(edges, null)
+    expect(nodes.size).toBe(0)
+    expect(incident.size).toBe(0)
+  })
+
+  it('keys incident edges in the original edge orientation', () => {
+    // c->a is stored source=c, target=a; the key must match that order.
+    const { edges: incident } = hoverNeighbours(edges, 'a')
+    expect(incident.has(edgeKey('c', 'a'))).toBe(true)
+    expect(incident.has(edgeKey('a', 'c'))).toBe(false)
+  })
+})
+
+// ─────────────────────── viewport round-trip (G2) ──────────────────────────
+
+describe('viewportFromTransform (G2 viewport persistence)', () => {
+  const base = { w: DEFAULT_VIEWPORT.w, h: DEFAULT_VIEWPORT.h }
+
+  it('round-trips a no-op settle (scale 1) back to the base box', () => {
+    const vp = viewportFromTransform(base, { x: 0, y: 0, scale: 1 })
+    expect(vp).toEqual({
+      x: 0,
+      y: 0,
+      w: DEFAULT_VIEWPORT.w,
+      h: DEFAULT_VIEWPORT.h,
+    })
+  })
+
+  it('halves the box when zoomed in 2x and carries the pan offset', () => {
+    const vp = viewportFromTransform(base, { x: 100, y: 50, scale: 2 })
+    expect(vp.x).toBe(100)
+    expect(vp.y).toBe(50)
+    expect(vp.w).toBeCloseTo(DEFAULT_VIEWPORT.w / 2, 5)
+    expect(vp.h).toBeCloseTo(DEFAULT_VIEWPORT.h / 2, 5)
+  })
+
+  it('grows the box when zoomed out (scale < 1)', () => {
+    const vp = viewportFromTransform(base, { x: -10, y: -20, scale: 0.5 })
+    expect(vp.w).toBeCloseTo(DEFAULT_VIEWPORT.w * 2, 5)
+    expect(vp.h).toBeCloseTo(DEFAULT_VIEWPORT.h * 2, 5)
+  })
+
+  it('falls back to scale 1 on a non-finite / non-positive scale', () => {
+    const vp = viewportFromTransform(base, {
+      x: 0,
+      y: 0,
+      scale: Number.NaN,
+    })
+    expect(vp.w).toBe(DEFAULT_VIEWPORT.w)
+    const vp2 = viewportFromTransform(base, { x: 0, y: 0, scale: 0 })
+    expect(vp2.w).toBe(DEFAULT_VIEWPORT.w)
+  })
+})
+
+describe('clampViewport (G2 sanitisation)', () => {
+  it('defaults non-finite fields to the base viewport', () => {
+    const vp = clampViewport({
+      x: Number.NaN,
+      y: Number.POSITIVE_INFINITY,
+      w: Number.NaN,
+      h: undefined as unknown as number,
+    })
+    expect(vp.x).toBe(DEFAULT_VIEWPORT.x)
+    expect(vp.y).toBe(DEFAULT_VIEWPORT.y)
+    expect(vp.w).toBe(DEFAULT_VIEWPORT.w)
+    expect(vp.h).toBe(DEFAULT_VIEWPORT.h)
+  })
+
+  it('clamps an absurdly small width up to the floor', () => {
+    const vp = clampViewport({ x: 0, y: 0, w: 0.0001, h: 0.0001 })
+    expect(vp.w).toBeGreaterThan(0)
+    expect(vp.w).toBeCloseTo(DEFAULT_VIEWPORT.w / 50, 5)
+  })
+
+  it('passes a sane box through unchanged', () => {
+    const vp = clampViewport({ x: 5, y: 6, w: 200, h: 150 })
+    expect(vp).toEqual({ x: 5, y: 6, w: 200, h: 150 })
+  })
+})


### PR DESCRIPTION
Makes the `noteser-graph` fullscreen view feel like Obsidian by consuming the v1.3 interaction surface (L1-L4). Only `public/plugins/noteser-graph/` and a new test under `src/__tests__/` are touched; `src/plugins` (the platform) is untouched.

## Behaviours

**G2 — wheel zoom + drag pan.** The svg declares `panZoom: 'host'`, so the host owns the viewBox: wheel-zoom and dragging the background pan instantly with no worker round-trip. On settle the host emits one `surface.transform` `{x,y,scale}` event; the plugin reconstructs the viewport box (`viewportFromTransform`) and persists it under `g2.viewport`, so the viewport survives a reload. The nine manual zoom/pan buttons are deleted; a single **Reset view** button remains (net code removal).

**G3 — node drag (pin/unpin).** `onPointerDown` pins a node (the host auto-captures the pointer because the circle declares both down + move); `onPointerMove` drags it to `payload.{x,y}` (already svg user-space). The simulation reheats around pinned nodes (`simulationStep` skips integration for `fixed` nodes) and streams **only the moved coordinates** via `ctx.patchSvgPositions({ viewId, patches })` each frame (L4 patch channel) — no full-tree re-emit, so a 500-node drag holds 60fps. A pinned node keeps a distinct ring; click a pinned node to unpin, or use **Release pinned**.

**G4 — hover highlight.** `onPointerEnter`/`onPointerLeave` dim every non-neighbour circle and brighten/thicken the hovered node's edges (`hoverNeighbours`). Recolor only — no re-layout, no patch channel.

**G5 — click vs drag.** A press that releases within ~4px and ~250ms (`isTapGesture`) is a click: a click on a free note node selects it and surfaces the open link; a click on a pinned node unpins it. A real drag never opens the note.

## Platform events used
- L1 pointer: `onPointerDown/Move/Up` + automatic pointer capture (G3, G5)
- L2 wheel + host pan/zoom: `VNodeSvg.panZoom:'host'` + the `surface.transform` settle event (G2)
- L3 hover: `onPointerEnter/Leave` (G4)
- L4 patch channel: `ctx.patchSvgPositions(...)` + `line.sourceId`/`targetId` + `circle.id` (G3)

## Known platform limitation
`PluginCtx` exposes no `ctx.openNote(id)` and SVG children cannot be a `link` VNode, so a true single-click *programmatic* open is not possible. G5 ships as click-vs-drag disambiguation that surfaces the existing `wikilink://` open link on a genuine click. The existing wikilink open behaviour still works. Closing this fully would need a new `ctx.openNote` host hook (intentionally not added here — the platform is done).

## Preserved
All G1 features (local graph, color groups, filters, force tuning, tags-as-nodes) and the sidebar **backlinks** panel are unchanged. Manifest bumped to **v0.3.0** with `interaction: { pointer, wheel, hover }` on the fullscreen view.

## Tests / verify
- New pure-helper tests in `src/__tests__/noteserGraphPluginG2G5.test.ts`: click-vs-drag threshold, pinned-node `fixed`-flag in the sim step, hover neighbour set, viewport round-trip.
- `npm run lint` clean, `npx tsc --noEmit` zero errors, `npm test -- --ci` green (225 suites / 2891 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)