### PR TITLE
ci: auto-merge Dependabot patch/minor updates on green

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot auto-merge
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for patch & minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What this does

Adds `.github/workflows/dependabot-auto-merge.yml`, the official GitHub pattern for hands-off Dependabot maintenance:

- Triggers on `pull_request`, runs only when the actor is `dependabot[bot]`.
- Uses `dependabot/fetch-metadata@v2` to read the bump's semver update type.
- Calls `gh pr merge --auto --squash` **only** for `version-update:semver-patch` and `version-update:semver-minor`.
- **Major** bumps (`semver-major`) are intentionally NOT auto-merged, so breaking-change majors still require a human.

This means future bumps like the recent undici PR (#204) get merged automatically once CI is green, without a human in the loop.

## Prerequisite (action needed by repo admin)

`gh pr merge --auto` only **waits** for CI if the default branch requires those status checks. Today the active `protect-main` ruleset enforces only `deletion` and `non_fast_forward` rules and does **not** require any status checks. Without a required-checks gate, `--auto` would merge immediately on PR open.

Before relying on this, an admin should add the CI checks as required on `main`:
- `Lint · Typecheck · Test · Build`
- `E2E (Playwright)`

(Also enable the repo-level "Allow auto-merge" setting, which requires admin and could not be toggled by the non-admin CI account.)

Do not merge until those gates are in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)