### PR TITLE
fix(editor): tight Enter continuation for loose task/list lines

### DIFF
--- a/src/__tests__/listTransforms.test.ts
+++ b/src/__tests__/listTransforms.test.ts
@@ -9,6 +9,7 @@ import {
   setCycleState,
   cycleListType,
   renumberOrderedRuns,
+  tightListContinuation,
 } from '@/utils/listTransforms'
 
 describe('splitListLine', () => {
@@ -229,5 +230,43 @@ describe('renumberOrderedRuns', () => {
     const input = ['2. a', '1. b'].join('\n')
     const once = renumberOrderedRuns(input)
     expect(renumberOrderedRuns(once)).toBe(once)
+  })
+})
+
+describe('tightListContinuation (Enter)', () => {
+  it('continues a task line with a single fresh unchecked box (no blank line)', () => {
+    // This is the regression: in a "loose" list the markdown keymap would
+    // produce "\n\n- [ ] "; the continuation we insert must be just "- [ ] ".
+    expect(tightListContinuation('- [ ] Some task')).toBe('- [ ] ')
+  })
+
+  it('continues a checked task as a fresh UNCHECKED box', () => {
+    expect(tightListContinuation('- [x] done')).toBe('- [ ] ')
+  })
+
+  it('preserves indentation for nested items', () => {
+    expect(tightListContinuation('  - [ ] nested')).toBe('  - [ ] ')
+    expect(tightListContinuation('\t- bullet')).toBe('\t- ')
+  })
+
+  it('repeats a bullet marker', () => {
+    expect(tightListContinuation('- foo')).toBe('- ')
+    expect(tightListContinuation('* foo')).toBe('* ')
+  })
+
+  it('advances an ordered item to the next number', () => {
+    expect(tightListContinuation('1. first')).toBe('2. ')
+    expect(tightListContinuation('  7. x')).toBe('  8. ')
+  })
+
+  it('returns null for a plain line (default Enter splits it)', () => {
+    expect(tightListContinuation('just text')).toBeNull()
+    expect(tightListContinuation('')).toBeNull()
+  })
+
+  it('returns null for an empty list item so default Enter exits the list', () => {
+    expect(tightListContinuation('- ')).toBeNull()
+    expect(tightListContinuation('1. ')).toBeNull()
+    expect(tightListContinuation('- [ ] ')).toBeNull()
   })
 })

--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -27,6 +27,7 @@ import { findNoteByTitleOrAlias } from '@/utils/aliases'
 import { toggleTaskLineText, UI_TASK_LINE_REGEX } from '@/utils/tasks'
 import {
   splitListLine,
+  tightListContinuation,
   cycleState,
   nextCycleState,
   setCycleState,
@@ -347,6 +348,35 @@ export const continueListItemParagraph: Command = (view) => {
     scrollIntoView: true,
     userEvent: 'input',
   })
+  return true
+}
+
+// Pressing Enter at the end of a NON-EMPTY list/task line continues the list
+// TIGHTLY: exactly one newline + the next marker. This pre-empts the markdown
+// keymap's `insertNewlineContinueMarkup`, which inserts an extra blank line
+// before each new item when the list is "loose" (its items are separated by
+// blank lines — the shape Jon's daily notes use), turning one Enter on
+// "- [ ] foo" into "\n\n- [ ] " instead of "\n- [ ] ". Returns false for a
+// plain line or an empty list item / mid-line caret so default Enter (split /
+// list-exit) still applies.
+const continueListTight: Command = (view) => {
+  const { state } = view
+  const sel = state.selection.main
+  if (!sel.empty) return false
+  const line = state.doc.lineAt(sel.head)
+  if (sel.head !== line.to) return false // only at the end of the line
+  const cont = tightListContinuation(line.text)
+  if (cont === null) return false
+  const insert = state.lineBreak + cont
+  view.dispatch({
+    changes: { from: sel.head, to: sel.head, insert },
+    selection: { anchor: sel.head + insert.length },
+    userEvent: 'input',
+    scrollIntoView: true,
+  })
+  // Advancing an ordered item can leave the rest of the run mis-numbered;
+  // heal it the same way the other list commands do.
+  if (splitListLine(line.text).kind === 'ordered') renumberDocument(view)
   return true
 }
 
