### PR TITLE
fix(calendar): Today button could open next/prev month's date

### DIFF
--- a/src/components/sidebar/CalendarView.tsx
+++ b/src/components/sidebar/CalendarView.tsx
@@ -115,8 +115,8 @@ export const CalendarView = () => {
     [activeNotes, year, month, dateFormat, ensureFolderPath],
   )
 
-  const openDay = (day: number) => {
-    const dayDate = new Date(year, month, day)
+  const openDay = (day: number, dayYear: number = year, dayMonth: number = month) => {
+    const dayDate = new Date(dayYear, dayMonth, day)
     const title = formatDate(dayDate, dateFormat || 'YYYY-MM-DD')
     const folderId = ensureFolderPath(dailyNotesFolder.get().split('/'))
     const existing = activeNotes.find(n => n.folderId === folderId && n.title === title)
@@ -134,7 +134,7 @@ export const CalendarView = () => {
 
   const goToToday = () => {
     setViewDate(new Date(today.getFullYear(), today.getMonth(), 1))
-    openDay(today.getDate())
+    openDay(today.getDate(), today.getFullYear(), today.getMonth())
   }
 
   const onDayContextMenu = (e: React.MouseEvent, day: number) => {


### PR DESCRIPTION
## Summary
- `goToToday()` called `setViewDate()` (async state update) then immediately `openDay(today.getDate())`, which built the note's date from the component's stale `year`/`month` closure variables, not today's actual date.
- If the calendar sidebar had been navigated to a different month before clicking "Today", it opened/created the daily note for that other month's same day-of-month instead of the real today.
- Fix: `openDay` now accepts explicit year/month (defaulting to current view state for the existing day-cell click paths), and `goToToday` passes today's actual year/month directly.

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — full suite (3042 passed)
- [ ] Manual: navigate the calendar forward a month, click "Today", confirm it opens today's note (not next month's)