### PR TITLE
fix(security): close SSRF + complete title sanitization (CodeQL)

### DIFF
--- a/src/__tests__/pasteLink.test.ts
+++ b/src/__tests__/pasteLink.test.ts
@@ -62,6 +62,10 @@ describe('sanitizeLinkTitle', () => {
     )
   })
 
+  test('escapes a literal backslash so it cannot pair with bracket escapes', () => {
+    expect(sanitizeLinkTitle('a\\]b')).toBe('a\\\\\\]b')
+  })
+
   test('caps absurdly long titles with an ellipsis', () => {
     const long = 'x'.repeat(500)
     const out = sanitizeLinkTitle(long)
@@ -145,5 +149,9 @@ describe('extractHtmlTitle', () => {
   test('no usable title → null', () => {
     expect(extractHtmlTitle('<body>nothing here</body>')).toBeNull()
     expect(extractHtmlTitle('<title>   </title>')).toBeNull()
+  })
+
+  test('nested inline tags in title text are stripped, no markup survives', () => {
+    expect(extractHtmlTitle('<title>Hello <b>brave</b> <i>World</i></title>')).toBe('Hello brave World')
   })
 })

--- a/src/app/api/link-title/route.ts
+++ b/src/app/api/link-title/route.ts
@@ -1,3 +1,5 @@
+import { lookup } from 'node:dns/promises'
+import { isIP } from 'node:net'
 import { NextResponse } from 'next/server'
 import { checkRateLimit, getClientIp } from '@/utils/rateLimit'
 import { isOriginAllowed } from '@/utils/originAllowlist'
@@ -12,6 +14,10 @@ import { extractHtmlTitle } from '@/utils/pasteLink'
 //   - Per-IP rate limit: 30/min — pasting links is a human-speed action
 //   - http(s) targets only, public hosts only (no localhost / RFC1918 /
 //     link-local / dotless intranet names) to keep SSRF surface closed
+//   - the hostname is resolved via DNS and the request is refused unless
+//     EVERY resolved address is public — this closes the DNS-rebinding /
+//     cloud-metadata (169.254.169.254) hole where a public-looking name
+//     points at internal space
 //   - 5s fetch timeout, response body read capped at 256 KB
 //
 // Auth-walled pages (e.g. a private Jira) return their login page's title
@@ -36,7 +42,7 @@ export async function GET(request: Request) {
   }
 
   const target = new URL(request.url).searchParams.get('url') ?? ''
-  const validated = validateTargetUrl(target)
+  const validated = await validateTargetUrl(target)
   if (!validated.ok) {
     return NextResponse.json({ error: 'invalid_url', message: validated.reason }, { status: 400 })
   }
@@ -74,7 +80,9 @@ export async function GET(request: Request) {
   }
 }
 
-function validateTargetUrl(raw: string): { ok: true; url: URL } | { ok: false; reason: string } {
+async function validateTargetUrl(
+  raw: string,
+): Promise<{ ok: true; url: URL } | { ok: false; reason: string }> {
   if (!raw || raw.length > MAX_URL_CHARS) return { ok: false, reason: 'missing or oversized url' }
   let url: URL
   try {
@@ -85,33 +93,85 @@ function validateTargetUrl(raw: string): { ok: true; url: URL } | { ok: false; r
   if (url.protocol !== 'http:' && url.protocol !== 'https:') {
     return { ok: false, reason: 'only http(s) urls are supported' }
   }
-  if (!isPublicHost(url.hostname)) {
+  if (!isPublicHostname(url.hostname)) {
     return { ok: false, reason: 'host not allowed' }
+  }
+
+  // Resolve the name and refuse unless every resolved address is public.
+  // Without this, a public-looking host can point at 127.0.0.1, RFC1918
+  // space, or the 169.254.169.254 cloud-metadata endpoint (SSRF). We
+  // gate on the resolved IPs the OS will actually connect to.
+  const literal = isIP(url.hostname)
+  if (literal) {
+    // hostname is an IP literal: validate it directly (strip IPv6 brackets).
+    if (!isPublicAddress(stripBrackets(url.hostname))) {
+      return { ok: false, reason: 'host not allowed' }
+    }
+    return { ok: true, url }
+  }
+  let addresses: { address: string }[]
+  try {
+    addresses = await lookup(url.hostname, { all: true })
+  } catch {
+    return { ok: false, reason: 'host could not be resolved' }
+  }
+  if (addresses.length === 0 || !addresses.every((a) => isPublicAddress(a.address))) {
+    return { ok: false, reason: 'host resolves to a non-public address' }
   }
   return { ok: true, url }
 }
 
-// SSRF guard: refuse loopback, RFC1918/link-local literals, IPv6
-// literals, and dotless intranet names. DNS names that *resolve* to
-// private space are not caught here (full protection needs resolver
-// hooks), but on Vercel's serverless network there is no private LAN
-// to reach anyway — this guard is defense in depth.
-function isPublicHost(hostname: string): boolean {
+function stripBrackets(host: string): string {
+  return host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
+}
+
+// Cheap name-based pre-filter (before any DNS): refuse loopback names,
+// link-local / intranet suffixes, and dotless intranet names.
+function isPublicHostname(hostname: string): boolean {
   const host = hostname.toLowerCase()
+  if (isIP(stripBrackets(host))) return true // IP literals handled by isPublicAddress
   if (host === 'localhost' || host.endsWith('.localhost')) return false
   if (host.endsWith('.local') || host.endsWith('.internal')) return false
   if (!host.includes('.')) return false // dotless = intranet name
-  if (host.includes(':') || host.startsWith('[')) return false // IPv6 literal
-  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
-  if (m) {
-    const a = Number(m[1])
-    const b = Number(m[2])
-    if (a === 127 || a === 10 || a === 0) return false
-    if (a === 169 && b === 254) return false
-    if (a === 192 && b === 168) return false
-    if (a === 172 && b >= 16 && b <= 31) return false
-    if (a >= 224) return false // multicast/reserved
-  }
+  return true
+}
+
+// True only for globally-routable unicast addresses. Rejects loopback,
+// RFC1918, link-local (incl. 169.254.169.254 cloud metadata), CGNAT,
+// multicast/reserved, and their IPv6 equivalents (::1, fc00::/7, fe80::/10,
+// IPv4-mapped/-compatible v6).
+function isPublicAddress(ip: string): boolean {
+  const kind = isIP(ip)
+  if (kind === 4) return isPublicIPv4(ip)
+  if (kind === 6) return isPublicIPv6(ip)
+  return false
+}
+
+function isPublicIPv4(ip: string): boolean {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(ip)
+  if (!m) return false
+  const a = Number(m[1])
+  const b = Number(m[2])
+  if ([a, b, Number(m[3]), Number(m[4])].some((n) => n > 255)) return false
+  if (a === 0 || a === 127 || a === 10) return false // this-network, loopback, RFC1918
+  if (a === 169 && b === 254) return false // link-local + cloud metadata
+  if (a === 192 && b === 168) return false // RFC1918
+  if (a === 172 && b >= 16 && b <= 31) return false // RFC1918
+  if (a === 100 && b >= 64 && b <= 127) return false // CGNAT 100.64.0.0/10
+  if (a >= 224) return false // multicast / reserved / broadcast
+  return true
+}
+
+function isPublicIPv6(ip: string): boolean {
+  const host = ip.toLowerCase()
+  if (host === '::' || host === '::1') return false // unspecified, loopback
+  if (host.startsWith('fe80')) return false // link-local fe80::/10
+  if (host.startsWith('fc') || host.startsWith('fd')) return false // unique-local fc00::/7
+  if (host.startsWith('ff')) return false // multicast
+  // IPv4-mapped (::ffff:a.b.c.d) and IPv4-compatible (::a.b.c.d): validate
+  // the embedded IPv4 so a private v4 cannot be smuggled through v6.
+  const embedded = host.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)
+  if (embedded) return isPublicIPv4(embedded[1])
   return true
 }
 

--- a/src/utils/pasteLink.ts
+++ b/src/utils/pasteLink.ts
@@ -36,7 +36,10 @@ export function isBareUrl(text: string): boolean {
 export function sanitizeLinkTitle(raw: string): string {
   const collapsed = raw.replace(/\s+/g, ' ').trim()
   const capped = collapsed.length > MAX_TITLE_CHARS ? `${collapsed.slice(0, MAX_TITLE_CHARS - 1)}…` : collapsed
-  return capped.replace(/([[\]])/g, '\\$1')
+  // Escape the backslash itself FIRST (it is in the class), then the
+  // brackets — otherwise a literal "\" in the title survives unescaped and
+  // can pair with our added escapes to break out of the `[...]` link text.
+  return capped.replace(/[\\[\]]/g, '\\$&')
 }
 
 /** Build a markdown link, sanitizing the title. */
@@ -82,7 +85,17 @@ export function extractHtmlTitle(html: string): string | null {
 }
 
 function stripTags(html: string): string {
-  return html.replace(/<[^>]*>/g, '')
+  // Removing tags once can re-form a tag from the surrounding text
+  // (e.g. "<<a>script>" → "<script>"), so repeat until the string is
+  // stable. The text is only used for the link title, never as HTML, but
+  // we keep stripping complete so no markup survives.
+  let prev: string
+  let out = html
+  do {
+    prev = out
+    out = out.replace(/<[^>]*>/g, '')
+  } while (out !== prev)
+  return out
 }
 
 const NAMED_ENTITIES: Record<string, string> = {


### PR DESCRIPTION
Fixes the 3 open CodeQL code-scanning alerts.

## Alerts addressed

### 1. js/request-forgery — CRITICAL — `src/app/api/link-title/route.ts`
SSRF in the page-title proxy. The previous guard only string-matched the hostname, so a public-looking name resolving to `127.0.0.1`, RFC1918 space, or the cloud-metadata endpoint `169.254.169.254` slipped through (DNS-rebinding class).

Now `validateTargetUrl` is async and:
- Resolves the hostname via `dns.lookup({ all: true })` and refuses the fetch unless **every** resolved address is globally routable.
- Validates IP literals directly (no DNS needed), with full coverage: IPv4 loopback/`0.0.0.0`/RFC1918/`169.254.0.0/16`/CGNAT `100.64.0.0/10`/multicast, and IPv6 `::`/`::1`/`fc00::/7`/`fe80::/10`/multicast plus IPv4-mapped/-compatible forms.

Legitimate public URLs are unaffected.

### 2. js/incomplete-sanitization — HIGH — `src/utils/pasteLink.ts` (`sanitizeLinkTitle`)
The bracket-escaping `.replace` did not escape the backslash itself, so a literal `\` in a page title survived and could pair with the added escapes to break out of `[...]` link text. Now escapes `\`, `[`, `]` in one class (`/[\\[\]]/g`), backslash included.

### 3. js/incomplete-multi-character-sanitization — HIGH — `src/utils/pasteLink.ts` (`stripTags`)
Single-pass tag removal can re-form a tag from surrounding text. `stripTags` now loops until the output is stable.

## Verification
| Command | Result |
| --- | --- |
| `npm run typecheck` | PASS |
| `npm run lint` | PASS |
| `npm test` | PASS (3029 passed, 17 skipped, 3046 total) |
| `npm run build` | PASS (`/api/link-title` compiled) |

Added unit tests for the backslash escape and nested-tag stripping in `src/__tests__/pasteLink.test.ts`.

## For review
- The SSRF fix relies on `node:dns`/`node:net` at request time. On Vercel serverless this is fine; the resolved-IP check adds one DNS lookup per uncached paste (rate-limited to 30/min/IP).
- There is an unavoidable TOCTOU gap: `fetch` re-resolves DNS independently, so a host could in theory return a public IP to our `lookup` then a private IP to `fetch`. Fully closing this needs pinning the connection to the validated IP (custom agent/undici dispatcher), which `fetch` does not expose cleanly. The current change matches the CodeQL-recognized mitigation and is a large improvement over name-only checks; flagging in case you want the IP-pinned version later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)