### PR TITLE
fix(collab): deterministic single-seeder to stop daily-note body duplication

### DIFF
--- a/src/__tests__/collabExtension.test.ts
+++ b/src/__tests__/collabExtension.test.ts
@@ -210,3 +210,108 @@ describe('createCollabBinding', () => {
     expect(() => binding.destroy()).not.toThrow()
   })
 })
+
+describe('SEED RACE: concurrent empty clients must not double the body', () => {
+  // A hub that BUFFERS Yjs updates and cross-applies them only on flush(),
+  // mimicking a y-websocket server that broadcasts updates to peers. Buffering
+  // (rather than relaying immediately) is what makes the real race
+  // reproducible: it lets every client seed while still empty BEFORE any
+  // update crosses the wire. An immediate relay would hide the bug.
+  function makeRelay() {
+    const docs: Y.Doc[] = []
+    const buffer: Array<{ from: Y.Doc; update: Uint8Array }> = []
+    const register = (doc: Y.Doc) => {
+      docs.push(doc)
+      doc.on('update', (update: Uint8Array, origin: unknown) => {
+        if (origin === 'relay') return // don't re-broadcast what we just applied
+        buffer.push({ from: doc, update })
+      })
+    }
+    // Deliver everything both ways, repeating until quiescent so the
+    // collapser's trim (itself a new update) also propagates.
+    const flush = () => {
+      let guard = 0
+      while (buffer.length && guard++ < 100) {
+        const batch = buffer.splice(0, buffer.length)
+        for (const { from, update } of batch) {
+          for (const other of docs) {
+            if (other !== from) Y.applyUpdate(other, update, 'relay')
+          }
+        }
+      }
+    }
+    return { register, flush }
+  }
+
+  // Build N bindings on the same room, all seeded with the same body, all
+  // starting empty. Returns the bindings + their providers + the relay.
+  function setup(n: number, body: string) {
+    const relay = makeRelay()
+    const providers: FakeProvider[] = []
+    const factory: ProviderFactory = (url, room, doc) => {
+      relay.register(doc)
+      const p = new FakeProvider(url, room, doc)
+      providers.push(p)
+      return p
+    }
+    const bindings = Array.from({ length: n }, (_, i) =>
+      createCollabBinding({
+        url: 'wss://x',
+        room: 'note-1',
+        initialContent: body,
+        user: null,
+        providerFactory: factory,
+      }),
+    )
+    void bindings // referenced below by the caller
+    return { relay, providers, bindings }
+  }
+
+  test('two empty clients both seeding leaves the body exactly once', () => {
+    const body = '# 2026-06-19\n\n- [ ] morning routine\n'
+    const { relay, providers, bindings } = setup(2, body)
+    const [a, b] = bindings
+
+    // Both reach sync while both are still empty → both seed (the race).
+    providers[0].fireSync(true)
+    providers[1].fireSync(true)
+    // Each has its own single copy locally; nothing has crossed yet.
+    expect(a.ytext.toString()).toBe(body)
+    expect(b.ytext.toString()).toBe(body)
+
+    // Server delivers the updates both ways; the election + collapse settle.
+    relay.flush()
+
+    // The regression guard: body appears ONCE, not body+body.
+    expect(a.ytext.toString()).toBe(body)
+    expect(b.ytext.toString()).toBe(body)
+    bindings.forEach(x => x.destroy())
+  })
+
+  test('three empty clients collapse to a single body', () => {
+    const body = 'shared body\nline 2\n'
+    const { relay, providers, bindings } = setup(3, body)
+    providers.forEach(p => p.fireSync(true))
+    relay.flush()
+    bindings.forEach(x => expect(x.ytext.toString()).toBe(body))
+    bindings.forEach(x => x.destroy())
+  })
+
+  test('a genuine edit during the race window is never destroyed', () => {
+    const body = 'one\n'
+    const { relay, providers, bindings } = setup(2, body)
+    const [a, b] = bindings
+    providers[0].fireSync(true)
+    providers[1].fireSync(true)
+    // Before the updates cross, client B edits its copy. After merge the text
+    // is no longer an exact k-fold repeat, so the collapser must leave it
+    // alone — we never delete real edits. (Some duplication may remain; data
+    // safety beats tidiness.)
+    b.ytext.insert(b.ytext.length, 'EDIT')
+    relay.flush()
+    // The edit survived on both clients.
+    expect(a.ytext.toString()).toContain('EDIT')
+    expect(b.ytext.toString()).toContain('EDIT')
+    bindings.forEach(x => x.destroy())
+  })
+})

