### PR TITLE
fix(collab-server): bump @cloudflare/workers-types to ^5 to fix ERESOLVE breaking CI

### DIFF
--- a/collab-server/package-lock.json
+++ b/collab-server/package-lock.json
@@ -13,7 +13,7 @@
         "yjs": "^13.6.30"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20260702.1",
+        "@cloudflare/workers-types": "^5.20260708.1",
         "typescript": "^5.6.0",
         "vitest": "^4.1.10",
         "wrangler": "^4.110.0"
@@ -131,9 +131,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260702.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
-      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "version": "5.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260714.1.tgz",
+      "integrity": "sha512-HGCTQVIQwzqAMLrZBCgLDrWKMgOdi6yn+S0Do1rF6z7t8tVvNprQfa53V6EDRRwsVO92uN5gviX2SxASDINZfA==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },

--- a/collab-server/package.json
+++ b/collab-server/package.json
@@ -16,7 +16,7 @@
     "yjs": "^13.6.30"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20260702.1",
+    "@cloudflare/workers-types": "^5.20260708.1",
     "typescript": "^5.6.0",
     "vitest": "^4.1.10",
     "wrangler": "^4.110.0"


### PR DESCRIPTION
## Root cause

The collab-server CI job fails at `npm ci` with an ERESOLVE error on every PR (observed on the @dnd-kit/sortable 9.0.0 dependabot branch, run 29313914823, but it reproduces on `main` too — the failure is unrelated to dnd-kit):

- `wrangler@4.110.0` (merged recently) declares `peerOptional @cloudflare/workers-types@"^5.20260708.1"`
- `collab-server/package.json` still pinned `@cloudflare/workers-types@"^4.20260702.1"`

npm refuses to resolve the conflicting peer dependency, so the install step exits 1 before typecheck/test/audit ever run.

## Fix

Bump `@cloudflare/workers-types` to `^5.20260708.1` in `collab-server/package.json` and regenerate `collab-server/package-lock.json` (5-line lockfile diff). This matches the version wrangler expects — dependabot had proposed the same bump separately.

## Verification (all run locally in `collab-server/`)

- ✅ `npm ci` — installs cleanly, no ERESOLVE
- ✅ `npm run typecheck` — passes
- ✅ `npm test` — 11/11 tests pass
- ✅ `npm audit --audit-level=high` — 0 vulnerabilities

Once merged, the failing dependabot PRs (including @dnd-kit/sortable 9.0.0) should go green after rebase.

---
*This PR was opened by the automated autofix bot and is awaiting human review.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)