### PR TITLE
fix(search): stop redundant setState cascade in semantic-search effect

### DIFF
--- a/src/components/modals/SearchModal.tsx
+++ b/src/components/modals/SearchModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { MagnifyingGlassIcon, DocumentTextIcon, SparklesIcon } from '@heroicons/react/24/outline'
 import { useUIStore, useNoteStore, useFolderStore, useWorkspaceStore, useSettingsStore } from '@/stores'
 import { searchNotes, getMatchSnippet } from '@/utils/search'
@@ -53,22 +53,31 @@ export const SearchModal = () => {
     return searchNotes(activeNotes, fuzzyDebounced).slice(0, 10)
   }, [activeNotes, fuzzyDebounced])
 
+  // Clear semantic state WITHOUT scheduling a re-render when it's already
+  // clear. Functional updaters that return the same reference are a no-op in
+  // React, so this can run on every effect pass (the effect re-fires whenever
+  // `activeNotes` changes) without feeding an update loop. A plain
+  // setSemanticResults([]) allocates a fresh array each call, which React
+  // treats as a change — during a large note influx that cascade tripped
+  // "Maximum update depth exceeded".
+  const resetSemanticState = useCallback(() => {
+    setSemanticResults(prev => (prev.length ? [] : prev))
+    setSemanticError(prev => (prev === null ? prev : null))
+    setSemanticPending(prev => (prev ? false : prev))
+  }, [])
+
   // Run semantic search when in semantic mode + debounced query changes.
   // Each call: embed the query, cosine-rank against every cached note
   // embedding, surface the top 10. Falls back to fuzzy results when
   // the embed call fails (network / quota).
   useEffect(() => {
     if (mode !== 'semantic' || !semanticAvailable) {
-      setSemanticResults([])
-      setSemanticError(null)
-      setSemanticPending(false)
+      resetSemanticState()
       return
     }
     const query = semanticDebounced.trim()
     if (!query) {
-      setSemanticResults([])
-      setSemanticError(null)
-      setSemanticPending(false)
+      resetSemanticState()
       return
     }
     let cancelled = false
@@ -116,7 +125,7 @@ export const SearchModal = () => {
       }
     })()
     return () => { cancelled = true }
-  }, [mode, semanticDebounced, semanticAvailable, activeNotes])
+  }, [mode, semanticDebounced, semanticAvailable, activeNotes, resetSemanticState])
 
   // Recent notes shown when the query box is empty (Obsidian quick-switcher /
   // VS Code Ctrl+P style). Resolve the MRU note-id list against the ACTIVE


### PR DESCRIPTION
## What changed

The semantic-search effect (keyed on `activeNotes`) called
`setSemanticResults([])` — a fresh array each pass — plus two more
`setState` calls in its early-return branch. The resets now go through
`resetSemanticState()`, which uses functional updaters that return the
same reference when state is already clear, making the reset a no-op in
React.

## Why

During a large note influx `activeNotes` changes in rapid batches,
re-firing the effect. The always-fresh-array resets fed a re-render
cascade that could hit `Maximum update depth exceeded`. Returning stable
references breaks the cascade.

## How it was tested

- [x] `npm run lint`
- [x] `npm run typecheck` (clean)
- [x] `npm test` — `semanticSearch`, `settingsSearch`: 17 tests pass
- [x] `npm run build` (verified on a sibling branch off the same `dev` base)
- [ ] Sync change? n/a
- [ ] UI change? No visual change.

## Notes

Single-file change (`src/components/modals/SearchModal.tsx`).