--- a/src/components/editor/collabExtension.ts
+++ b/src/components/editor/collabExtension.ts
@@ -91,17 +91,38 @@ export function colorForUser(seed: string): string {
 export const defaultProviderFactory: ProviderFactory = (url, room, doc) =>
   new WebsocketProvider(url, room, doc) as unknown as ProviderLike
 
+// Shared meta map key prefix recording which clients seeded a fresh room.
+// One entry per seeder: `seeder:<clientID> → 1`. Used to elect a single
+// deterministic "collapser" when a concurrent seed race happens.
+const SEEDER_PREFIX = 'seeder:'
+
 /**
  * Build the live-collaboration binding for one note. Callers (the editor)
  * only invoke this when collab is enabled AND a note is open, passing the
  * note's stable collabId as `room`.
  *
- * Seeding: we attach the local content to the Y.Text only AFTER the
- * provider reports 'sync' AND the shared text is still empty. This avoids a
- * double-seed race — the first client to join a fresh room seeds it; later
- * clients receive the already-seeded content over the wire and skip
- * seeding. (Checking `ytext.length === 0` post-sync is the documented Yjs
- * idiom for "is this a brand-new document".)
+ * Seeding (and the concurrent-seed race): we attach the local content to the
+ * Y.Text only AFTER the provider reports 'sync' AND the shared text is still
+ * empty. The `ytext.length === 0` check alone is NOT race-safe: when two
+ * empty clients (e.g. a PC and a phone) join the same fresh room at nearly
+ * the same time, both fire 'sync' while still empty and BOTH insert
+ * `initialContent`. The Y.Text is a sequence CRDT, so the two inserts both
+ * survive the merge → the body appears N times and (once saved back) the
+ * duplication compounds day over day. A plain `meta.seeded` flag does NOT fix
+ * this either: the Y.Map flag resolves last-write-wins to one value, but the
+ * two text inserts still both survive.
+ *
+ * The fix is a self-healing single-seeder election that needs no server or
+ * protocol change:
+ *   1. Every client that seeds records `seeder:<its clientID>` in a shared
+ *      `meta` Y.Map (in the same transaction as the insert).
+ *   2. The elected "collapser" is the LOWEST clientID among recorded seeders.
+ *      Reacting to text/meta changes, the collapser deletes the duplicate
+ *      copies, keeping exactly one — but ONLY when the text is an exact
+ *      k-fold (k≥2) repeat of `initialContent`. If a real edit landed during
+ *      the race window the text is no longer an exact repeat, so we leave it
+ *      untouched: never destroy a genuine edit (data safety over tidiness).
+ * This converges to a single body regardless of message timing.
  */
 export function createCollabBinding(
   options: CreateCollabBindingOptions,
@@ -116,7 +137,9 @@ export function createCollabBinding(
 
   const doc = new Y.Doc()
   const ytext = doc.getText('content')
+  const meta = doc.getMap<number>('meta')
   const provider = providerFactory(url, room, doc)
+  const myKey = SEEDER_PREFIX + doc.clientID
 
   // Awareness — label this client's cursor for remote peers. Derive a
   // stable color from the GitHub login when available; otherwise a random
@@ -128,26 +151,74 @@ export function createCollabBinding(
     color: colorForUser(colorSeed),
   })
 
-  // Seed-on-empty: wait for the first sync, then seed only if nobody else
-  // already populated the room.
+  let destroyed = false
+
+  // Collapse a concurrent double-seed back to a single body. Only the elected
+  // collapser (lowest seeder clientID) acts, and only when the text is an
+  // EXACT k-fold (k≥2) repeat of initialContent — see the doc comment above.
+  // Idempotent and re-entrant: re-runs on every text/meta change until the
+  // text is a single copy (or has been genuinely edited), so a late-arriving
+  // concurrent seed is trimmed too.
+  const reconcileSeed = () => {
+    if (destroyed || initialContent.length === 0) return
+    const seederIds: number[] = []
+    for (const k of meta.keys()) {
+      if (!k.startsWith(SEEDER_PREFIX)) continue
+      const id = Number(k.slice(SEEDER_PREFIX.length))
+      if (Number.isFinite(id)) seederIds.push(id)
+    }
+    if (seederIds.length < 2) return // no concurrent seed → nothing to collapse
+    if (doc.clientID !== Math.min(...seederIds)) return // not the elected collapser
+
+    const text = ytext.toString()
+    const unit = initialContent.length
+    if (text.length <= unit || text.length % unit !== 0) return
+    const k = text.length / unit
+    if (text !== initialContent.repeat(k)) return // a real edit happened → leave it
+
+    doc.transact(() => {
+      // Keep the first copy; drop the remaining (k-1) identical copies.
+      ytext.delete(unit, text.length - unit)
+      // Prune the losers' markers so meta converges to just the collapser's.
+      for (const id of seederIds) {
+        if (id !== doc.clientID) meta.delete(SEEDER_PREFIX + id)
+      }
+    })
+  }
+
+  // Seed-on-empty: wait for the first sync, then seed only if the room is
+  // still empty. Records this client as a seeder (same transaction) so a
+  // concurrent double-seed can be detected and collapsed.
   const onSync = (isSynced: boolean) => {
     if (!isSynced) return
     if (ytext.length === 0 && initialContent.length > 0) {
-      // Wrap in a transaction so it's a single CRDT update.
       doc.transact(() => {
+        meta.set(myKey, 1)
         ytext.insert(0, initialContent)
       })
     }
+    reconcileSeed()
   }
   provider.on('sync', onSync)
 
+  // React to remote seeds / text arriving so the elected collapser trims any
+  // duplicate a concurrent seeder produced, converging to one copy.
+  const onChange = () => reconcileSeed()
+  ytext.observe(onChange)
+  meta.observe(onChange)
+
   const extension = yCollab(ytext, provider.awareness as never)
 
-  let destroyed = false
   const destroy = () => {
     if (destroyed) return
     destroyed = true
     provider.off?.('sync', onSync)
+    try {
+      ytext.unobserve(onChange)
+      meta.unobserve(onChange)
+    } catch {
+      /* ignore — observers may already be gone with the doc */
+    }
     try {
       provider.destroy()
     } catch {


### PR DESCRIPTION
## Problem
The remaining collab data-corruption bug: daily-note bodies duplicated (5x → 13x, compounding daily). The post-sync seed guard `ytext.length === 0` (`collabExtension.ts`) is **not race-safe** — when two empty clients (PC + phone) join the same fresh room near-simultaneously, both fire `sync` while still empty and **both** insert `initialContent`. The Y.Text is a sequence CRDT, so both inserts survive the merge → `body+body`, and once saved back it compounds day over day.

A plain `meta.seeded` flag does **not** fix it: the `Y.Map` flag resolves last-write-wins to one value, but the two **text inserts both survive**.

## Fix
A self-healing single-seeder election — **no server or protocol change**:
- Every client that seeds records `seeder:<clientID>` in a shared `meta` Y.Map (same transaction as the insert).
- The elected **collapser** (lowest seeder clientID), reacting to text/meta changes, deletes the duplicate copies keeping exactly one — **only** when the text is an exact k-fold (k≥2) repeat of `initialContent`.
- If a real edit landed during the race window the text is no longer an exact repeat, so it is left untouched: **never destroy a genuine edit** (data safety over tidiness).
- Idempotent + re-entrant → a late concurrent seed is trimmed too; converges to a single body regardless of message timing.

## Tests
- New buffering-relay harness lets two/three empty clients seed **before any update crosses the wire** (an immediate relay would hide the bug).
- Asserts the body survives **exactly once** for 2 and 3 concurrent seeders.
- Guard: an edit during the race window is preserved.
- **Mutation-checked**: disabling the collapse makes the race tests fail (body doubled).
- Full suite green (3041 pass), typecheck + lint clean.

## Not included
- One-time migration to collapse pre-existing duplicates: not added — the vault was already cleaned (`0f3ea138`) and collab has been OFF since, so nothing new accumulated. Can add the dry-run KMP-period script if needed.

## Deploy note
Collab is currently disabled in all environments. Re-enabling on dev/preview needs the preview `NEXT_PUBLIC_COLLAB_DISABLED` flipped (already set to `0`) **and a dev redeploy** (NEXT_PUBLIC vars are build-time inlined). Recommend landing this first, then redeploy + test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)