### PR TITLE
fix(plugins): yield to a macrotask between vault snapshot chunks

### DIFF
--- a/src/plugins/vaultSnapshot.ts
+++ b/src/plugins/vaultSnapshot.ts
@@ -24,6 +24,7 @@
 import { useNoteStore } from '@/stores/noteStore'
 import { useFolderStore } from '@/stores/folderStore'
 import { parseFrontmatter } from '@/utils/frontmatter'
+import { yieldToMain } from '@/utils/bootTrace'
 import type { Note, Folder } from '@/types'
 import type { NoteWithBodyWire } from './protocol'
 
@@ -155,10 +156,12 @@ export async function streamVaultSnapshot(
     chunkIndex++
     const slice = all.slice(i, i + chunkSize)
     await opts.onChunk(slice, chunkIndex)
-    // Cooperative yield. queueMicrotask is enough — the worker
-    // postMessage queued before the next iteration also yields the
-    // main thread macrotask boundary.
-    await new Promise<void>((resolve) => queueMicrotask(resolve))
+    // Cooperative yield to a MACROTASK boundary so the host main thread
+    // can repaint between chunks. queueMicrotask is NOT enough — the
+    // microtask queue drains before any rendering, so the whole loop
+    // would run as one blocking task. yieldToMain uses scheduler.postTask
+    // (or a 0ms timeout) — a real macrotask yield.
+    await yieldToMain()
   }
   await opts.onEnd?.()
 }


### PR DESCRIPTION
## What changed

`streamVaultSnapshot` yielded between chunks with `queueMicrotask`. The
microtask queue drains before the browser gets a chance to paint, so the
entire chunk loop effectively ran as a single blocking task on the host
main thread. Switched to the existing `yieldToMain()` helper
(`scheduler.postTask` with a `0ms`-timeout fallback) — a real macrotask
boundary — so the UI can repaint between chunks.

## Why

On large vaults the snapshot stream froze the host UI until the loop
finished. Yielding to a macrotask keeps the app responsive while the
snapshot streams to plugins.

## How it was tested

- [x] `npm run lint`
- [x] `npm run typecheck` (no errors introduced by this change)
- [x] `npm test` — `vaultSnapshotCache`, `syncPullWritesSnapshot`, `largeVaultPerf` pass
- [x] `npm run build`
- [ ] Sync change? n/a
- [ ] UI change? n/a (behavioral perf fix, no visual change)

## Notes

Single-file change (`src/plugins/vaultSnapshot.ts`, +7/-4). Reuses the
already-present `yieldToMain()` from `@/utils/bootTrace`.