### PR TITLE
fix(editor): per-view ordered-list renumber guard

### DIFF
--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -369,10 +369,13 @@ function moveLineThenRenumber(base: Command): Command {
 // AND the change inserted or deleted a newline (the operations that shift item
 // counts); pure in-line typing is left alone for performance.
 const ORDERED_LINE_PROBE = /(^|\n)\s*\d+\.\s/
-let renumberInFlight = false
+// Per-view guard. A single module-level boolean would be shared by every
+// editor instance, so in a split-pane layout one pane's in-flight renumber
+// would suppress another pane's. Key the flag on the EditorView instead.
+const renumberInFlight = new WeakMap<EditorView, boolean>()
 const renumberOnEdit = EditorView.updateListener.of((update) => {
   if (!update.docChanged) return
-  if (renumberInFlight) return
+  if (renumberInFlight.get(update.view)) return
   if (update.view.composing) return
 
   let touchedNewline = false
@@ -403,14 +406,14 @@ const renumberOnEdit = EditorView.updateListener.of((update) => {
   if (!touchedNewline && !touchedOrderedLineStart) return
   if (!ORDERED_LINE_PROBE.test(update.state.doc.toString())) return
 
-  renumberInFlight = true
+  renumberInFlight.set(update.view, true)
   // Defer to escape the current update cycle (dispatching inside an
   // updateListener is discouraged).
   queueMicrotask(() => {
     try {
       renumberDocument(update.view)
     } finally {
-      renumberInFlight = false
+      renumberInFlight.delete(update.view)
     }
   })
 })


### PR DESCRIPTION
## What changed

The `renumberInFlight` guard was a module-level boolean shared by every
editor instance, so in a split-pane layout one pane's in-flight renumber
could suppress another pane's, leaving the second list mis-numbered. The
flag is now keyed on the `EditorView` via a `WeakMap`.

## Why

Split-pane editing of ordered lists could leave a list mis-numbered.

## How it was tested

- [x] `npm run lint`
- [x] `npm run typecheck` (clean)
- [x] `npm test` — `editorKeymapCommands`, `listTransforms`, `continueListItemParagraph`, `taskListItem`: 101 pass
- [x] `npm run build`
- [ ] Sync change? n/a
- [ ] UI change? No visual change — corrects numbering behavior in split panes.

## Notes

Single-file change (`src/components/editor/CodeMirrorEditor.tsx`).
Companion PR: `perf(editor): cut redundant doc serialization in ordered-list renumber` builds on this area.