@@ -913,9 +943,14 @@ export function CodeMirrorEditor({
     { key: 'Mod-Alt-[', preventDefault: true, run: foldAll },
     { key: 'Mod-Alt-]', preventDefault: true, run: unfoldAll },
     // Enter on an EMPTY checkbox exits the list. No preventDefault: when it
-    // returns false (any other line) the event falls through to the markdown
-    // keymap's normal Enter continuation.
+    // returns false (any other line) the event falls through to the next Enter
+    // binding / the markdown keymap.
     { key: 'Enter', run: exitEmptyCheckboxOnEnter },
+    // Enter on a NON-EMPTY list/task line continues it tightly (one newline +
+    // marker), pre-empting the markdown keymap's loose-list continuation that
+    // would otherwise insert an extra blank line. Falls through (returns false)
+    // for plain lines and empty list items.
+    { key: 'Enter', run: continueListTight },
     // Shift+Enter inside a list/task line: insert a continuation indent so the
     // next line parses as a paragraph inside the same list item (instead of a
     // top-level paragraph at column 0). Returns false on plain lines so the

--- a/src/utils/listTransforms.ts
+++ b/src/utils/listTransforms.ts
@@ -67,6 +67,29 @@ export function splitListLine(line: string): {
   return { indent, kind: 'plain', check: '', carrier: '', body: rest }
 }
 
+// ── Tight list continuation (Enter) ──────────────────────────────────────
+// Given the CURRENT line, return the text to insert AFTER a single newline to
+// continue the list "tightly" (indent + the next marker), or null when the
+// line should NOT continue: a plain line (default Enter splits it) or an empty
+// list item (default Enter exits the list). Used by the Enter command to
+// bypass @codemirror/lang-markdown's continuation, which inserts an extra
+// blank line before each new item in a "loose" list (items separated by blank
+// lines — the shape Jon's daily notes use), producing "\n\n- [ ] " instead of
+// "\n- [ ] ". Tasks always continue as a fresh unchecked box; ordered items
+// advance the number (the editor renumbers the run afterwards); bullets repeat
+// their marker.
+export function tightListContinuation(line: string): string | null {
+  const parts = splitListLine(line)
+  if (parts.kind === 'plain') return null
+  if (parts.body.trim() === '') return null // empty item → let default exit
+  if (parts.kind === 'task') return `${parts.indent}${parts.carrier}[ ] `
+  if (parts.kind === 'ordered') {
+    const n = parseInt(parts.carrier, 10) // carrier is "N. "
+    return `${parts.indent}${Number.isFinite(n) ? n + 1 : 1}. `
+  }
+  return `${parts.indent}${parts.carrier}` // bullet
+}
+
 // ── Toggle DONE (Mod+L, Obsidian "Toggle checkbox status") ────────────────
 // On a task line: flip [ ] <-> [x]. On a plain line or a bullet/ordered list
 // line: turn it INTO an unchecked task. This is Obsidian's documented Cmd/Ctrl


### PR DESCRIPTION
## Problem
In production, pressing **Enter** at the end of a non-empty task/list item (e.g. `- [ ] foo`) inserts an **extra blank line** before the new item, yielding `\n\n- [ ] ` instead of `\n- [ ] `. Jon hit this in his daily notes.

## Cause
`@codemirror/lang-markdown`'s `insertNewlineContinueMarkup` preserves a list's "tightness": in a **loose** list (items separated by blank lines — exactly how the daily notes are written), it deliberately inserts a blank line before every continuation item. Prod's only Enter binding is `exitEmptyCheckboxOnEnter`, which falls through to that command for non-empty items.

## Fix
- New pure helper `tightListContinuation()` in `listTransforms.ts` — given a list/task line, returns the single-newline continuation marker (or `null` for plain lines / empty items, which keep default Enter = split / list-exit).
- New `continueListTight` Enter command in `CodeMirrorEditor.tsx`, registered in the existing `Prec.highest` keymap so it pre-empts the markdown keymap. Ordered lists renumber afterward via the existing `renumberDocument`.
- `Shift+Enter` paragraph continuation (`continueListItemParagraph`) is unchanged.

## Tests
7 new unit tests for `tightListContinuation` (tight/loose tasks, checked→unchecked, nested indent, bullets, ordered increment, plain + empty fall-through). Full suite green (58/58 in that file), `tsc` and `eslint` clean.

Verified on `dev` before promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)