### PR TITLE
fix: resolve 7 code-scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Lint · Typecheck · Test · Build

--- a/public/plugins/noteser-properties/main.js
+++ b/public/plugins/noteser-properties/main.js
@@ -199,7 +199,7 @@ function tableToMarkdown(columns, rows) {
       r.folderPath || '',
       ...columns.map((c) => {
         const v = r.frontmatter ? r.frontmatter[c.key] : undefined
-        return valueToText(v).replace(/\|/g, '\\|')
+        return valueToText(v).replace(/\\/g, '\\\\').replace(/\|/g, '\\|')
       }),
     ]
     lines.push(`| ${cells.join(' | ')} |`)

--- a/src/__tests__/settingsModal.test.tsx
+++ b/src/__tests__/settingsModal.test.tsx
@@ -82,7 +82,7 @@ describe('SettingsModal — 2-pane layout', () => {
     fireEvent.click(screen.getByTestId('settings-cat-about'))
     const links = screen.getAllByRole('link')
     expect(links.some(a => a.getAttribute('href') === 'https://thetechjon.com')).toBe(true)
-    expect(links.some(a => a.getAttribute('href')?.includes('github.com'))).toBe(true)
+    expect(links.some(a => a.getAttribute('href') === 'https://github.com/ipapakonstantinou/noteser')).toBe(true)
   })
 
   test('returns null when modal is closed', () => {

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -45,7 +45,7 @@ export async function POST(request: Request) {
   }
 
   const email = (body.email ?? '').trim().toLowerCase()
-  if (!email || !EMAIL_RE.test(email) || email.length > 254) {
+  if (!email || email.length > 254 || !EMAIL_RE.test(email)) {
     return NextResponse.json({ error: 'invalid_email', message: 'That does not look like a valid email address.' }, { status: 400 })
   }
 

--- a/src/plugins/propertiesPluginLogic.ts
+++ b/src/plugins/propertiesPluginLogic.ts
@@ -198,7 +198,7 @@ export function tableToMarkdown(
       r.folderPath || '',
       ...columns.map((c) => {
         const v = r.frontmatter ? r.frontmatter[c.key] : undefined
-        return valueToText(v).replace(/\|/g, '\\|')
+        return valueToText(v).replace(/\\/g, '\\\\').replace(/\|/g, '\\|')
       }),
     ]
     lines.push(`| ${cells.join(' | ')} |`)

--- a/src/utils/embeds.ts
+++ b/src/utils/embeds.ts
@@ -125,7 +125,7 @@ function formatEmbed(title: string, body: string): string {
 }
 
 function escapeMd(s: string): string {
-  return s.replace(/[`*_]/g, '\\$&')
+  return s.replace(/[\\`*_]/g, '\\$&')
 }
 
 // Format an attachment path as a markdown image destination. CommonMark only


### PR DESCRIPTION
Closes all 7 open GitHub code-scanning alerts.

## Changes
- **ci.yml** (#1, #2) — added `permissions: contents: read` least-privilege block.
- **subscribe/route.ts** (#3, ReDoS) — length guard now runs before the email regex.
- **embeds.ts** (#5) — `escapeMd` escapes backslash first.
- **propertiesPluginLogic.ts** (#6) — escape backslash before pipe.
- **public/plugins/noteser-properties/main.js** (#4) — same fix applied manually (no automated build regenerates this file).
- **settingsModal.test.tsx** (#7, false-positive) — assert exact GitHub href instead of `.includes('github.com')`.

## Validation
- lint ✅ · typecheck ✅ · unit tests ✅ (2982 passed, 0 failures)
- Build / Playwright e2e left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)