### PR TITLE
fix(test): deflake publishGistModal edited-description test (babel 7.29.7 timing)

### DIFF
--- a/src/__tests__/publishGistModal.test.tsx
+++ b/src/__tests__/publishGistModal.test.tsx
@@ -217,10 +217,20 @@ describe('PublishGistModal — submit', () => {
     const descInput = screen.getByTestId('publish-gist-description')
     await user.clear(descInput)
     await user.type(descInput, 'Custom desc')
+    // Settle the typing-induced re-renders (and the Modal's rAF-deferred
+    // focus effect they interleave with) *inside* act() before clicking
+    // submit. Without this barrier the per-keystroke setDescription updates
+    // and the focus rAF can flush outside act() under CI load — which on the
+    // slower babel-7.29.7 transpile timing tipped the modal into unmounting
+    // mid-test ('Unable to find publish-gist-submit', body collapsed to
+    // <div/>). Asserting the input value here both forces the stable state
+    // and confirms the edit landed before we submit it.
+    await waitFor(() => expect(descInput).toHaveValue('Custom desc'))
     await user.click(await screen.findByTestId('publish-gist-submit'))
     await waitFor(() => expect(mockPublishGist).toHaveBeenCalledTimes(1))
     expect(mockPublishGist.mock.calls[0][0].description).toBe('Custom desc')
-    // Same act-bleed guard as above.
+    // Same act-bleed guard as above — let the submit handler's
+    // setResult/setPublishing settle before the test ends.
     await screen.findByTestId('publish-gist-url')
   })
 })


### PR DESCRIPTION
## What

Hardens the flaky test `PublishGistModal — submit › passes the edited description to publishGist` so it passes deterministically. **No app/component code changed** — test-only.

## Root cause

PR #200 forced `@babel/core: ^7.29.6`, bumping all `@babel/*` to 7.29.7 and shifting Jest transpile timing. That tipped over a pre-existing fragile test: in CI it began failing deterministically with `Unable to find an element by: [data-testid="publish-gist-submit"]` and a collapsed `<body><div /></body>` — the modal had unmounted mid-test.

The mechanism is act-bleed (same class the earlier `test: deflake publishGistModal submit tests` commit fixed). This test additionally does `user.clear` + `user.type` on the description input before submitting. Each keystroke fires `setDescription` and interleaves with the `Modal`'s `requestAnimationFrame`-deferred focus effect. Under CI load on the slower 7.29.7 transpile, those updates flushed outside `act()` and bled across the test boundary, leaving the modal torn down.

## Fix

Before clicking submit, await `expect(descInput).toHaveValue('Custom desc')`. This forces the typing-induced re-renders and the focus rAF to settle inside `act()`, and confirms the edit landed before submitting it. The end-of-test settle on `publish-gist-url` is kept. The core assertion — `publishGist` receives `description === 'Custom desc'` — is unchanged.

## Verification

- `npm test`: 237 suites / 3034 tests pass (1 suite, 17 tests skipped)
- `npm run lint`: clean
- `npm run typecheck`: clean
- Target test run repeatedly under `CI=true`: stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)