### PR TITLE
fix(editor): cycle-list / bullet-toggle keys never fire on Windows

### DIFF
--- a/src/components/editor/CodeMirrorEditor.tsx
+++ b/src/components/editor/CodeMirrorEditor.tsx
@@ -1029,17 +1029,25 @@ export function CodeMirrorEditor({
     // line(s) through plain -> numbered ("1. ") -> task ("- [ ] ") -> plain.
     // Replaces the earlier trio of Mod+Shift+7/8/9 toggles. Separate from
     // Mod+L (which only toggles a checkbox done/undone).
+    // Spelled 'Mod-Alt-L' (capital, no explicit "Shift-" word) rather than
+    // 'Mod-Alt-Shift-l': CodeMirror's runHandlers() skips its case-insensitive
+    // base-key fallback whenever ctrlKey+altKey are both held on Windows (its
+    // AltGr-avoidance guard), so a lowercase-letter spec can never match
+    // event.key's uppercase 'L' there and the binding silently never fires.
+    // The uppercase form matches on the first (always-tried) lookup on every
+    // platform. See @codemirror/view's `runHandlers`/`modifiers` internals.
     {
-      key: 'Mod-Alt-Shift-l',
+      key: 'Mod-Alt-L',
       preventDefault: true,
       run: cycleListTypeCommand,
     },
     // (3) Mod+Alt+Shift+B — Toggle a plain bullet list ("- ") on the current
     // line(s). A STANDALONE toggle, NOT part of the Mod+Alt+Shift+L cycle:
     // a plain line gains "- ", a "- " bullet drops it. Multi-line aware,
-    // indentation preserved.
+    // indentation preserved. Same 'Mod-Alt-B' (not '...-Shift-b') spelling
+    // rationale as the cycle-list binding above.
     {
-      key: 'Mod-Alt-Shift-b',
+      key: 'Mod-Alt-B',
       preventDefault: true,
       run: toggleBulletCommand,
     },


### PR DESCRIPTION
## Summary
- `Mod-Alt-Shift-l` (cycle list type) and `Mod-Alt-Shift-b` (bullet toggle) never fired on Windows.
- Root cause: `@codemirror/view`'s `runHandlers()` deliberately skips its case-insensitive base-key fallback whenever `ctrlKey && altKey` are both held on Windows (an AltGr-avoidance guard). With that fallback skipped, a lowercase-letter binding spec can never match `event.key`'s uppercase `'L'`/`'B'` (produced because Shift is held), so the binding silently never runs — no error, just nothing happens.
- Confirmed via a user report (Edge/Windows): raw `keydown` showed correct `ctrlKey/altKey/shiftKey` flags and `key: 'L'`, but the app did nothing; `Mod-l` (single modifier) worked fine on the same line, isolating it to this specific 3-modifier chord.
- Fix: spell both bindings as `Mod-Alt-L` / `Mod-Alt-B` (capital letter, no explicit `Shift-` word) instead of `Mod-Alt-Shift-l` / `Mod-Alt-Shift-b`. This matches on CodeMirror's first, always-tried lookup on every platform, sidestepping the Windows-only fallback entirely.
- The existing e2e/unit coverage for these commands dispatches a synthetic `KeyboardEvent` directly (bypassing real OS/browser key routing) in a Linux CI runner, so it could never exercise the Windows-specific guard — that's why this shipped without failing CI.

## Test plan
- [x] `npx jest cycleListTypeCommand.test.ts listTransforms.test.ts` — 61 passed
- [x] `npx playwright test e2e/parity/list-shortcuts-obsidian.spec.ts` — all cycle/bullet-toggle cases pass (1 pre-existing unrelated failure on `Mod+D`, reproduces identically on `dev` without this change)
- [ ] Manual confirmation on the reporter's actual Windows/Edge setup once deployed to `beta.noteser.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)