### PR TITLE
perf(editor): stop blocking full-doc parse on note open

### DIFF
--- a/src/components/editor/foldableHeadings.ts
+++ b/src/components/editor/foldableHeadings.ts
@@ -4,7 +4,6 @@ import {
   foldGutter,
   codeFolding,
   syntaxTree,
-  ensureSyntaxTree,
 } from '@codemirror/language'
 import type { EditorState } from '@codemirror/state'
 import type { Tree } from '@lezer/common'
@@ -45,10 +44,11 @@ interface HeadingInfo {
 const headingCache = new WeakMap<Tree, HeadingInfo[]>()
 
 function resolveTree(state: EditorState): Tree {
-  // Force a full parse so folding works for the whole document (and in headless
-  // test states with no view driving incremental parsing). Falls back to the
-  // partial tree if the parse times out on a very large doc.
-  return ensureSyntaxTree(state, state.doc.length, 5000) ?? syntaxTree(state)
+  // Use the non-blocking parsed tree (same as the other live-preview
+  // extensions). The fold gutter only queries visible lines, so a forced
+  // full-document parse on every per-note editor remount is unnecessary and
+  // caused a ~1s stall on each note switch.
+  return syntaxTree(state)
 }
 
 function collectHeadings(state: EditorState): HeadingInfo[] {


### PR DESCRIPTION
## Root cause

Every note switch took ~1s. The editor is keyed per-note, so it fully remounts on each switch. `src/components/editor/foldableHeadings.ts` resolved the syntax tree with `ensureSyntaxTree(state, state.doc.length, 5000)`, which forces a **synchronous, blocking, full-document lezer parse** (up to a 5s budget) at mount time — stalling the UI on each note open.

## Fix

One-line change in `resolveTree`: use the non-blocking `syntaxTree(state)` instead, matching every other live-preview extension in the codebase. The fold gutter only ever queries visible lines, so the forced full-doc parse was unnecessary. The now-unused `ensureSyntaxTree` import was removed (it had no other reference in the file).

## Checks

- `npm run lint` — pass
- `npm run typecheck` — pass
- `npm test -- --ci` — 3017 passed / 17 skipped, all 9 `foldableHeadings` tests green (they run on headless EditorState/EditorView and resolve fine via `syntaxTree`)

Build and Playwright e2e skipped.

## Verify

The perf win should be confirmed by switching between notes on the Vercel preview — note open should no longer stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)